### PR TITLE
PanelGroup: honor ResizablePanel sizing hints

### DIFF
--- a/docs/widgets/panel-group.md
+++ b/docs/widgets/panel-group.md
@@ -9,7 +9,6 @@ ui.panelGroup(
   {
     id: "panel-group",
     direction: "horizontal",
-    autoSaveId: "main-layout",
   },
   [
     ui.resizablePanel({ defaultSize: 25 }, [Sidebar()]),
@@ -24,12 +23,11 @@ ui.panelGroup(
 |------|------|---------|-------------|
 | `id` | `string` | **required** | Group identifier |
 | `direction` | `"horizontal" \| "vertical"` | **required** | Layout direction |
-| `autoSaveId` | `string` | - | App-level key for persisting layout (core does not persist) |
 
 ## Notes
 
-- `PanelGroup` distributes space evenly when sizes are not provided.
-- `ResizablePanel` size hints are preserved but not applied by core layout.
+- `PanelGroup` distributes space based on `ResizablePanel` size hints (with equal distribution when unspecified).
+- `ResizablePanel` size hints are interpreted as percentages of the group's width/height (based on `direction`).
 - Use [`SplitPane`](split-pane.md) for draggable resizing.
 
 ## Related

--- a/docs/widgets/resizable-panel.md
+++ b/docs/widgets/resizable-panel.md
@@ -18,13 +18,13 @@ ui.panelGroup(
 
 | Prop | Type | Default | Description |
 |------|------|---------|-------------|
-| `defaultSize` | `number` | auto | Initial size (percent or cells, based on parent) |
-| `minSize` | `number` | - | Minimum size |
-| `maxSize` | `number` | - | Maximum size |
+| `defaultSize` | `number` | auto | Initial size (percentage of the parent axis) |
+| `minSize` | `number` | - | Minimum size (percentage) |
+| `maxSize` | `number` | - | Maximum size (percentage) |
 | `collapsible` | `boolean` | `false` | Allow collapsing the panel |
 
 ## Notes
 
 - `ResizablePanel` should contain exactly one child widget.
-- `PanelGroup` distributes space evenly; size hints on `ResizablePanel` are preserved as metadata but not applied by core layout.
+- `PanelGroup` uses `defaultSize`/`minSize`/`maxSize` as sizing hints along its primary axis.
 - For draggable sizing, use [`SplitPane`](split-pane.md).

--- a/packages/core/src/layout/__tests__/panelGroupSizing.test.ts
+++ b/packages/core/src/layout/__tests__/panelGroupSizing.test.ts
@@ -1,0 +1,127 @@
+import { assert, describe, test } from "@rezi-ui/testkit";
+import type { VNode } from "../../index.js";
+import { layout } from "../layout.js";
+
+function mustLayout(vnode: VNode, maxW: number, maxH: number) {
+  const res = layout(vnode, 0, 0, maxW, maxH, "column");
+  if (!res.ok) {
+    assert.fail(`layout failed: ${res.fatal.code}: ${res.fatal.detail}`);
+  }
+  return res.value;
+}
+
+describe("panelGroup sizing hints", () => {
+  test("resizablePanel defaultSize controls distribution (horizontal)", () => {
+    const pg = {
+      kind: "panelGroup",
+      props: { id: "pg", direction: "horizontal" },
+      children: Object.freeze([
+        {
+          kind: "resizablePanel",
+          props: { defaultSize: 25 },
+          children: Object.freeze([{ kind: "text", text: "A", props: {} }]),
+        },
+        {
+          kind: "resizablePanel",
+          props: { defaultSize: 75 },
+          children: Object.freeze([{ kind: "text", text: "B", props: {} }]),
+        },
+      ]),
+    } as unknown as VNode;
+
+    const tree = mustLayout(pg, 100, 10);
+    const c0 = tree.children[0];
+    const c1 = tree.children[1];
+    assert.ok(c0 !== undefined && c1 !== undefined);
+    if (!c0 || !c1) return;
+
+    assert.equal(c0.rect.x, 0);
+    assert.equal(c0.rect.w, 25);
+    assert.equal(c1.rect.x, 25);
+    assert.equal(c1.rect.w, 75);
+  });
+
+  test("unspecified defaultSize takes remaining percent", () => {
+    const pg = {
+      kind: "panelGroup",
+      props: { id: "pg", direction: "horizontal" },
+      children: Object.freeze([
+        {
+          kind: "resizablePanel",
+          props: { defaultSize: 25 },
+          children: Object.freeze([{ kind: "text", text: "A", props: {} }]),
+        },
+        {
+          kind: "resizablePanel",
+          props: {},
+          children: Object.freeze([{ kind: "text", text: "B", props: {} }]),
+        },
+      ]),
+    } as unknown as VNode;
+
+    const tree = mustLayout(pg, 100, 10);
+    const c0 = tree.children[0];
+    const c1 = tree.children[1];
+    assert.ok(c0 !== undefined && c1 !== undefined);
+    if (!c0 || !c1) return;
+
+    assert.equal(c0.rect.w, 25);
+    assert.equal(c1.rect.w, 75);
+  });
+
+  test("minSize clamps panel (and transfers space to siblings)", () => {
+    const pg = {
+      kind: "panelGroup",
+      props: { id: "pg", direction: "horizontal" },
+      children: Object.freeze([
+        {
+          kind: "resizablePanel",
+          props: { defaultSize: 10, minSize: 20 },
+          children: Object.freeze([{ kind: "text", text: "A", props: {} }]),
+        },
+        {
+          kind: "resizablePanel",
+          props: { defaultSize: 90 },
+          children: Object.freeze([{ kind: "text", text: "B", props: {} }]),
+        },
+      ]),
+    } as unknown as VNode;
+
+    const tree = mustLayout(pg, 100, 10);
+    const c0 = tree.children[0];
+    const c1 = tree.children[1];
+    assert.ok(c0 !== undefined && c1 !== undefined);
+    if (!c0 || !c1) return;
+
+    assert.equal(c0.rect.w, 20);
+    assert.equal(c1.rect.w, 80);
+  });
+
+  test("maxSize clamps panel (and transfers remainder to siblings)", () => {
+    const pg = {
+      kind: "panelGroup",
+      props: { id: "pg", direction: "horizontal" },
+      children: Object.freeze([
+        {
+          kind: "resizablePanel",
+          props: { defaultSize: 80, maxSize: 50 },
+          children: Object.freeze([{ kind: "text", text: "A", props: {} }]),
+        },
+        {
+          kind: "resizablePanel",
+          props: { defaultSize: 20 },
+          children: Object.freeze([{ kind: "text", text: "B", props: {} }]),
+        },
+      ]),
+    } as unknown as VNode;
+
+    const tree = mustLayout(pg, 100, 10);
+    const c0 = tree.children[0];
+    const c1 = tree.children[1];
+    assert.ok(c0 !== undefined && c1 !== undefined);
+    if (!c0 || !c1) return;
+
+    assert.equal(c0.rect.w, 50);
+    assert.equal(c1.rect.w, 50);
+  });
+});

--- a/packages/core/src/layout/kinds/splitPane.ts
+++ b/packages/core/src/layout/kinds/splitPane.ts
@@ -1,10 +1,77 @@
-import type { VNode } from "../../index.js";
+import type { ResizablePanelProps, VNode } from "../../index.js";
 import { computePanelCellSizes } from "../../widgets/splitPane.js";
 import { clampNonNegative, toFiniteMax } from "../engine/bounds.js";
 import { ok } from "../engine/result.js";
 import type { LayoutTree } from "../engine/types.js";
 import type { Axis, Size } from "../types.js";
 import type { LayoutResult } from "../validateProps.js";
+
+function resolvePanelGroupPercentSpecs(children: readonly VNode[]): readonly number[] {
+  const panelCount = children.length;
+  if (panelCount <= 0) return Object.freeze([]);
+
+  const defaultSizes = new Array<number | null>(panelCount);
+
+  let specifiedCount = 0;
+  let specifiedSum = 0;
+
+  for (let i = 0; i < panelCount; i++) {
+    const child = children[i];
+    if (child?.kind === "resizablePanel") {
+      const raw = (child.props as ResizablePanelProps).defaultSize;
+      if (Number.isFinite(raw) && (raw as number) >= 0) {
+        const v = raw as number;
+        defaultSizes[i] = v;
+        specifiedCount++;
+        specifiedSum += v;
+        continue;
+      }
+    }
+    defaultSizes[i] = null;
+  }
+
+  // No defaultSize hints → equal weights.
+  if (specifiedCount === 0) {
+    const each = 100 / panelCount;
+    return Object.freeze(new Array<number>(panelCount).fill(each));
+  }
+
+  const unspecifiedCount = panelCount - specifiedCount;
+  const out = new Array<number>(panelCount);
+
+  // All panels specified: treat defaultSize as weights and normalize to sum=100.
+  if (unspecifiedCount === 0) {
+    if (specifiedSum <= 0) {
+      const each = 100 / panelCount;
+      out.fill(each);
+      return Object.freeze(out);
+    }
+    for (let i = 0; i < panelCount; i++) {
+      const w = defaultSizes[i] ?? 0;
+      out[i] = (w / specifiedSum) * 100;
+    }
+    return Object.freeze(out);
+  }
+
+  // Some specified:
+  // - If sum<=100, treat specified values as percentages and distribute the remainder evenly.
+  // - If sum>100, treat values as weights; give unspecified panels a weight=1.
+  if (specifiedSum <= 100) {
+    const remaining = 100 - specifiedSum;
+    const each = remaining / unspecifiedCount;
+    for (let i = 0; i < panelCount; i++) {
+      out[i] = defaultSizes[i] ?? each;
+    }
+    return Object.freeze(out);
+  }
+
+  const totalWeight = specifiedSum + unspecifiedCount;
+  for (let i = 0; i < panelCount; i++) {
+    const w = defaultSizes[i] ?? 1;
+    out[i] = (w / totalWeight) * 100;
+  }
+  return Object.freeze(out);
+}
 
 type LayoutNodeFn = (
   vnode: VNode,
@@ -104,7 +171,7 @@ export function layoutSplitPaneKinds(
       return ok({ vnode, rect: { x, y, w: rectW, h: rectH }, children: Object.freeze(childTrees) });
     }
     case "panelGroup": {
-      // Panel group: similar to splitPane but with children as panels
+      // Panel group: resizablePanel children can provide size hints (defaultSize/minSize/maxSize)
       const childCount = vnode.children.length;
       if (childCount === 0) {
         return ok({ vnode, rect: { x, y, w: rectW, h: rectH }, children: Object.freeze([]) });
@@ -113,15 +180,43 @@ export function layoutSplitPaneKinds(
       const { direction } = vnode.props;
       const childTrees: LayoutTree[] = [];
       const total = direction === "horizontal" ? rectW : rectH;
-      const basePanelSize = Math.floor(total / childCount);
-      const remainder = total - basePanelSize * childCount;
+
+      const percentSpecs = resolvePanelGroupPercentSpecs(vnode.children);
+
+      const minSizes = new Array<number>(childCount).fill(0);
+      const maxSizes = new Array<number>(childCount).fill(total);
+      let hasConstraints = false;
+
+      for (let i = 0; i < childCount; i++) {
+        const child = vnode.children[i];
+        if (child?.kind !== "resizablePanel") continue;
+
+        const p = child.props as ResizablePanelProps;
+        if (Number.isFinite(p.minSize) && (p.minSize as number) >= 0) {
+          minSizes[i] = Math.floor((total * (p.minSize as number)) / 100);
+          hasConstraints = true;
+        }
+        if (Number.isFinite(p.maxSize) && (p.maxSize as number) >= 0) {
+          maxSizes[i] = Math.floor((total * (p.maxSize as number)) / 100);
+          hasConstraints = true;
+        }
+      }
+
+      const panelSizes = computePanelCellSizes(
+        childCount,
+        percentSpecs,
+        total,
+        "percent",
+        0 /* dividerSize */,
+        hasConstraints ? minSizes : undefined,
+        hasConstraints ? maxSizes : undefined,
+      ).sizes;
 
       let offset = 0;
       for (let i = 0; i < childCount; i++) {
         const child = vnode.children[i];
         if (!child) continue;
-        // Distribute remainder cells one each to the first `remainder` panels
-        const panelSize = basePanelSize + (i < remainder ? 1 : 0);
+        const panelSize = panelSizes[i] ?? 0;
 
         const childX = direction === "horizontal" ? x + offset : x;
         const childY = direction === "vertical" ? y + offset : y;

--- a/packages/core/src/widgets/__tests__/containers.test.ts
+++ b/packages/core/src/widgets/__tests__/containers.test.ts
@@ -91,7 +91,6 @@ describe("container widgets - VNode construction", () => {
       {
         id: "group",
         direction: "vertical",
-        autoSaveId: "layout-main",
       },
       [ui.resizablePanel({ defaultSize: 30 }, [left]), ui.resizablePanel({}, [right])],
     );
@@ -100,7 +99,6 @@ describe("container widgets - VNode construction", () => {
     assert.deepEqual(group.props, {
       id: "group",
       direction: "vertical",
-      autoSaveId: "layout-main",
     });
 
     const panel = ui.resizablePanel({ minSize: 10, maxSize: 70, collapsible: true }, [left]);

--- a/packages/core/src/widgets/splitPane.ts
+++ b/packages/core/src/widgets/splitPane.ts
@@ -40,13 +40,18 @@ function normalizePanelCellSizes(
   const remainder = availableForPanels - totalSize;
   if (remainder > 0) {
     let r = remainder;
-    for (let i = 0; i < sizes.length && r > 0; i++) {
-      const currentSize = sizes[i] ?? 0;
-      const maxSize = maxSizes?.[i] ?? availableForPanels;
-      if (currentSize < maxSize) {
-        sizes[i] = currentSize + 1;
-        r--;
+    while (r > 0) {
+      let progressed = false;
+      for (let i = 0; i < sizes.length && r > 0; i++) {
+        const currentSize = sizes[i] ?? 0;
+        const maxSize = maxSizes?.[i] ?? availableForPanels;
+        if (currentSize < maxSize) {
+          sizes[i] = currentSize + 1;
+          r--;
+          progressed = true;
+        }
       }
+      if (!progressed) break;
     }
   } else if (remainder < 0) {
     let overshoot = -remainder;

--- a/packages/core/src/widgets/types.ts
+++ b/packages/core/src/widgets/types.ts
@@ -991,8 +991,6 @@ export type PanelGroupProps = Readonly<{
   key?: string;
   /** Layout direction. */
   direction: SplitDirection;
-  /** Auto-save layout key (localStorage). */
-  autoSaveId?: string;
 }>;
 
 /* ---------- CodeEditor Widget ---------- */

--- a/packages/core/src/widgets/ui.ts
+++ b/packages/core/src/widgets/ui.ts
@@ -840,7 +840,6 @@ export const ui = {
    * ui.panelGroup({
    *   id: "panel-group",
    *   direction: "horizontal",
-   *   autoSaveId: "main-layout",
    * }, [
    *   ui.resizablePanel({ defaultSize: 25 }, [Sidebar()]),
    *   ui.resizablePanel({ defaultSize: 75, minSize: 50 }, [Content()]),


### PR DESCRIPTION
Fixes P1 API inconsistency: ResizablePanel size hints were documented/typed but ignored by PanelGroup layout.

Changes:
- PanelGroup now uses ResizablePanel defaultSize/minSize/maxSize (percent-based) to distribute space.
- Removes unused PanelGroup autoSaveId from types/docs.
- Fixes split pane size normalization to fully distribute remainder when max constraints clamp a panel.

Tests:
- npm run lint
- npm run typecheck -- --force
- npm test

Note: npm run test:e2e is linux-only by design.