### PR TITLE
fix(ink-compat): parse ANSI SGR sequences in Text nodes

### DIFF
--- a/packages/ink-compat/src/__tests__/reconciler.test.tsx
+++ b/packages/ink-compat/src/__tests__/reconciler.test.tsx
@@ -48,6 +48,24 @@ describe("reconciler: host tree -> Rezi VNode", () => {
     assert.deepEqual(spans[1], { text: " there" });
   });
 
+  test("<Text> parses ANSI SGR color sequences into richText spans", () => {
+    const vnode = renderToVNode(<Text>{"\u001b[31mRED\u001b[0m plain"}</Text>);
+    assert.equal(vnode.kind, "richText");
+    const spans = vnode.props.spans;
+    assert.equal(spans.length, 2);
+    assert.deepEqual(spans[0], { text: "RED", style: { fg: { r: 128, g: 0, b: 0 } } });
+    assert.deepEqual(spans[1], { text: " plain" });
+  });
+
+  test("<Text> supports ANSI 256-color foreground (38;5;n)", () => {
+    const vnode = renderToVNode(<Text>{"\u001b[38;5;74mA\u001b[39mB"}</Text>);
+    assert.equal(vnode.kind, "richText");
+    const spans = vnode.props.spans;
+    assert.equal(spans.length, 2);
+    assert.deepEqual(spans[0], { text: "A", style: { fg: { r: 95, g: 175, b: 215 } } });
+    assert.deepEqual(spans[1], { text: "B" });
+  });
+
   test("<Box flexDirection> maps to ui.row/ui.column", () => {
     const row = renderToVNode(
       <Box flexDirection="row">


### PR DESCRIPTION
## Summary
- parse ANSI CSI/SGR sequences inside text nodes instead of stripping only ESC
- prevent raw artifacts like `[38;5;74m` from leaking into rendered output
- map common SGR attributes/colors (including 256-color and truecolor) into Rezi text styles
- add reconciler tests for `\x1b[31m` and `\x1b[38;5;74m` cases

## Repro before fix
`<Text>{"\x1b[31mRED\x1b[0m plain"}</Text>` rendered as literal `[31mRED[0m plain`.

## Validation
- `npx tsc -b packages/ink-compat`
- `node --test packages/ink-compat/dist/__tests__/reconciler.test.js`