### PR TITLE
feat(ink-compat): tier2/3 completion for testing entrypoint and parity

### DIFF
--- a/packages/ink-compat/package.json
+++ b/packages/ink-compat/package.json
@@ -22,6 +22,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing.d.ts",
+      "default": "./dist/testing.js"
     }
   },
   "files": ["dist/", "README.md"],

--- a/packages/ink-compat/src/__tests__/lifecycle.behavior.test.tsx
+++ b/packages/ink-compat/src/__tests__/lifecycle.behavior.test.tsx
@@ -80,6 +80,30 @@ test("lifecycle_render_with_stream_shorthand (IKINV-009)", async () => {
   app.cleanup();
 });
 
+test("lifecycle_render_result_exposes_configured_streams (IKINV-009)", () => {
+  const io = createStreams(false);
+  const app = render(<Text>handles</Text>, { ...io, debug: true });
+
+  assert.equal(app.stdout, io.stdout);
+  assert.equal(app.stderr, io.stderr);
+  assert.equal(app.stdin, io.stdin);
+
+  app.unmount();
+  app.cleanup();
+});
+
+test("lifecycle_render_result_exposes_default_streams (IKINV-009)", () => {
+  const stdout = new MemoryWriteStream({ isTTY: false, columns: 80 });
+  const app = render(<Text>defaults</Text>, { stdout, debug: true });
+
+  assert.equal(app.stdout, stdout);
+  assert.equal(app.stderr, process.stderr);
+  assert.equal(app.stdin, process.stdin);
+
+  app.unmount();
+  app.cleanup();
+});
+
 test("lifecycle_rerender_writes_latest_frame (IKINV-001)", async () => {
   const io = createStreams(false);
   const app = render(<Text>first</Text>, { ...io, debug: true });

--- a/packages/ink-compat/src/__tests__/testing.entrypoint.contract.test.tsx
+++ b/packages/ink-compat/src/__tests__/testing.entrypoint.contract.test.tsx
@@ -1,0 +1,102 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+
+import React, { useEffect, useRef, useState } from "react";
+
+import { Text, useInput, useStderr } from "../index.js";
+import { cleanup, render } from "../testing.js";
+import { flushTurns } from "./helpers.js";
+
+test.afterEach(() => {
+  cleanup();
+});
+
+test("testing_render_exposes_ink_testing_library_v4_shape (IKINV-009)", async () => {
+  const app = render(<Text>alpha</Text>);
+
+  await flushTurns(6);
+  assert.equal(app.lastFrame(), "alpha");
+  assert.equal(app.stdout.lastFrame(), "alpha");
+  assert.equal(app.frames.at(-1), "alpha");
+  assert.equal(app.frames, app.stdout.frames);
+
+  app.rerender(<Text>beta</Text>);
+  await flushTurns(6);
+
+  assert.equal(app.lastFrame(), "beta");
+  assert.equal(app.frames.at(-1), "beta");
+
+  app.unmount();
+  app.cleanup();
+  app.cleanup();
+});
+
+test("testing_stdin_write_drives_input_events (IKINV-005)", async () => {
+  const Probe = () => {
+    const [value, setValue] = useState("idle");
+
+    useInput((input, key) => {
+      if (key.return) {
+        setValue((previous) => `${previous}|enter`);
+        return;
+      }
+
+      setValue((previous) => `${previous}${input}`);
+    });
+
+    return <Text>{value}</Text>;
+  };
+
+  const app = render(<Probe />);
+  await flushTurns(6);
+
+  app.stdin.write("a");
+  await flushTurns(4);
+  app.stdin.write("b");
+  await flushTurns(4);
+  app.stdin.write("\r");
+  await flushTurns(8);
+
+  assert.equal(app.lastFrame(), "idleab|enter");
+
+  app.unmount();
+  app.cleanup();
+});
+
+test("testing_cleanup_global_is_idempotent (IKINV-007)", async () => {
+  render(<Text>one</Text>);
+  render(<Text>two</Text>);
+
+  await flushTurns(4);
+
+  cleanup();
+  cleanup();
+});
+
+test("testing_stderr_collects_frames (IKINV-007)", async () => {
+  const Probe = () => {
+    const { write } = useStderr();
+    const wroteRef = useRef(false);
+
+    useEffect(() => {
+      if (wroteRef.current) {
+        return;
+      }
+
+      wroteRef.current = true;
+      write("stderr-frame");
+    }, [write]);
+
+    return <Text>stdout-frame</Text>;
+  };
+
+  const app = render(<Probe />);
+  await flushTurns(8);
+
+  assert.equal(app.stderr.lastFrame(), "stderr-frame");
+  assert.equal(app.stderr.frames.at(-1), "stderr-frame");
+  assert.ok(app.stdout.frames.length >= 1);
+
+  app.unmount();
+  app.cleanup();
+});

--- a/packages/ink-compat/src/__tests__/tier23.parity.test.tsx
+++ b/packages/ink-compat/src/__tests__/tier23.parity.test.tsx
@@ -1,0 +1,74 @@
+import { strict as assert } from "node:assert";
+import test from "node:test";
+
+import React from "react";
+
+import { Text, Transform, render } from "../index.js";
+import { cleanup as cleanupTesting, render as renderTesting } from "../testing.js";
+import { MemoryWriteStream, createStdin, flushTurns, stripAnsi } from "./helpers.js";
+
+test.afterEach(() => {
+  cleanupTesting();
+});
+
+test("transform_multiline_index_mapping_is_stable (IKINV-004)", async () => {
+  const app = renderTesting(
+    <Transform transform={(line, index) => `${index}:${line}`}>
+      <Text>{"alpha\nbeta\ngamma"}</Text>
+    </Transform>,
+  );
+
+  await flushTurns(6);
+
+  assert.equal(app.lastFrame(), "0:alpha\n1:beta\n2:gamma");
+
+  app.unmount();
+  app.cleanup();
+});
+
+async function runModeScenario(isTTY: boolean): Promise<string> {
+  const stdout = new MemoryWriteStream({ isTTY, columns: 80 });
+  const stderr = new MemoryWriteStream({ isTTY, columns: 80 });
+  const stdin = createStdin(isTTY);
+
+  const app = render(<Text>start</Text>, { stdout, stderr, stdin, debug: true });
+
+  for (let index = 1; index <= 40; index++) {
+    app.rerender(<Text>{`step=${index}`}</Text>);
+  }
+
+  await flushTurns(8);
+  const finalFrame = stripAnsi(stdout.lastChunk());
+
+  app.unmount();
+  app.cleanup();
+
+  return finalFrame;
+}
+
+test("tty_and_non_tty_rerender_sequences_are_deterministic (IKINV-008)", async () => {
+  const ttyFrame = await runModeScenario(true);
+  const nonTtyFrame = await runModeScenario(false);
+
+  assert.equal(ttyFrame, "step=40");
+  assert.equal(nonTtyFrame, "step=40");
+  assert.equal(ttyFrame, nonTtyFrame);
+});
+
+test("high_frequency_rerender_final_output_is_deterministic (IKINV-001)", async () => {
+  const iterations = 300;
+  const app = renderTesting(<Text>frame-0</Text>);
+
+  for (let index = 1; index <= iterations; index++) {
+    app.rerender(<Text>{`frame-${index}`}</Text>);
+  }
+
+  await flushTurns(10);
+
+  assert.equal(app.lastFrame(), `frame-${iterations}`);
+  assert.equal(app.frames.at(-1), `frame-${iterations}`);
+  assert.ok(app.frames.length >= 1);
+
+  app.unmount();
+  app.cleanup();
+});

--- a/packages/ink-compat/src/index.ts
+++ b/packages/ink-compat/src/index.ts
@@ -17,7 +17,7 @@ export { Box, Text } from "./components.js";
 export type { BoxProps, TextProps } from "./components.js";
 
 export { render } from "./render.js";
-export type { RenderOptions } from "./render.js";
+export type { RenderOptions, RenderResult } from "./render.js";
 
 export { useInput } from "./useInput.js";
 export type { InputHandler } from "./useInput.js";

--- a/packages/ink-compat/src/keyNormalization.ts
+++ b/packages/ink-compat/src/keyNormalization.ts
@@ -8,10 +8,10 @@ type LegacyKeyFields = Readonly<{
   hyper: boolean;
   capsLock: boolean;
   numLock: boolean;
-  eventType: string | undefined;
+  eventType?: string;
 }>;
 
-type InkCompatKeyInput = Partial<InkKey> &
+type InkCompatKeyInput = Omit<Partial<InkKey>, "eventType"> &
   Readonly<{
     enter?: boolean;
     home?: boolean;
@@ -23,7 +23,7 @@ type InkCompatKeyInput = Partial<InkKey> &
     eventType?: unknown;
   }>;
 
-export type InkCompatKey = InkKey & LegacyKeyFields;
+export type InkCompatKey = Omit<InkKey, "eventType"> & LegacyKeyFields;
 
 function isTrue(value: unknown): boolean {
   return value === true;
@@ -35,8 +35,7 @@ export function normalizeKey(key: InkCompatKeyInput | null | undefined): InkComp
   const isDelete = isTrue(safe.delete);
   const isBackspace = isTrue(safe.backspace) || isDelete;
   const eventType = typeof safe.eventType === "string" ? safe.eventType : undefined;
-
-  return {
+  const normalized: Omit<InkCompatKey, "eventType"> = {
     upArrow: isTrue(safe.upArrow),
     downArrow: isTrue(safe.downArrow),
     leftArrow: isTrue(safe.leftArrow),
@@ -58,6 +57,14 @@ export function normalizeKey(key: InkCompatKeyInput | null | undefined): InkComp
     hyper: isTrue(safe.hyper),
     capsLock: isTrue(safe.capsLock),
     numLock: isTrue(safe.numLock),
+  };
+
+  if (eventType === undefined) {
+    return normalized;
+  }
+
+  return {
+    ...normalized,
     eventType,
   };
 }

--- a/packages/ink-compat/src/testing.ts
+++ b/packages/ink-compat/src/testing.ts
@@ -1,0 +1,192 @@
+import { PassThrough, Writable } from "node:stream";
+
+import type { ReactElement } from "react";
+
+import { type RenderOptions, type RenderResult, render as compatRender } from "./render.js";
+
+export class TestingStdout extends Writable {
+  public readonly isTTY: boolean;
+  public readonly columns: number;
+  public readonly frames: string[] = [];
+
+  #lastFrame: string | undefined;
+
+  constructor(options: Readonly<{ isTTY: boolean; columns: number }>) {
+    super();
+    this.isTTY = options.isTTY;
+    this.columns = options.columns;
+  }
+
+  _write(
+    chunk: string | Uint8Array,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    const frame = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    this.frames.push(frame);
+    this.#lastFrame = frame;
+    callback();
+  }
+
+  public lastFrame(): string | undefined {
+    return this.#lastFrame;
+  }
+
+  public getColorDepth(_env?: Record<string, unknown>): number {
+    return this.isTTY ? 8 : 1;
+  }
+
+  public hasColors(_count?: number, _env?: Record<string, unknown>): boolean {
+    return this.isTTY;
+  }
+}
+
+export class TestingStderr extends Writable {
+  public readonly isTTY: boolean;
+  public readonly columns: number;
+  public readonly frames: string[] = [];
+
+  #lastFrame: string | undefined;
+
+  constructor(options: Readonly<{ isTTY: boolean; columns: number }>) {
+    super();
+    this.isTTY = options.isTTY;
+    this.columns = options.columns;
+  }
+
+  _write(
+    chunk: string | Uint8Array,
+    _encoding: BufferEncoding,
+    callback: (error?: Error | null) => void,
+  ): void {
+    const frame = typeof chunk === "string" ? chunk : Buffer.from(chunk).toString("utf8");
+    this.frames.push(frame);
+    this.#lastFrame = frame;
+    callback();
+  }
+
+  public lastFrame(): string | undefined {
+    return this.#lastFrame;
+  }
+
+  public getColorDepth(_env?: Record<string, unknown>): number {
+    return this.isTTY ? 8 : 1;
+  }
+
+  public hasColors(_count?: number, _env?: Record<string, unknown>): boolean {
+    return this.isTTY;
+  }
+}
+
+export type TestingStdin = PassThrough & NodeJS.ReadStream;
+
+function createTestingStdin(isTTY = true): TestingStdin {
+  const stdin = new PassThrough() as TestingStdin;
+  stdin.isTTY = isTTY;
+  stdin.isRaw = false;
+  stdin.ref = () => stdin;
+  stdin.unref = () => stdin;
+  stdin.setRawMode = (mode: boolean) => {
+    stdin.isRaw = mode;
+    return stdin;
+  };
+  stdin.setEncoding("utf8");
+  stdin.resume();
+  return stdin;
+}
+
+export type TestingRenderOptions = Omit<RenderOptions, "stdout" | "stderr" | "stdin"> &
+  Readonly<{
+    stdout?: TestingStdout;
+    stderr?: TestingStderr;
+    stdin?: TestingStdin;
+    isTTY?: boolean;
+    columns?: number;
+  }>;
+
+export type TestingRenderResult = Readonly<{
+  rerender: (tree: ReactElement) => void;
+  unmount: () => void;
+  cleanup: () => void;
+  stdout: TestingStdout;
+  stderr: TestingStderr;
+  stdin: TestingStdin;
+  frames: string[];
+  lastFrame: () => string | undefined;
+}>;
+
+type ActiveRenderEntry = Readonly<{
+  unmount: () => void;
+  cleanup: () => void;
+}>;
+
+const activeRenders = new Set<ActiveRenderEntry>();
+
+export function render(
+  tree: ReactElement,
+  options: TestingRenderOptions = {},
+): TestingRenderResult {
+  const {
+    stdout: customStdout,
+    stderr: customStderr,
+    stdin: customStdin,
+    isTTY = false,
+    columns = 100,
+    ...renderOptions
+  } = options;
+
+  const stdout = customStdout ?? new TestingStdout({ isTTY, columns });
+  const stderr = customStderr ?? new TestingStderr({ isTTY, columns });
+  const stdin = customStdin ?? createTestingStdin(true);
+
+  const app = compatRender(tree, {
+    ...renderOptions,
+    stdout: stdout as unknown as NodeJS.WriteStream,
+    stderr: stderr as unknown as NodeJS.WriteStream,
+    stdin,
+    debug: renderOptions.debug ?? true,
+    exitOnCtrlC: renderOptions.exitOnCtrlC ?? false,
+    patchConsole: renderOptions.patchConsole ?? false,
+  });
+
+  let cleaned = false;
+  const entry: ActiveRenderEntry = {
+    unmount: app.unmount,
+    cleanup: () => {
+      if (cleaned) {
+        return;
+      }
+
+      cleaned = true;
+      activeRenders.delete(entry);
+      app.cleanup();
+    },
+  };
+
+  activeRenders.add(entry);
+
+  return {
+    rerender: (nextTree) => {
+      app.rerender(nextTree);
+    },
+    unmount: entry.unmount,
+    cleanup: entry.cleanup,
+    stdout,
+    stderr,
+    stdin,
+    frames: stdout.frames,
+    lastFrame: () => stdout.lastFrame(),
+  };
+}
+
+export function cleanup(): void {
+  const entries = [...activeRenders];
+  activeRenders.clear();
+
+  for (const entry of entries) {
+    entry.unmount();
+    entry.cleanup();
+  }
+}
+
+export type { RenderResult };


### PR DESCRIPTION
## Summary
This PR continues from merged feat/ink-compat-super-pass and closes the remaining Tier-2/3 implementation cluster with code-only changes (no internal docs in diff).

### Implemented
- Added @rezi-ui/ink-compat/testing subpath entrypoint.
  - New module: packages/ink-compat/src/testing.ts
  - Exposes render() + global cleanup() compatible with ink-testing-library-style workflows.
  - render() returns stdout, stderr, stdin, frames, and lastFrame() plus lifecycle methods.
- Extended main render() contract to expose resolved stream handles.
  - packages/ink-compat/src/render.ts
  - New exported RenderResult type now includes stdout/stderr/stdin.
  - Preserves existing lifecycle methods and non-TTY clear semantics.
- Export surface updates.
  - packages/ink-compat/src/index.ts exports RenderResult.
  - packages/ink-compat/package.json adds ./testing export map.
- Added deterministic Tier-2/3 parity tests.
  - packages/ink-compat/src/__tests__/testing.entrypoint.contract.test.tsx
  - packages/ink-compat/src/__tests__/tier23.parity.test.tsx
  - Updated lifecycle contract tests in packages/ink-compat/src/__tests__/lifecycle.behavior.test.tsx.

## Reviewer Gate (subagents)
- Reviewer A: PASS
- Reviewer B: PASS
- No follow-up fix loop required.

## Validation
- npm -w @rezi-ui/ink-compat run build ✅
- npm -w @rezi-ui/ink-compat run test ✅ (53/53)
- npm run lint ✅
- npm run typecheck ✅
- npm run build ✅
- npm test ✅
- npm run test:e2e ✅
- npm run test:e2e:reduced ✅
- npm run test:native:smoke ✅

Note: test:e2e required building native once in this fresh worktree (npm run build:native) because the e2e terminal fixture depends on @rezi-ui/native binary presence.

## Scope guard
- No internal .md design/audit docs are included in this PR.
- Diff is limited to packages/ink-compat code/tests and package export metadata.
