### PR TITLE
Divider: support surrogate-pair glyphs in char

### DIFF
--- a/packages/core/src/renderer/__tests__/render.golden.test.ts
+++ b/packages/core/src/renderer/__tests__/render.golden.test.ts
@@ -307,6 +307,19 @@ describe("renderer - widget tree to deterministic ZRDL bytes", () => {
     assertBytesEqual(actual, expected, "divider_with_label.bin");
   });
 
+  test("divider preserves surrogate-pair glyph char", () => {
+    // U+1D306 TETRAGRAM FOR CENTRE (surrogate pair in UTF-16)
+    const glyph = "𝌆";
+    const vnode: VNode = { kind: "divider", props: { char: glyph } };
+    const actual = renderBytes(vnode, Object.freeze({ focusedId: null }));
+    const strings = parseInternedStrings(actual);
+    assert.equal(
+      strings.includes(glyph.repeat(80)),
+      true,
+      "expected glyph line in interned strings",
+    );
+  });
+
   test("modal_backdrop_dim.bin", async () => {
     const expected = await load("modal_backdrop_dim.bin");
     const modal: VNode = {

--- a/packages/core/src/renderer/renderToDrawlist/simpleVNode.ts
+++ b/packages/core/src/renderer/renderToDrawlist/simpleVNode.ts
@@ -728,11 +728,12 @@ export function renderVNodeSimple(
       const direction = props.direction === "vertical" ? "vertical" : "horizontal";
       const rawChar =
         typeof props.char === "string" && props.char.length > 0 ? props.char : undefined;
-      const glyph = rawChar
-        ? (rawChar[0] ?? (direction === "horizontal" ? "─" : "│"))
-        : direction === "horizontal"
-          ? "─"
-          : "│";
+      const glyph = (() => {
+        const fallback = direction === "horizontal" ? "─" : "│";
+        if (!rawChar) return fallback;
+        const cp = rawChar.codePointAt(0);
+        return cp === undefined ? fallback : String.fromCodePoint(cp);
+      })();
       const label = typeof props.label === "string" ? props.label : undefined;
       const color = typeof props.color === "string" ? props.color : undefined;
       const style = color

--- a/packages/core/src/renderer/renderToDrawlist/widgets/basic.ts
+++ b/packages/core/src/renderer/renderToDrawlist/widgets/basic.ts
@@ -442,11 +442,12 @@ export function renderBasicWidget(
       const direction = props.direction === "vertical" ? "vertical" : "horizontal";
       const rawChar =
         typeof props.char === "string" && props.char.length > 0 ? props.char : undefined;
-      const glyph = rawChar
-        ? (rawChar[0] ?? (direction === "horizontal" ? "─" : "│"))
-        : direction === "horizontal"
-          ? "─"
-          : "│";
+      const glyph = (() => {
+        const fallback = direction === "horizontal" ? "─" : "│";
+        if (!rawChar) return fallback;
+        const cp = rawChar.codePointAt(0);
+        return cp === undefined ? fallback : String.fromCodePoint(cp);
+      })();
       const label = typeof props.label === "string" ? props.label : undefined;
       const color = typeof props.color === "string" ? props.color : undefined;
       const style = color


### PR DESCRIPTION
Fixes P2 edge correctness: divider custom `char` used `rawChar[0]` (UTF-16 code unit), breaking surrogate-pair glyphs.

Changes:
- Divider rendering now uses the first Unicode codepoint via `codePointAt(0)` in both advanced and simple renderers.
- Adds renderer test to ensure a surrogate-pair glyph is preserved in interned strings.

Tests:
- npm run lint
- npm run typecheck -- --force
- npm test

Note: npm run test:e2e is linux-only by design.