### PR TITLE
add mouse support documentation across docs and widget references

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,6 +158,7 @@ Templates: `dashboard`, `form-app`, `file-browser`, `streaming-viewer`.
 - **50+ widgets** — code editor, diff viewer, file picker, command palette, charts, tables, trees, overlays, forms
 - **Composition API** — `defineWidget` + hooks for state and lifecycle
 - **Focus management** — built-in focus ring, keybindings, chord sequences
+- **Mouse support** — click to focus/activate, scroll wheel, drag-to-resize split panes, modal backdrop clicks
 - **6 built-in themes** with semantic color tokens and style props
 - **Binary protocols** — ZRDL (drawlists) and ZREV (event batches) for minimal IPC overhead
 

--- a/docs/backend/terminal-caps.md
+++ b/docs/backend/terminal-caps.md
@@ -1,13 +1,34 @@
-# Terminal capabilities
+# Terminal Capabilities
 
-The Zireael engine detects terminal capabilities (color, cursor, mouse tracking, etc.) and surfaces them to the wrapper.
+The Zireael engine detects terminal capabilities at startup and surfaces them to the framework via the `TerminalCaps` type.
+
+## Detected Capabilities
+
+| Capability | Type | Description |
+|------------|------|-------------|
+| `colorMode` | `ColorMode` | Color depth (none, 16, 256, truecolor) |
+| `supportsMouse` | `boolean` | Whether the terminal supports mouse tracking |
+| `supportsBracketedPaste` | `boolean` | Whether bracketed paste mode is available |
+| `supportsFocusEvents` | `boolean` | Whether terminal focus/blur events are reported |
+
+## Mouse Support Detection
+
+`supportsMouse` indicates whether the terminal can report mouse events (clicks, scroll wheel, movement, drag). When `true`, Rezi automatically enables mouse tracking and routes mouse events to widgets.
+
+Most modern terminals support mouse tracking, including iTerm2, Alacritty, kitty, WezTerm, Windows Terminal, GNOME Terminal, and Konsole. Some legacy terminals or minimal configurations may not.
+
+When `supportsMouse` is `false`, Rezi operates in keyboard-only mode. No special handling is needed — all interactive widgets work with keyboard navigation.
+
+## Usage
 
 Rezi uses these capabilities to:
 
-- decide rendering strategies
-- select feature fallbacks
+- decide rendering strategies (color depth, optimized scroll sequences)
+- enable or disable mouse tracking
+- select feature fallbacks for unsupported capabilities
 
 See also:
 
 - `terminalCaps` export in `@rezi-ui/core`
