### PR TITLE
WidgetRenderer: GC virtualList/table state + render caches

### DIFF
--- a/packages/core/src/app/__tests__/widgetRenderer.integration.test.ts
+++ b/packages/core/src/app/__tests__/widgetRenderer.integration.test.ts
@@ -1,7 +1,7 @@
 import { assert, describe, test } from "@rezi-ui/testkit";
 import type { RuntimeBackend } from "../../backend.js";
 import type { ZrevEvent } from "../../events.js";
-import { defineWidget, ui } from "../../index.js";
+import { type VNode, defineWidget, ui } from "../../index.js";
 import { DEFAULT_TERMINAL_CAPS } from "../../terminalCaps.js";
 import { defaultTheme } from "../../theme/defaultTheme.js";
 import { TOAST_HEIGHT, getToastActionFocusId } from "../../widgets/toast.js";
@@ -589,6 +589,76 @@ describe("WidgetRenderer integration battery", () => {
       { scrollTop: 3, range: [0, 16] },
       { scrollTop: 90, range: [87, 100] },
     ]);
+  });
+
+  test("routing rebuild GC clears virtualList/table local state for removed ids", () => {
+    const backend = createNoopBackend();
+    const renderer = new WidgetRenderer<void>({
+      backend,
+      requestRender: () => {},
+    });
+
+    const vlistSelected: string[] = [];
+    const tablePressed: string[] = [];
+
+    const Virtual = () =>
+      ui.virtualList({
+        id: "v",
+        items: ["a", "b"],
+        itemHeight: 1,
+        renderItem: (item) => ui.text(item),
+        onSelect: (item, index) => vlistSelected.push(`${item}:${String(index)}`),
+      });
+
+    const Table = () =>
+      ui.table({
+        id: "t",
+        columns: [{ key: "id", header: "ID", flex: 1 }],
+        data: [{ id: "r0" }, { id: "r1" }],
+        getRowKey: (row) => row.id,
+        onRowPress: (row, index) => tablePressed.push(`${row.id}:${String(index)}`),
+      });
+
+    const submit = (vnode: VNode) => {
+      const res = renderer.submitFrame(
+        () => vnode,
+        undefined,
+        { cols: 40, rows: 10 },
+        defaultTheme,
+        noRenderHooks(),
+      );
+      assert.ok(res.ok);
+    };
+
+    submit(ui.column({}, [Virtual(), Table()]));
+
+    // VirtualList: select item index=1.
+    renderer.routeEngineEvent(keyEvent(3 /* TAB */));
+    renderer.routeEngineEvent(keyEvent(21 /* DOWN */));
+    renderer.routeEngineEvent(keyEvent(2 /* ENTER */));
+
+    // Table: focus and press row index=1.
+    renderer.routeEngineEvent(keyEvent(3 /* TAB */));
+    renderer.routeEngineEvent(keyEvent(21 /* DOWN */));
+    renderer.routeEngineEvent(keyEvent(2 /* ENTER */));
+
+    assert.deepEqual(vlistSelected, ["b:1"]);
+    assert.deepEqual(tablePressed, ["r1:1"]);
+
+    // Unmount both widgets and force a routing rebuild GC pass.
+    submit(ui.text("gone"));
+
+    // Remount with same ids; state should start from defaults.
+    submit(ui.column({}, [Virtual(), Table()]));
+
+    renderer.routeEngineEvent(keyEvent(3 /* TAB */));
+    renderer.routeEngineEvent(keyEvent(2 /* ENTER */));
+
+    renderer.routeEngineEvent(keyEvent(3 /* TAB */));
+    renderer.routeEngineEvent(keyEvent(2 /* ENTER */));
+
+    assert.deepEqual(vlistSelected, ["b:1", "a:0"]);
+    assert.deepEqual(tablePressed, ["r1:1", "r0:0"]);
   });
 
   test("table routing moves focused row and activates on Enter", () => {

--- a/packages/core/src/app/widgetRenderer.ts
+++ b/packages/core/src/app/widgetRenderer.ts
@@ -388,6 +388,8 @@ export class WidgetRenderer<S> {
   // Pooled Sets for tracking previous IDs (GC cleanup detection)
   private readonly _pooledPrevTreeIds = new Set<string>();
   private readonly _pooledPrevDropdownIds = new Set<string>();
+  private readonly _pooledPrevVirtualListIds = new Set<string>();
+  private readonly _pooledPrevTableIds = new Set<string>();
   private readonly _pooledPrevTreeStoreIds = new Set<string>();
   private readonly _pooledPrevCommandPaletteIds = new Set<string>();
   private readonly _pooledPrevToolApprovalDialogIds = new Set<string>();
@@ -2220,6 +2222,10 @@ export class WidgetRenderer<S> {
         for (const k of this.treeById.keys()) this._pooledPrevTreeIds.add(k);
         this._pooledPrevDropdownIds.clear();
         for (const k of this.dropdownById.keys()) this._pooledPrevDropdownIds.add(k);
+        this._pooledPrevVirtualListIds.clear();
+        for (const k of this.virtualListById.keys()) this._pooledPrevVirtualListIds.add(k);
+        this._pooledPrevTableIds.clear();
+        for (const k of this.tableById.keys()) this._pooledPrevTableIds.add(k);
         this._pooledPrevTreeStoreIds.clear();
         for (const k of this.treeById.keys()) this._pooledPrevTreeStoreIds.add(k);
         for (const k of this.filePickerById.keys()) this._pooledPrevTreeStoreIds.add(k);
@@ -2721,6 +2727,23 @@ export class WidgetRenderer<S> {
         for (const prevDropdownId of this._pooledPrevDropdownIds) {
           if (!this.dropdownById.has(prevDropdownId)) {
             this.dropdownSelectedIndexById.delete(prevDropdownId);
+          }
+        }
+
+        // Garbage collect local state for virtual lists that were removed.
+        for (const prevId of this._pooledPrevVirtualListIds) {
+          if (!this.virtualListById.has(prevId)) {
+            this.virtualListStore.delete(prevId);
+            if (this.pressedVirtualList?.id === prevId) {
+              this.pressedVirtualList = null;
+            }
+          }
+        }
+
+        // Garbage collect local state for tables that were removed.
+        for (const prevId of this._pooledPrevTableIds) {
+          if (!this.tableById.has(prevId)) {
+            this.tableStore.delete(prevId);
           }
         }
 

--- a/packages/core/src/app/widgetRenderer/renderCaches.ts
+++ b/packages/core/src/app/widgetRenderer/renderCaches.ts
@@ -65,6 +65,20 @@ export function rebuildRenderCaches(
     emptyStringArray: readonly string[];
   }>,
 ): void {
+  // Prune caches for widgets that were removed (avoid unbounded growth with churny ids).
+  for (const id of opts.tableRenderCacheById.keys()) {
+    if (!opts.tableById.has(id)) opts.tableRenderCacheById.delete(id);
+  }
+  for (const id of opts.logsConsoleRenderCacheById.keys()) {
+    if (!opts.logsConsoleById.has(id)) opts.logsConsoleRenderCacheById.delete(id);
+  }
+  for (const id of opts.diffRenderCacheById.keys()) {
+    if (!opts.diffViewerById.has(id)) opts.diffRenderCacheById.delete(id);
+  }
+  for (const id of opts.codeEditorRenderCacheById.keys()) {
+    if (!opts.codeEditorById.has(id)) opts.codeEditorRenderCacheById.delete(id);
+  }
+
   for (const table of opts.tableById.values()) {
     const dataRef = table.data as readonly unknown[];
     const getRowKeyRef = table.getRowKey as (row: unknown, index: number) => string;


### PR DESCRIPTION
Fixes P2 leak risk: churny ids could leave behind virtualList/table local state and render caches.

Changes:
- WidgetRenderer GC removes `virtualListStore` + `tableStore` entries for unmounted widget ids.
- renderCaches: prunes `*RenderCacheById` maps for removed widgets during routing rebuild.
- Adds integration test to ensure state resets after unmount/remount.
- Stabilizes widgetMeta perf tests (warmup + larger workload) to avoid timing flakiness.

Tests:
- npm run lint
- npm run typecheck -- --force
- npm test

Note: npm run test:e2e is linux-only by design.