### PR TITLE
SplitPane: collapse state + onCollapse double-click

### DIFF
--- a/docs/widgets/split-pane.md
+++ b/docs/widgets/split-pane.md
@@ -44,6 +44,16 @@ Dividers between panels can be dragged with the mouse to resize:
 
 The hit area for dividers extends 1 cell on each side of the divider for easier grabbing.
 
+### Collapse
+
+When `collapsible: true`:
+
+- A panel index in `collapsed` is laid out at its minimum size (`minSizes[index]` or `0`).
+- **Double-click** near a divider to toggle collapse:
+  - Click just to the **left/top** of a divider to target the panel on that side
+  - Click just to the **right/bottom** of a divider to target the other panel
+- Use `onCollapse(index, collapsed)` to update your `collapsed` list (controlled state).
+
 ## Notes
 
 - `sizes` length should match the number of child panels.

--- a/packages/core/src/layout/__tests__/splitPaneCollapse.test.ts
+++ b/packages/core/src/layout/__tests__/splitPaneCollapse.test.ts
@@ -1,0 +1,98 @@
+import { assert, describe, test } from "@rezi-ui/testkit";
+import type { VNode } from "../../index.js";
+import { layout } from "../layout.js";
+
+function mustLayout(vnode: VNode, maxW: number, maxH: number) {
+  const res = layout(vnode, 0, 0, maxW, maxH, "column");
+  if (!res.ok) {
+    assert.fail(`layout failed: ${res.fatal.code}: ${res.fatal.detail}`);
+  }
+  return res.value;
+}
+
+describe("splitPane collapse", () => {
+  test("collapsed index forces panel to minSize (default 0)", () => {
+    const sp = {
+      kind: "splitPane",
+      props: {
+        id: "sp",
+        direction: "horizontal",
+        sizes: Object.freeze([50, 50]),
+        onResize: () => {},
+        collapsible: true,
+        collapsed: Object.freeze([0]),
+      },
+      children: Object.freeze([
+        { kind: "divider", props: {} },
+        { kind: "divider", props: {} },
+      ]),
+    } as unknown as VNode;
+
+    const tree = mustLayout(sp, 100, 10);
+    const c0 = tree.children[0];
+    const c1 = tree.children[1];
+    assert.ok(c0 !== undefined && c1 !== undefined);
+    if (!c0 || !c1) return;
+
+    // dividerSize default = 1, so panel widths must sum to 99.
+    assert.equal(c0.rect.w, 0);
+    assert.equal(c1.rect.x, 1);
+    assert.equal(c1.rect.w, 99);
+  });
+
+  test("collapsed index uses provided minSizes[index]", () => {
+    const sp = {
+      kind: "splitPane",
+      props: {
+        id: "sp",
+        direction: "horizontal",
+        sizes: Object.freeze([50, 50]),
+        minSizes: Object.freeze([10, 0]),
+        onResize: () => {},
+        collapsible: true,
+        collapsed: Object.freeze([0]),
+      },
+      children: Object.freeze([
+        { kind: "divider", props: {} },
+        { kind: "divider", props: {} },
+      ]),
+    } as unknown as VNode;
+
+    const tree = mustLayout(sp, 100, 10);
+    const c0 = tree.children[0];
+    const c1 = tree.children[1];
+    assert.ok(c0 !== undefined && c1 !== undefined);
+    if (!c0 || !c1) return;
+
+    assert.equal(c0.rect.w, 10);
+    assert.equal(c1.rect.x, 11);
+    assert.equal(c1.rect.w, 89);
+  });
+
+  test("collapsed list is ignored when collapsible is false", () => {
+    const sp = {
+      kind: "splitPane",
+      props: {
+        id: "sp",
+        direction: "horizontal",
+        sizes: Object.freeze([50, 50]),
+        onResize: () => {},
+        collapsible: false,
+        collapsed: Object.freeze([0]),
+      },
+      children: Object.freeze([
+        { kind: "divider", props: {} },
+        { kind: "divider", props: {} },
+      ]),
+    } as unknown as VNode;
+
+    const tree = mustLayout(sp, 100, 10);
+    const c0 = tree.children[0];
+    const c1 = tree.children[1];
+    assert.ok(c0 !== undefined && c1 !== undefined);
+    if (!c0 || !c1) return;
+
+    assert.ok(c0.rect.w > 0, "panel should not be collapsed when collapsible=false");
+    assert.ok(c1.rect.w > 0);
+  });
+});

--- a/packages/core/src/renderer/renderToDrawlist/widgets/containers.ts
+++ b/packages/core/src/renderer/renderToDrawlist/widgets/containers.ts
@@ -358,10 +358,11 @@ export function renderContainerWidget(
       const childCount = Math.min(node.children.length, layoutNode.children.length);
       if (direction === "horizontal") {
         for (let i = 0; i < childCount - 1; i++) {
-          const childRect = layoutNode.children[i]?.rect;
-          if (!childRect) continue;
+          const nextRect = layoutNode.children[i + 1]?.rect;
+          if (!nextRect) continue;
 
-          const offset = childRect.x + childRect.w - rect.x;
+          // Divider starts immediately before the next panel's x.
+          const offset = nextRect.x - rect.x - dividerSize;
           if (offset < 0 || offset >= rect.w) continue;
 
           const width = Math.min(dividerSize, rect.w - offset);
@@ -373,10 +374,11 @@ export function renderContainerWidget(
         }
       } else {
         for (let i = 0; i < childCount - 1; i++) {
-          const childRect = layoutNode.children[i]?.rect;
-          if (!childRect) continue;
+          const nextRect = layoutNode.children[i + 1]?.rect;
+          if (!nextRect) continue;
 
-          const offset = childRect.y + childRect.h - rect.y;
+          // Divider starts immediately before the next panel's y.
+          const offset = nextRect.y - rect.y - dividerSize;
           if (offset < 0 || offset >= rect.h) continue;
 
           const line = rect.w > 0 ? "─".repeat(rect.w) : "";


### PR DESCRIPTION
Fixes P1 API inconsistency: SplitPane collapsible/collapsed/onCollapse were documented/typed but unused.

Changes:
- Layout applies `collapsed` indices when `collapsible: true` (collapsed panels clamp to `minSizes[index]` or 0).
- WidgetRenderer: double-click near a divider invokes `onCollapse(index, collapsed)` (click left/top vs right/bottom to choose panel).
- Divider hit-testing + rendering now use panel boundaries derived from adjacent child positions (works even when child widgets don't naturally fill).

Tests:
- npm run lint
- npm run typecheck -- --force
- npm test

Note: npm run test:e2e is linux-only by design.