+- [Mouse Support guide](../guide/mouse-support.md)
 

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -77,7 +77,7 @@ Run with:
 npx tsx index.ts
 ```
 
-You should see a counter UI. Use Tab to navigate between buttons, Enter to activate them, and 'q' to quit.
+You should see a counter UI. Use Tab to navigate between buttons, Enter to activate them, and 'q' to quit. You can also click the buttons with the mouse if your terminal supports mouse tracking.
 
 ## Understanding the Code
 

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -161,7 +161,7 @@ Container and layout: `box`, `row`, `column`, `spacer`, `divider`
 Display information: `text`, `richText`, `icon`, `badge`, `status`
 
 ### Interactive Widgets
-Accept user input: `button`, `input`, `checkbox`, `select`, `radioGroup`
+Accept user input via keyboard and mouse: `button`, `input`, `checkbox`, `select`, `radioGroup`
 
 ### Data Widgets
 Display structured data: `table`, `virtualList`, `tree`
@@ -174,10 +174,10 @@ Loading and error states: `spinner`, `progress`, `skeleton`, `errorDisplay`
 
 ## Focus Model
 
-Rezi manages focus automatically:
+Rezi manages focus automatically through keyboard and mouse input:
 
-### Tab Navigation
-Tab moves focus forward through focusable widgets. Shift+Tab moves backward.
+### Tab and Mouse Navigation
+Tab moves focus forward through focusable widgets. Shift+Tab moves backward. Clicking any focusable widget with the mouse also moves focus to it. See [Mouse Support](mouse-support.md) for details.
 
 ### Focus Zones
 Group widgets into focus zones for organized Tab navigation:
@@ -256,5 +256,6 @@ app.modes({
 
 - [Lifecycle & Updates](lifecycle-and-updates.md) - State management in depth
 - [Layout](layout.md) - Spacing, alignment, and constraints
-- [Input & Focus](input-and-focus.md) - Keyboard navigation and focus management
+- [Input & Focus](input-and-focus.md) - Keyboard and mouse navigation
+- [Mouse Support](mouse-support.md) - Click, scroll, and drag interactions
 - [Widget Catalog](../widgets/index.md) - Complete widget reference

--- a/docs/guide/input-and-focus.md
+++ b/docs/guide/input-and-focus.md
@@ -1,6 +1,6 @@
 # Input & Focus
 
-Rezi routes input deterministically through a focus system that manages keyboard navigation and event delivery.
+Rezi routes input deterministically through a focus system that manages keyboard and mouse navigation and event delivery. See also the dedicated [Mouse Support](mouse-support.md) guide.
 
 ## Identity: `id` vs `key`
 
@@ -20,12 +20,13 @@ These must not be conflated:
 
 ## Focus Navigation
 
-Focusable widgets (buttons, inputs, selects) participate in Tab navigation:
+Focusable widgets (buttons, inputs, selects) participate in Tab and mouse navigation:
 
 - **Tab** - Move focus forward
 - **Shift+Tab** - Move focus backward
 - **Enter/Space** - Activate focused widget
 - **Arrow keys** - Navigate within widgets (lists, tables)
+- **Mouse click** - Focus and activate the clicked widget
 
 ### Focus Order
 
@@ -157,6 +158,19 @@ app.setMode("normal");
 
 Query current mode with `app.getMode()`.
 
+## Mouse Input
+
+Rezi supports mouse interaction when the terminal supports mouse tracking. Mouse events are routed through the same focus system as keyboard input:
+
+- **Click** any focusable widget to focus it. Clicking a button also activates its `onPress` callback.
+- **Scroll wheel** scrolls focused or hovered scrollable widgets (VirtualList, CodeEditor, LogsConsole, DiffViewer).
+- **Drag** split pane dividers to resize panels.
+- **Click** a modal backdrop to close the modal (when `closeOnBackdrop` is enabled).
+
+Mouse and keyboard input can be freely mixed. Clicking a widget updates the same focus state that Tab navigation uses.
+
+For the complete mouse support reference, see the [Mouse Support](mouse-support.md) guide.
+
 ## Event Handling
 
 ### Widget Events
@@ -232,6 +246,7 @@ This enables:
 
 ## Next Steps
 
+- [Mouse Support](mouse-support.md) - Click, scroll, and drag interactions
 - [Styling](styling.md) - Colors, themes, and visual customization
 - [Focus Zone](../widgets/focus-zone.md) - Focus zone widget reference
 - [Focus Trap](../widgets/focus-trap.md) - Focus trap widget reference

--- a/docs/guide/mouse-support.md
+++ b/docs/guide/mouse-support.md
@@ -1,0 +1,176 @@
+# Mouse Support
+
+Rezi has built-in mouse support. When the terminal supports mouse tracking, Rezi automatically enables it — clicks focus and activate widgets, the scroll wheel navigates lists and editors, and split pane dividers can be dragged to resize.
+
+No configuration is required. Mouse support is detected at startup and works alongside keyboard navigation.
+
+## Terminal Detection
+
+The Zireael engine detects mouse support at startup through `terminalCaps.supportsMouse`. Most modern terminals support mouse tracking:
+
+- **Supported:** iTerm2, Alacritty, kitty, WezTerm, Windows Terminal, GNOME Terminal, Konsole, tmux, VS Code integrated terminal
+- **Not supported:** Some legacy terminals and bare `xterm` configurations
+
+If the terminal doesn't support mouse tracking, Rezi falls back to keyboard-only navigation. Your app works either way — no conditional code needed.
+
+## What Works with Mouse
+
+### Clicking to Focus and Activate
+
+Clicking any focusable widget (button, input, select, checkbox, etc.) moves focus to it. Clicking a button also activates it, just like pressing Enter or Space:
+
+```typescript
+ui.button({
+  id: "save",
+  label: "Save",
+  onPress: () => save(), // Fires on click or Enter/Space
+})
+```
+
+The click model uses press-and-release: mouse down captures the target, mouse up on the same target triggers the action. If the user drags away before releasing, no action fires. This matches how buttons work on the web and in native UIs.
+
+### Scroll Wheel
+
+The mouse wheel scrolls any scrollable widget that is focused or under the cursor:
+
+| Widget | Scroll Behavior |
+|--------|----------------|
+| [VirtualList](../widgets/virtual-list.md) | Scrolls items (3 lines per tick) |
+| [CodeEditor](../widgets/code-editor.md) | Scrolls vertically and horizontally |
+| [LogsConsole](../widgets/logs-console.md) | Scrolls log entries |
+| [DiffViewer](../widgets/diff-viewer.md) | Scrolls diff content |
+| [Table](../widgets/table.md) | Scrolls rows (when virtualized) |
+
+Scroll callbacks (`onScroll`) fire for both keyboard navigation and mouse wheel input.
+
+### Dragging Split Pane Dividers
+
+[SplitPane](../widgets/split-pane.md) dividers can be dragged with the mouse to resize panels:
+
+```typescript
+ui.splitPane(
+  {
+    id: "main",
+    direction: "horizontal",
+    sizes: state.sizes,
+    onResize: (sizes) => app.update((s) => ({ ...s, sizes })),
+  },
+  [Sidebar(), Editor()]
+)
+```
+
+Mouse down on the divider starts the drag. Moving the mouse updates panel sizes in real-time. Releasing the mouse ends the drag.
+
+### Clicking Modal Backdrops
+
+Modals with `closeOnBackdrop: true` (the default) close when the user clicks the backdrop area:
+
+```typescript
+ui.modal({
+  id: "confirm",
+  title: "Are you sure?",
+  content: ui.text("This will delete the item."),
+  closeOnBackdrop: true, // Default — click backdrop to close
+  onClose: () => app.update((s) => ({ ...s, showModal: false })),
+  actions: [
+    ui.button({ id: "yes", label: "Yes" }),
+    ui.button({ id: "no", label: "No" }),
+  ],
+})
+```
+
+When a modal layer blocks input, mouse events to widgets below the modal are blocked entirely.
+
+### Toast Action Buttons
+
+[Toast](../widgets/toast.md) notifications with action buttons can be clicked:
+
+```typescript
+app.update((s) => ({
+  ...s,
+  toasts: [...s.toasts, {
+    id: "saved",
+    message: "File saved",
+    type: "success",
+    action: { label: "Undo", onAction: () => undoSave() }, // Clickable
+  }],
+}));
+```
+
+## How Mouse Routing Works
+
+Mouse events flow through a deterministic pipeline:
+
+```
+Terminal mouse input
+    |
+    v
+Zireael engine (detects & encodes mouse events)
+    |
+    v
+ZREV event batch (binary protocol)
+    |
+    v
+Hit testing — which widget is under (x, y)?
+    |
+    v
+Layer check — is a modal blocking input?
+    |
+    v
+Mouse router — focus, press/release, scroll, drag
+    |
+    v
+Widget callbacks (onPress, onScroll, onResize, etc.)
+```
+
+### Hit Testing
+
+When a mouse event arrives, Rezi performs a depth-first traversal of the widget tree to find which focusable widget contains the cursor position. If multiple widgets overlap, the last one in document order (topmost) wins.
+
+Disabled widgets are excluded from hit testing — they cannot receive mouse events.
+
+### Press and Release
+
+Mouse routing uses a simple state machine:
+
+1. **Mouse down** on a focusable widget: focus moves to that widget and it becomes the "pressed" target
+2. **Mouse up** on the same widget: the press action fires (e.g., `onPress` callback)
+3. **Mouse up** on a different widget: the press is cancelled, no action fires
+
+This ensures accidental clicks don't trigger actions when the user drags away from a button.
+
+## Mouse Events in the Event System
+
+Raw mouse events are available through `app.onEvent()`:
+
+```typescript
+app.onEvent((ev) => {
+  if (ev.kind === "engine" && ev.event.kind === "mouse") {
+    const { x, y, mouseKind, wheelY } = ev.event;
+    // mouseKind: 1=move, 2=press, 3=release, 4=drag, 5=scroll
+  }
+});
+```
+
+Most applications don't need raw mouse events — widget callbacks (`onPress`, `onScroll`, etc.) handle the common cases. Raw events are useful for custom widgets or debugging.
+
+## Keyboard + Mouse
+
+Mouse support is additive. All keyboard navigation continues to work:
+
+| Action | Keyboard | Mouse |
+|--------|----------|-------|
+| Focus a widget | Tab / Shift+Tab | Click |
+| Activate a button | Enter / Space | Click |
+| Scroll a list | Arrow keys / Page Up/Down | Scroll wheel |
+| Resize split panes | *(not available)* | Drag divider |
+| Close modal | Escape | Click backdrop |
+| Navigate options | Arrow keys | Click option |
+
+Users can freely mix keyboard and mouse input. Focus state is shared — clicking a widget updates the same focus ring that Tab navigation uses.
+
+## Next Steps
+
+- [Input & Focus](input-and-focus.md) — Keyboard navigation and focus management
+- [Widget Catalog](../widgets/index.md) — Browse all widgets and their mouse interactions
+- [Terminal Capabilities](../backend/terminal-caps.md) — How terminal features are detected

--- a/docs/index.md
+++ b/docs/index.md
@@ -39,6 +39,9 @@ await app.start();
 **Focus Management**
 : Automatic keyboard navigation with focus zones, focus traps, and modal stacking.
 
+**Mouse Support**
+: Click to focus and activate widgets, scroll wheel for lists and editors, drag to resize split panes, click backdrops to close modals. Detected automatically — no configuration needed.
+
 **Theming**
 : Six built-in themes (dark, light, dimmed, high-contrast, nord, dracula) with semantic color tokens.
 
@@ -167,7 +170,7 @@ ui.box({ title: "User Form", p: 1 }, [
 
 ### Focus and Navigation
 
-Interactive widgets (buttons, inputs) automatically participate in focus navigation. Use Tab/Shift+Tab to move between focusable elements:
+Interactive widgets (buttons, inputs) automatically participate in focus navigation. Use Tab/Shift+Tab to move between focusable elements, or click any focusable widget with the mouse:
 
 ```typescript
 ui.column({}, [
@@ -209,6 +212,7 @@ User feedback: `spinner`, `skeleton`, `callout`, `errorDisplay`, `empty`
 - [Lifecycle & Updates](guide/lifecycle-and-updates.md) - State management patterns
 - [Layout](guide/layout.md) - Spacing, alignment, and constraints
 - [Input & Focus](guide/input-and-focus.md) - Keyboard navigation and focus management
+- [Mouse Support](guide/mouse-support.md) - Click, scroll, and drag interactions
 - [Styling](guide/styling.md) - Colors, themes, and visual customization
 - [Performance](guide/performance.md) - Optimization techniques
 - [Debugging](guide/debugging.md) - Debug tools and frame inspection

--- a/docs/protocol/zrev.md
+++ b/docs/protocol/zrev.md
@@ -1,6 +1,29 @@
-# Event batches (ZREV)
+# Event Batches (ZREV)
 
-The engine emits input as a ZREV event batch.
+The engine emits input as a ZREV event batch — a binary format containing one or more input events.
+
+## Event Types
+
+ZREV batches contain these event record types:
+
+| Record | Description |
+|--------|-------------|
+| Key | Keyboard input with key code and modifiers |
+| Mouse | Mouse events (move, press, release, drag, scroll) with position and button state |
+| Resize | Terminal size change |
+| Tick | Animation timer |
+
+### Mouse Event Records
+
+Mouse records include:
+
+- `x`, `y` — cursor position in terminal cells
+- `mouseKind` — event type: move (1), press (2), release (3), drag (4), scroll (5)
+- `mods` — modifier keys held (shift, ctrl, alt, meta)
+- `buttons` — button state bitmask
+- `wheelX`, `wheelY` — scroll deltas
+
+## Parsing
 
 Rezi parses ZREV deterministically:
 
@@ -12,3 +35,4 @@ See:
 
 - [Safety rules](safety.md)
 - [Versioning](versioning.md)
+- [Mouse Support guide](../guide/mouse-support.md)

--- a/docs/widgets/button.md
+++ b/docs/widgets/button.md
@@ -28,13 +28,14 @@ ui.button({
 
 ## Behavior
 
-Buttons are focusable when enabled. When focused:
+Buttons are focusable when enabled. They can be activated by keyboard or mouse:
 
 - **Enter** or **Space** activates the button
+- **Mouse click** focuses and activates the button (press down + release on the same button)
 - **Tab** moves focus to the next focusable widget
 - **Shift+Tab** moves focus to the previous focusable widget
 
-Buttons can be handled either via callback props or in a global `app.onEvent` handler.
+The `onPress` callback fires regardless of whether the button was activated by keyboard or mouse. Buttons can be handled either via callback props or in a global `app.onEvent` handler.
 
 ## Examples
 

--- a/docs/widgets/checkbox.md
+++ b/docs/widgets/checkbox.md
@@ -30,6 +30,7 @@ ui.checkbox({
 
 - Focusable when enabled.
 - Toggle with **Space** (and commonly **Enter** depending on terminal key mapping).
+- **Mouse click** focuses and toggles the checkbox.
 - **Tab / Shift+Tab** moves focus.
 
 ## Examples

--- a/docs/widgets/code-editor.md
+++ b/docs/widgets/code-editor.md
@@ -44,6 +44,11 @@ ui.codeEditor({
 | `onUndo` | `() => void` | - | Undo callback |
 | `onRedo` | `() => void` | - | Redo callback |
 
+## Mouse Behavior
+
+- **Mouse scroll wheel** scrolls the editor vertically and horizontally, firing the `onScroll` callback.
+- **Clicking** the editor area focuses the widget.
+
 ## Notes
 
 - `lines` is the source of truth; update it in `onChange` to keep the editor controlled.

--- a/docs/widgets/diff-viewer.md
+++ b/docs/widgets/diff-viewer.md
@@ -37,6 +37,11 @@ ui.diffViewer({
 | `onApplyHunk` | `(index) => void` | - | Apply callback |
 | `onRevertHunk` | `(index) => void` | - | Revert callback |
 
+## Mouse Behavior
+
+- **Mouse scroll wheel** scrolls diff content, firing the `onScroll` callback.
+- **Clicking** the viewer area focuses the widget.
+
 ## Notes
 
 - `DiffData` includes file paths, hunks, and optional binary flag.

--- a/docs/widgets/dropdown.md
+++ b/docs/widgets/dropdown.md
@@ -20,6 +20,12 @@ ui.dropdown({
 })
 ```
 
+## Behavior
+
+- **Arrow keys** navigate items. **Enter** selects the highlighted item.
+- **Mouse click** on an item selects it and fires the `onSelect` callback.
+- **Clicking outside** the dropdown closes it (via the layer backdrop).
+
 ## Notes
 
 - Use `anchorId` to position the dropdown relative to an element in the layout tree.

--- a/docs/widgets/focus-trap.md
+++ b/docs/widgets/focus-trap.md
@@ -105,8 +105,13 @@ ui.focusTrap({ id: "outer", active: true }, [
 ])
 ```
 
+## Mouse Behavior
+
+When a focus trap is active, mouse clicks outside the trap region are blocked. Clicking widgets inside the trap works normally — the clicked widget receives focus.
+
 ## Related
 
 - [Focus Zone](focus-zone.md) - Group focusable widgets
 - [Modal](modal.md) - Modal dialog widget
 - [Layer](layer.md) - Generic overlay layer
+- [Mouse Support](../guide/mouse-support.md) - Mouse interaction details

--- a/docs/widgets/focus-zone.md
+++ b/docs/widgets/focus-zone.md
@@ -118,8 +118,13 @@ ui.column({ gap: 2 }, [
 ])
 ```
 
+## Mouse Behavior
+
+Clicking any focusable widget inside a focus zone moves focus to that widget, just like Tab navigation. The zone's `onEnter` callback fires when focus enters the zone via mouse click.
+
 ## Related
 
 - [Focus Trap](focus-trap.md) - Constrain focus within a region
 - [Modal](modal.md) - Modal dialog with focus trap
 - [Button](button.md) - Focusable button
+- [Mouse Support](../guide/mouse-support.md) - Mouse interaction details

--- a/docs/widgets/index.md
+++ b/docs/widgets/index.md
@@ -210,13 +210,13 @@ ui.column(
 
 ### Event Handlers
 
-Interactive widgets support event callbacks:
+Interactive widgets support event callbacks. These fire for both keyboard and mouse input:
 
 ```typescript
 ui.button({
   id: "submit",
   label: "Submit",
-  onPress: () => handleSubmit(),
+  onPress: () => handleSubmit(), // Fires on Enter, Space, or mouse click
 })
 
 ui.input({
@@ -226,6 +226,10 @@ ui.input({
   onBlur: () => validateField("name"),
 })
 ```
+
+### Mouse Support
+
+All focusable widgets can be clicked with the mouse to receive focus. Scrollable widgets (VirtualList, CodeEditor, LogsConsole, DiffViewer) respond to the mouse scroll wheel. SplitPane dividers can be dragged to resize panels. See the [Mouse Support guide](../guide/mouse-support.md) for details.
 
 ## API Reference
 

--- a/docs/widgets/input.md
+++ b/docs/widgets/input.md
@@ -26,7 +26,7 @@ ui.input({
 
 ## Behavior
 
-Inputs are focusable when enabled. When focused:
+Inputs are focusable when enabled. **Clicking** the input focuses it. When focused:
 
 - Text entry inserts at cursor position
 - **Left/Right** arrows move the cursor

--- a/docs/widgets/layer.md
+++ b/docs/widgets/layer.md
@@ -25,6 +25,11 @@ ui.layer({
 | `onClose` | `() => void` | - | Called when layer should close |
 | `content` | `VNode` | **required** | Layer content |
 
+## Mouse Behavior
+
+- When `modal` is `true`, mouse events to widgets in lower layers are blocked.
+- Clicking the backdrop area triggers the `onClose` callback (if provided).
+
 ## Notes
 
 - Use [`Layers`](layers.md) to manage stacking order and modals.

--- a/docs/widgets/logs-console.md
+++ b/docs/widgets/logs-console.md
@@ -35,6 +35,11 @@ ui.logsConsole({
 | `onEntryToggle` | `(id, expanded) => void` | - | Expand/collapse callback |
 | `onClear` | `() => void` | - | Clear entries callback |
 
+## Mouse Behavior
+
+- **Mouse scroll wheel** scrolls log entries, firing the `onScroll` callback.
+- **Clicking** the console area focuses the widget.
+
 ## Notes
 
 - `LogEntry` supports optional details, token usage, duration, and cost fields.

--- a/docs/widgets/modal.md
+++ b/docs/widgets/modal.md
@@ -57,6 +57,12 @@ ui.modal({
 })
 ```
 
+## Mouse Behavior
+
+- **Clicking the backdrop** closes the modal when `closeOnBackdrop` is `true` (the default).
+- **Clicking action buttons** activates them the same as pressing Enter/Space.
+- Mouse events to widgets below the modal are blocked when the modal is active.
+
 ## Notes
 
 - Modals are rendered by conditionally including them in the tree (there is no `open` prop).

--- a/docs/widgets/radio-group.md
+++ b/docs/widgets/radio-group.md
@@ -34,6 +34,7 @@ ui.radioGroup({
 ## Behavior
 
 - Focusable when enabled.
+- **Mouse click** focuses the radio group.
 - Navigate choices with **ArrowUp/ArrowDown** (or left/right in horizontal layouts).
 - Confirm with **Enter**.
 - **Tab / Shift+Tab** moves focus in/out.

--- a/docs/widgets/select.md
+++ b/docs/widgets/select.md
@@ -34,6 +34,7 @@ ui.select({
 ## Behavior
 
 - Focusable when enabled.
+- **Mouse click** focuses the select widget.
 - Navigate options with **ArrowUp/ArrowDown**.
 - Confirm selection with **Enter**.
 - **Tab / Shift+Tab** moves focus to the next/previous widget.

--- a/docs/widgets/split-pane.md
+++ b/docs/widgets/split-pane.md
@@ -34,6 +34,16 @@ ui.splitPane(
 | `onResize` | `(sizes) => void` | **required** | Resize callback |
 | `onCollapse` | `(index, collapsed) => void` | - | Collapse callback |
 
+## Behavior
+
+Dividers between panels can be dragged with the mouse to resize:
+
+- **Mouse down** on a divider starts the drag
+- **Moving the mouse** updates panel sizes in real-time via the `onResize` callback
+- **Mouse up** ends the drag
+
+The hit area for dividers extends 1 cell on each side of the divider for easier grabbing.
+
 ## Notes
 
 - `sizes` length should match the number of child panels.

--- a/docs/widgets/table.md
+++ b/docs/widgets/table.md
@@ -59,6 +59,12 @@ ui.table({
 })
 ```
 
+## Behavior
+
+- **Arrow keys** navigate rows. **Enter** activates the selected row.
+- **Mouse click** on a row selects it and moves focus to the table.
+- **Mouse scroll wheel** scrolls rows when the table is virtualized.
+
 ## Notes
 
 - Tables can be virtualized; prefer virtualization for large datasets.

--- a/docs/widgets/toast.md
+++ b/docs/widgets/toast.md
@@ -23,6 +23,10 @@ ui.toastContainer({
 | `maxVisible` | `number` | `5` | Max visible toasts |
 | `onDismiss` | `(id) => void` | **required** | Dismiss callback |
 
+## Mouse Behavior
+
+Toast action buttons (e.g., "Undo") can be clicked with the mouse to trigger their `onAction` callback.
+
 ## Toast shape
 
 - `id`: unique toast identifier

--- a/docs/widgets/virtual-list.md
+++ b/docs/widgets/virtual-list.md
@@ -32,6 +32,12 @@ ui.virtualList({
 | `onScroll` | `(scrollTop, range) => void` | - | Scroll callback with visible range |
 | `onSelect` | `(item, index) => void` | - | Selection callback |
 
+## Behavior
+
+- **Arrow Up/Down** navigates items. **Page Up/Down** and **Home/End** jump by page or to boundaries.
+- **Mouse scroll wheel** scrolls the list (3 lines per tick).
+- The `onScroll` callback fires for both keyboard navigation and mouse wheel input.
+
 ## Notes
 
 - Use `itemHeight` callback for variable-height rows.

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -103,6 +103,7 @@ nav:
       - Lifecycle & Updates: guide/lifecycle-and-updates.md
       - Layout: guide/layout.md
       - Input & Focus: guide/input-and-focus.md
+      - Mouse Support: guide/mouse-support.md
       - Styling: guide/styling.md
       - Performance: guide/performance.md
       - Debugging: guide/debugging.md


### PR DESCRIPTION
Add dedicated mouse support guide covering click-to-focus, scroll wheel, split pane drag, modal backdrop clicks, and hit testing. Update 25 existing docs to mention mouse interactions where relevant.
 