### PR TITLE
docs: finalize publication-readiness and contract alignment

### DIFF
--- a/README.md
+++ b/README.md
@@ -42,12 +42,10 @@ This design keeps authoring ergonomic in TypeScript while moving hot rendering p
 
 ```tsx
 /** @jsxImportSource @rezi-ui/jsx */
-import { createApp } from "@rezi-ui/core";
-import { createNodeBackend } from "@rezi-ui/node";
+import { createNodeApp } from "@rezi-ui/node";
 import { Column, Row, Text, Button, Divider } from "@rezi-ui/jsx";
 
-const app = createApp<{ count: number }>({
-  backend: createNodeBackend(),
+const app = createNodeApp<{ count: number }>({
   initialState: { count: 0 },
 });
 
@@ -78,11 +76,10 @@ bun add @rezi-ui/jsx @rezi-ui/core @rezi-ui/node
 Direct VNode authoring with no React and no JSX runtime:
 
 ```ts
-import { createApp, ui } from "@rezi-ui/core";
-import { createNodeBackend } from "@rezi-ui/node";
+import { ui } from "@rezi-ui/core";
+import { createNodeApp } from "@rezi-ui/node";
 
-const app = createApp<{ count: number }>({
-  backend: createNodeBackend(),
+const app = createNodeApp<{ count: number }>({
   initialState: { count: 0 },
 });
 

--- a/ROADMAP.md
+++ b/ROADMAP.md
@@ -1,23 +1,23 @@
 # Roadmap
 
-This roadmap is directional and may change; releases are driven by shipped, tested behavior.
+This roadmap is directional only. It is not a commitment to scope, ordering, or dates. Release decisions are based on shipped, tested behavior.
 
-## Near term (alpha)
+## Alpha direction (near term)
 
-- Stabilize remaining edge cases in createApp lifecycle
-- Performance optimization (frame coalescing, allocation reduction)
-- Expand example applications
+- Close remaining `createApp` lifecycle edge cases
+- Continue frame coalescing and allocation reduction work
+- Add targeted example applications
 
-## Medium term (beta)
+## Beta direction (medium term)
 
-- Widget composition API hardening (defineWidget)
-- Additional recipes and patterns documentation
-- CI benchmark regression tracking
-- Plugin/extension system
+- Harden widget composition APIs (`defineWidget`)
+- Expand recipes and patterns documentation
+- Add CI benchmark regression tracking
+- Evaluate plugin/extension architecture
 
-## Longer term (stable)
+## Stable direction (longer term)
 
-- Alternative runtime backends (Bun, Deno) via @rezi-ui/core portability
-- Additional platform features as Zireael evolves
-- Accessibility improvements
-- Community widget ecosystem
+- Explore additional runtime backends (for example Bun, Deno) via `@rezi-ui/core` portability
+- Add platform capabilities as Zireael evolves
+- Improve accessibility coverage
+- Support a community widget ecosystem

--- a/docs/backend/node.md
+++ b/docs/backend/node.md
@@ -2,7 +2,7 @@
 
 The Node backend owns:
 
-- worker-thread engine ownership (native engine is never called on the main thread)
+- native engine execution mode (`auto` | `worker` | `inline`)
 - frame scheduling and buffer pooling
 - transfer of drawlists to the engine and event batches back to core
 
@@ -14,6 +14,7 @@ import { createNodeApp } from "@rezi-ui/node";
 const app = createNodeApp({
   initialState: { count: 0 },
   config: {
+    executionMode: "auto",
     fpsCap: 60,
     maxEventBytes: 1 << 20,
     useV2Cursor: false,
@@ -25,8 +26,15 @@ const app = createNodeApp({
 knobs aligned:
 
 - `useV2Cursor` and drawlist v2 are paired automatically.
-- `maxEventBytes` is applied to both app parsing and backend worker buffers.
+- `maxEventBytes` is applied to both app parsing and backend transport buffers.
 - `fpsCap` is the single scheduling knob.
+- `executionMode: "auto"` resolves to inline when `fpsCap <= 30`, worker otherwise.
+
+Execution mode details:
+
+- `auto` (default): select inline for low-fps workloads (`fpsCap <= 30`), worker otherwise.
+- `worker`: force worker-thread engine execution.
+- `inline`: run the engine inline on the Node main thread.
 
 Legacy path deprecation:
 

--- a/docs/backend/worker-model.md
+++ b/docs/backend/worker-model.md
@@ -1,10 +1,14 @@
 # Worker model
 
-Rezi keeps the native engine on a worker thread.
+Rezi supports three backend execution modes via `config.executionMode`:
+
+- `auto` (default): inline when `fpsCap <= 30`, worker otherwise
+- `worker`: run native engine/polling on a worker thread
+- `inline`: run native engine inline on the Node main thread
 
 High-level goals:
 
-- never block the Node main thread on IO or polling
+- worker offload when needed, inline fast path when appropriate
 - deterministic backpressure when the app cannot keep up
 - avoid unbounded queue growth
 

--- a/docs/getting-started/create-rezi.md
+++ b/docs/getting-started/create-rezi.md
@@ -1,14 +1,12 @@
 # Create Rezi
 
-The fastest way to start a new Rezi app is the scaffolding tool:
+`create-rezi` is the fastest way to scaffold a ready-to-run Rezi app.
 
 ```bash
 npm create rezi my-app
 cd my-app
 npm run start
 ```
-
-This generates a TypeScript project with a multi-panel layout, list, status bar, and keybindings.
 
 If you prefer Bun:
 
@@ -18,9 +16,9 @@ cd my-app
 bun run start
 ```
 
-## Templates
+## Templates (Canonical Overview)
 
-Canonical template names for `--template`:
+If `--template` is omitted, the CLI prompts you to choose (default: `dashboard`).
 
 - `dashboard`: Live ops dashboard with deterministic table updates.
   Highlights: live-updating table with stable row keys, filter/sort/pin controls + incident telemetry.
@@ -31,16 +29,13 @@ Canonical template names for `--template`:
 - `streaming-viewer`: High-volume stream monitor with virtualized index.
   Highlights: virtual list over 15k streams, live ingest feed with follow/pause controls.
 
-Choose a template interactively or pass a canonical name:
+Choose directly with `--template`:
 
 ```bash
 npm create rezi my-app -- --template dashboard
-npm create rezi my-app -- --template form-app
-npm create rezi my-app -- --template file-browser
-npm create rezi my-app -- --template streaming-viewer
 ```
 
-To inspect templates and highlights from the CLI:
+Inspect all templates and highlights from the CLI:
 
 ```bash
 npm create rezi -- --list-templates
@@ -48,13 +43,15 @@ npm create rezi -- --list-templates
 
 ## Options
 
-- `--template <dashboard|form-app|file-browser|streaming-viewer>`: Select a template.
-- `--no-install`: Skip dependency installation.
-- `--pm <npm|pnpm|yarn|bun>`: Choose a package manager.
-- `--list-templates`: Print available templates and highlights.
-- `--help`: Show help.
+- `--template, -t <dashboard|form-app|file-browser|streaming-viewer>`: Select a template.
+- `--no-install, --skip-install`: Skip dependency installation.
+- `--pm, --package-manager <npm|pnpm|yarn|bun>`: Choose a package manager.
+- `--list-templates, --templates`: Print available templates and highlights.
+- `--help, -h`: Show help.
+
+For package-level CLI reference (invocation forms and options), see [packages/create-rezi](../packages/create-rezi.md).
 
 ## Next Steps
 
-- [Quickstart](quickstart.md) for a manual setup walkthrough.
-- [Examples](examples.md) for more layouts and patterns.
+- [Quickstart](quickstart.md) for manual setup.
+- [Examples](examples.md) for runnable repository examples.

--- a/docs/getting-started/examples.md
+++ b/docs/getting-started/examples.md
@@ -1,24 +1,15 @@
 # Examples
 
-Rezi includes example applications that demonstrate various features and patterns.
+This page lists the runnable example apps that currently live in this repository.
 
-## Running Examples
+## Runnable Repository Examples
 
-### From npm (Recommended)
+- `examples/hello-counter`: Minimal state/view/button flow using the node backend.
+- `examples/raw-draw-demo`: Low-level `draw()` rendering example.
 
-Create a new directory and copy example code:
+## Run from Source
 
-```bash
-mkdir my-rezi-app && cd my-rezi-app
-npm init -y
-npm install @rezi-ui/core @rezi-ui/node typescript tsx
-```
-
-Then create your TypeScript file and run with `npx tsx <file>.ts`.
-
-### From Source
-
-Clone the repository and build:
+Clone and build the workspace:
 
 ```bash
 git clone https://github.com/RtlZeroMemory/Rezi.git
@@ -29,318 +20,27 @@ npm run build
 npm run build:native
 ```
 
-Run examples:
+Run the examples:
 
 ```bash
 node examples/hello-counter/dist/index.js
 node examples/raw-draw-demo/dist/index.js
 ```
 
-## Example: Counter
+## Looking for Larger App Examples?
 
-A minimal counter application demonstrating state updates and button interactions.
+Use `create-rezi` templates (`dashboard`, `form-app`, `file-browser`, `streaming-viewer`) for full multi-panel starter apps:
 
-```typescript
-import { ui, rgb } from "@rezi-ui/core";
-import { createNodeApp } from "@rezi-ui/node";
+- [Create Rezi (canonical template overview)](create-rezi.md)
+- [create-rezi package reference](../packages/create-rezi.md)
 
-type State = { count: number };
+## Notes
 
-const app = createNodeApp<State>({
-    initialState: { count: 0 },
-});
-
-app.view((state) =>
-  ui.column({ p: 1, gap: 1 }, [
-    ui.text("Counter Example", { style: { fg: rgb(120, 200, 255), bold: true } }),
-    ui.box({ title: "Controls", p: 1 }, [
-      ui.row({ gap: 2 }, [
-        ui.text(`Count: ${state.count}`),
-        ui.button({
-          id: "inc",
-          label: "+1",
-          onPress: () => app.update((s) => ({ count: s.count + 1 })),
-        }),
-        ui.button({
-          id: "dec",
-          label: "-1",
-          onPress: () => app.update((s) => ({ count: s.count - 1 })),
-        }),
-        ui.button({
-          id: "reset",
-          label: "Reset",
-          onPress: () => app.update({ count: 0 }),
-        }),
-      ]),
-    ]),
-  ])
-);
-
-app.keys({
-  "q": () => app.stop(),
-  "ctrl+c": () => app.stop(),
-});
-
-await app.start();
-```
-
-## Example: Todo List
-
-A todo list with keyboard navigation, adding, and completing items.
-
-```typescript
-import { ui, rgb } from "@rezi-ui/core";
-import { createNodeApp } from "@rezi-ui/node";
-
-type Todo = { id: string; text: string; done: boolean };
-type State = {
-  todos: Todo[];
-  selected: number;
-  input: string;
-};
-
-const app = createNodeApp<State>({
-    initialState: {
-    todos: [
-      { id: "1", text: "Learn Rezi basics", done: false },
-      { id: "2", text: "Build a real app", done: false },
-    ],
-    selected: 0,
-    input: "",
-  },
-});
-
-app.view((state) => {
-  const { todos, selected, input } = state;
-
-  return ui.column({ p: 1, gap: 1 }, [
-    ui.text("Todo List", { style: { fg: rgb(100, 200, 255), bold: true } }),
-
-    ui.box({ title: `Tasks (${todos.filter(t => !t.done).length} pending)`, p: 1 }, [
-      todos.length === 0
-        ? ui.text("No tasks. Add one below.", { style: { dim: true } })
-        : ui.column({ gap: 0 },
-            todos.map((todo, i) => {
-              const isSel = i === selected;
-              const indicator = isSel ? ">" : " ";
-              const checkbox = todo.done ? "[x]" : "[ ]";
-              return ui.text(`${indicator} ${checkbox} ${todo.text}`, {
-                key: todo.id,
-                style: {
-                  bold: isSel,
-                  dim: todo.done,
-                },
-              });
-            })
-          ),
-    ]),
-
-    ui.row({ gap: 1 }, [
-      ui.input({
-        id: "new-todo",
-        value: input,
-        onInput: (v) => app.update((s) => ({ ...s, input: v })),
-      }),
-      ui.button({
-        id: "add",
-        label: "Add",
-        onPress: () => {
-          if (input.trim()) {
-            app.update((s) => ({
-              ...s,
-              todos: [...s.todos, { id: Date.now().toString(), text: input.trim(), done: false }],
-              input: "",
-            }));
-          }
-        },
-      }),
-    ]),
-
-    ui.text("j/k: move | space: toggle | d: delete | q: quit", {
-      style: { fg: rgb(100, 100, 100) },
-    }),
-  ]);
-});
-
-app.keys({
-  j: (ctx) => ctx.update((s) => ({
-    ...s,
-    selected: Math.min(s.selected + 1, s.todos.length - 1),
-  })),
-  k: (ctx) => ctx.update((s) => ({
-    ...s,
-    selected: Math.max(s.selected - 1, 0),
-  })),
-  space: (ctx) => ctx.update((s) => ({
-    ...s,
-    todos: s.todos.map((t, i) => i === s.selected ? { ...t, done: !t.done } : t),
-  })),
-  d: (ctx) => ctx.update((s) => ({
-    ...s,
-    todos: s.todos.filter((_, i) => i !== s.selected),
-    selected: Math.max(0, Math.min(s.selected, s.todos.length - 2)),
-  })),
-  q: () => app.stop(),
-});
-
-await app.start();
-```
-
-## Example: Form with Validation
-
-A login form demonstrating form fields, validation, and submission.
-
-```typescript
-import { ui, rgb } from "@rezi-ui/core";
-import { createNodeApp } from "@rezi-ui/node";
-
-type State = {
-  email: string;
-  password: string;
-  errors: { email?: string; password?: string };
-  submitted: boolean;
-};
-
-const app = createNodeApp<State>({
-    initialState: {
-    email: "",
-    password: "",
-    errors: {},
-    submitted: false,
-  },
-});
-
-function validate(state: State): { email?: string; password?: string } {
-  const errors: { email?: string; password?: string } = {};
-  if (!state.email) {
-    errors.email = "Email is required";
-  } else if (!state.email.includes("@")) {
-    errors.email = "Invalid email format";
-  }
-  if (!state.password) {
-    errors.password = "Password is required";
-  } else if (state.password.length < 8) {
-    errors.password = "Password must be at least 8 characters";
-  }
-  return errors;
-}
-
-app.view((state) => {
-  if (state.submitted) {
-    return ui.column({ p: 2 }, [
-      ui.text("Login Successful!", { style: { fg: rgb(100, 255, 100), bold: true } }),
-      ui.button({
-        id: "back",
-        label: "Back to Form",
-        onPress: () => app.update({ ...state, submitted: false }),
-      }),
-    ]);
-  }
-
-  return ui.column({ p: 1, gap: 1 }, [
-    ui.text("Login Form", { style: { fg: rgb(100, 200, 255), bold: true } }),
-
-    ui.box({ p: 1 }, [
-      ui.column({ gap: 1 }, [
-        ui.field({
-          label: "Email",
-          required: true,
-          error: state.errors.email,
-          children: ui.input({
-            id: "email",
-            value: state.email,
-            onInput: (v) => app.update((s) => ({ ...s, email: v })),
-          }),
-        }),
-
-        ui.field({
-          label: "Password",
-          required: true,
-          error: state.errors.password,
-          children: ui.input({
-            id: "password",
-            value: state.password,
-            onInput: (v) => app.update((s) => ({ ...s, password: v })),
-          }),
-        }),
-
-        ui.row({ gap: 2 }, [
-          ui.button({
-            id: "submit",
-            label: "Login",
-            onPress: () => {
-              const errors = validate(state);
-              if (Object.keys(errors).length === 0) {
-                app.update({ ...state, submitted: true, errors: {} });
-              } else {
-                app.update({ ...state, errors });
-              }
-            },
-          }),
-          ui.button({
-            id: "clear",
-            label: "Clear",
-            onPress: () => app.update({ email: "", password: "", errors: {}, submitted: false }),
-          }),
-        ]),
-      ]),
-    ]),
-  ]);
-});
-
-app.keys({
-  "ctrl+c": () => app.stop(),
-  "q": () => app.stop(),
-});
-
-await app.start();
-```
-
-## Example: Raw Drawing
-
-For advanced use cases, Rezi provides an escape hatch for direct drawing.
-
-```typescript
-import { rgb } from "@rezi-ui/core";
-import { createNodeApp } from "@rezi-ui/node";
-
-const app = createNodeApp({
-    initialState: { tick: 0 },
-});
-
-// Use draw() instead of view() for raw rendering
-app.draw((g) => {
-  // Clear the screen
-  g.clear();
-  g.fillRect(0, 0, 40, 12, { bg: rgb(0, 0, 30) });
-
-  // Draw a box
-  g.fillRect(5, 2, 30, 5, { bg: rgb(40, 40, 60) });
-
-  // Draw text
-  g.drawText(7, 4, "Raw Drawing Demo", { fg: rgb(255, 200, 100), bold: true });
-
-  // Draw more shapes
-  g.fillRect(5, 8, 15, 3, { bg: rgb(100, 50, 50) });
-  g.drawText(6, 9, "Red Box", { fg: rgb(255, 255, 255) });
-
-  g.fillRect(22, 8, 15, 3, { bg: rgb(50, 100, 50) });
-  g.drawText(23, 9, "Green Box", { fg: rgb(255, 255, 255) });
-});
-
-app.keys({
-  q: () => app.stop(),
-});
-
-await app.start();
-```
-
-## More Examples
-
-See the [examples/](https://github.com/RtlZeroMemory/Rezi/tree/main/examples) directory in the repository for additional examples.
+- The runnable examples in `examples/` are the two apps listed above.
+- Other docs may include inline snippets for concepts; those snippets are instructional, not tracked as standalone example packages.
 
 ## Next Steps
 
-- [Widget Catalog](../widgets/index.md) - Browse all available widgets
-- [Styling Guide](../guide/styling.md) - Customize colors and themes
-- [Keybindings](../guide/input-and-focus.md) - Advanced keyboard handling
+- [Quickstart](quickstart.md) - Build your first app
+- [Widget Catalog](../widgets/index.md) - Browse available widgets
+- [Keybindings](../guide/input-and-focus.md) - Advanced input handling

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -16,7 +16,7 @@ If you want a ready-to-run starter, use the scaffolding tool:
 npm create rezi my-app
 ```
 
-Install the core and node backend packages:
+Install the core and Node.js/Bun backend packages:
 
 ```bash
 npm install @rezi-ui/core @rezi-ui/node
@@ -63,7 +63,7 @@ If a prebuilt binary is not available for your platform, the package will attemp
 | Package | Description | Required |
 |---------|-------------|----------|
 | `@rezi-ui/core` | Widgets, layout, themes, forms, keybindings | Yes |
-| `@rezi-ui/node` | Node.js/Bun backend with native rendering | Yes |
+| `@rezi-ui/node` | Node.js/Bun backend (worker/inline modes + native rendering) | Yes |
 | `@rezi-ui/testkit` | Testing utilities and fixtures | Optional |
 
 ## Optional packages
@@ -87,9 +87,9 @@ The core package is runtime-agnostic and contains:
 
 ### @rezi-ui/node
 
-The Node.js backend provides:
+The Node.js/Bun backend provides:
 
-- Worker thread runtime for async rendering
+- Runtime execution modes (`worker`, `inline`, `auto`)
 - Native addon binding to the Zireael C engine
 - Terminal capability detection
 - Event loop integration

--- a/docs/guide/lifecycle-and-updates.md
+++ b/docs/guide/lifecycle-and-updates.md
@@ -122,7 +122,8 @@ Rezi coalesces work:
 
 - multiple updates in a single turn produce one commit
 - rendering occurs after the commit
-- at most one frame is submitted in-flight at a time
+- in-flight submissions are bounded by `config.maxFramesInFlight` (default `1`, clamped to `1..4`)
+- interactive input (`key`/`text`/`paste`/`mouse`) gets a short urgent burst that allows one additional in-flight frame
 
 This keeps runtime behavior bounded and prevents unbounded “render storms”.
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -1,6 +1,6 @@
 # Rezi
 
-Rezi is a **code-first terminal UI framework** for Node.js and Bun. Build rich, interactive terminal applications with a declarative widget API, automatic focus management, and native rendering performance.
+Rezi is a **code-first terminal UI framework** for Node.js and Bun. Build interactive terminal applications with a declarative widget API, automatic focus management, and native-backed rendering.
 
 ```typescript
 import { ui, rgb } from "@rezi-ui/core";
@@ -68,7 +68,7 @@ flowchart TB
         Core
     end
 
-    subgraph Node.js Runtime
+    subgraph Node.js/Bun Runtime
         Node
         Native
     end
@@ -77,7 +77,7 @@ flowchart TB
 | Layer | Purpose |
 |-------|---------|
 | **@rezi-ui/core** | Widgets, layout, themes, forms, keybindings. No Node.js APIs. |
-| **@rezi-ui/node** | Node.js backend with worker thread integration. |
+| **@rezi-ui/node** | Node.js/Bun backend with worker and inline execution modes. |
 | **@rezi-ui/native** | napi-rs binding to the Zireael C rendering engine. |
 | **@rezi-ui/jsx** | Optional JSX runtime for widget trees. |
 
@@ -97,7 +97,7 @@ flowchart TB
 
     ---
 
-    Build your first Rezi application in minutes.
+    Build a minimal Rezi application.
 
     [:octicons-arrow-right-24: Quickstart](getting-started/quickstart.md)
 

--- a/docs/packages/create-rezi.md
+++ b/docs/packages/create-rezi.md
@@ -1,53 +1,51 @@
 # create-rezi
 
-Scaffold a new Rezi terminal UI app in seconds.
+`create-rezi` is the CLI package that scaffolds new Rezi apps.
 
-## Quickstart
+## Usage
 
 ```bash
 npm create rezi my-app
-cd my-app
-npm run start
-
-# or bun
-# npm create rezi my-app -- --pm bun
-# cd my-app
-# bun run start
 ```
+
+Equivalent direct invocation:
+
+```bash
+npx create-rezi my-app
+```
+
+The CLI prompts for any missing values (project name/template) when run interactively.
 
 ## Templates
 
-- `dashboard`: Live ops dashboard with deterministic table updates.
-  Highlights: live-updating table with stable row keys, filter/sort/pin controls + incident telemetry.
-- `form-app`: Multi-step form with validation and command modes.
-  Highlights: insert/command key modes with chords, modal help and toast notifications.
-- `file-browser`: Explorer with async command palette search.
-  Highlights: async palette results with cancellation, table browser with details and preview.
-- `streaming-viewer`: High-volume stream monitor with virtualized index.
-  Highlights: virtual list over 15k streams, live ingest feed with follow/pause controls.
+Canonical template names:
 
-Choose a template interactively or pass a canonical template name:
+- `dashboard`
+- `form-app`
+- `file-browser`
+- `streaming-viewer`
+
+Use a specific template:
 
 ```bash
 npm create rezi my-app -- --template dashboard
-npm create rezi my-app -- --template form-app
-npm create rezi my-app -- --template file-browser
-npm create rezi my-app -- --template streaming-viewer
 ```
 
-List templates and highlights from the CLI:
+List templates and highlights:
 
 ```bash
 npm create rezi -- --list-templates
 ```
 
+For template descriptions and highlights, use the canonical guide: [Getting Started → Create Rezi](../getting-started/create-rezi.md).
+
 ## Options
 
-- `--template <dashboard|form-app|file-browser|streaming-viewer>`: Select a template.
-- `--no-install`: Skip dependency installation.
-- `--pm <npm|pnpm|yarn|bun>`: Choose a package manager.
-- `--list-templates`: Print available templates and highlights.
-- `--help`: Show help.
+- `--template, -t <dashboard|form-app|file-browser|streaming-viewer>`: Select a template.
+- `--no-install, --skip-install`: Skip dependency installation.
+- `--pm, --package-manager <npm|pnpm|yarn|bun>`: Choose a package manager.
+- `--list-templates, --templates`: Print available templates and highlights.
+- `--help, -h`: Show help.
 
 ## Template Smoke Check
 

--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -1,6 +1,6 @@
 # Packages
 
-Rezi is organized as a monorepo with multiple packages, each with distinct responsibilities.
+Rezi is organized as a monorepo with focused packages and clear runtime boundaries.
 
 ## Installation
 
@@ -24,7 +24,7 @@ flowchart TB
 | Package | Description | npm |
 |---------|-------------|-----|
 | [@rezi-ui/core](core.md) | Widgets, layout, themes, forms, keybindings | `npm i @rezi-ui/core` |
-| [@rezi-ui/node](node.md) | Node.js/Bun backend with worker threads | `npm i @rezi-ui/node` |
+| [@rezi-ui/node](node.md) | Node.js/Bun backend with worker/inline execution modes | `npm i @rezi-ui/node` |
 | [@rezi-ui/native](native.md) | Native addon (napi-rs + Zireael) | Bundled with node |
 | [@rezi-ui/jsx](jsx.md) | JSX runtime for Rezi widgets | `npm i @rezi-ui/jsx` |
 | [@rezi-ui/testkit](testkit.md) | Testing utilities and fixtures | `npm i -D @rezi-ui/testkit` |
@@ -34,7 +34,7 @@ flowchart TB
 
 **Runtime-agnostic TypeScript core**
 
-The core package is the heart of Rezi. It contains:
+The core package defines Rezi's runtime-agnostic API and contains:
 
 - All widget constructors (`ui.text`, `ui.button`, `ui.table`, etc.)
 - Layout engine with flexbox-like semantics
@@ -44,7 +44,7 @@ The core package is the heart of Rezi. It contains:
 - Focus management utilities
 - Binary protocol builders and parsers
 
-Critically, this package has **no Node.js-specific dependencies**. It can theoretically run in any JavaScript runtime.
+This package has **no Node.js-specific dependencies**. Runtime adapters can reuse it by implementing the backend contract.
 
 ```typescript
 import { ui, rgb, darkTheme } from "@rezi-ui/core";
@@ -56,9 +56,10 @@ import { ui, rgb, darkTheme } from "@rezi-ui/core";
 
 **Node.js/Bun runtime backend**
 
-The `@rezi-ui/node` backend provides the runtime integration:
+The `@rezi-ui/node` backend provides runtime integration:
 
-- Worker thread management for async rendering
+- Execution modes: `worker`, `inline`, and `auto`
+- Worker-mode transport and scheduling
 - Event loop integration
 - Terminal capability detection
 - Debug tracing and performance instrumentation
@@ -141,7 +142,7 @@ Application Code (ui.* API or JSX)
        │
        │ used by
        ▼
-@rezi-ui/node (Worker threads, event loop)
+@rezi-ui/node (worker/inline execution, event loop)
        │
        │ binds to
        ▼

--- a/docs/packages/node.md
+++ b/docs/packages/node.md
@@ -2,7 +2,7 @@
 
 Node/Bun backend package:
 
-- worker-thread engine ownership
+- configurable engine execution mode (`auto` | `worker` | `inline`)
 - transfer of drawlists/events between core and native
 - buffer pooling and scheduling
 
@@ -17,9 +17,17 @@ bun add @rezi-ui/node
 ## What you get
 
 - A backend implementation that satisfies the `@rezi-ui/core` runtime backend interface
-- A worker-thread model where the engine runs off the main thread
-- A stable message protocol between main thread and worker
+- Worker and inline execution paths for the native engine
+- A stable message protocol for worker mode
 - Integration with `@rezi-ui/native` (prebuilt binaries when available)
+
+## Execution mode
+
+Set `config.executionMode` on `createNodeApp(...)`:
+
+- `auto` (default): inline when `fpsCap <= 30`, worker otherwise
+- `worker`: always run the engine on a worker thread
+- `inline`: run the engine inline on the Node main thread
 
 ## Creating an app (recommended)
 
@@ -29,6 +37,7 @@ import { createNodeApp } from "@rezi-ui/node";
 const app = createNodeApp({
   initialState: { count: 0 },
   config: {
+    executionMode: "auto",
     fpsCap: 60,
     maxEventBytes: 1 << 20,
     useV2Cursor: false,

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -112,8 +112,10 @@ nav:
       - Styling: guide/styling.md
       - Performance: guide/performance.md
       - Debugging: guide/debugging.md
+      - Record & Replay: guide/record-replay.md
   - Widgets:
       - Overview: widgets/index.md
+      - Stability Tiers: widgets/stability.md
       - Primitives:
           - Text: widgets/text.md
           - Box: widgets/box.md
@@ -133,6 +135,7 @@ nav:
       - Inputs:
           - Button: widgets/button.md
           - Input: widgets/input.md
+          - Slider: widgets/slider.md
           - Checkbox: widgets/checkbox.md
           - Radio Group: widgets/radio-group.md
           - Select: widgets/select.md
@@ -193,6 +196,7 @@ nav:
           - Terminal Caps: backend/terminal-caps.md
       - Protocol:
           - Overview: protocol/index.md
+          - Terminal I/O Contract: terminal-io-contract.md
           - Event Batches (ZREV): protocol/zrev.md
           - Drawlists (ZRDL): protocol/zrdl.md
           - Cursor (v2): protocol/cursor-v2.md
@@ -208,12 +212,14 @@ nav:
           - "@rezi-ui/native": packages/native.md
           - "@rezi-ui/jsx": packages/jsx.md
           - "@rezi-ui/testkit": packages/testkit.md
-          - create-rezi: packages/create-rezi.md
+          - create-rezi CLI: packages/create-rezi.md
   - Developer:
       - Contributing: dev/contributing.md
       - Repo Layout: dev/repo-layout.md
       - Build: dev/build.md
       - Testing: dev/testing.md
+      - Perf Regressions: dev/perf-regressions.md
+      - Repro Replay: dev/repro-replay.md
       - Releasing: dev/releasing.md
       - Docs: dev/docs.md
       - Style Guide: dev/style-guide.md

--- a/packages/create-rezi/README.md
+++ b/packages/create-rezi/README.md
@@ -17,7 +17,12 @@ npm run start
 
 ## Templates
 
-Choose a template interactively, or pass `--template` with a canonical name.
+Choose a template interactively, or pass `--template` with a canonical name:
+
+- `dashboard`
+- `form-app`
+- `file-browser`
+- `streaming-viewer`
 
 ```bash
 npm create rezi my-app -- --template dashboard
@@ -34,8 +39,11 @@ npm create rezi -- --list-templates
 
 ## Options
 
-- `--template <dashboard|form-app|file-browser|streaming-viewer>`: Choose a template.
-- `--no-install`: Skip dependency installation.
-- `--pm <npm|pnpm|yarn|bun>`: Choose a package manager.
-- `--list-templates`: Print available templates and highlights.
-- `--help`: Show help.
+- `--template, -t <dashboard|form-app|file-browser|streaming-viewer>`: Select a template.
+- `--no-install, --skip-install`: Skip dependency installation.
+- `--pm, --package-manager <npm|pnpm|yarn|bun>`: Choose a package manager.
+- `--list-templates, --templates`: Print available templates and highlights.
+- `--help, -h`: Show help.
+
+For template descriptions and highlights, see:
+https://rtlzeromemory.github.io/Rezi/getting-started/create-rezi/

--- a/packages/native/README.md
+++ b/packages/native/README.md
@@ -20,10 +20,11 @@ npm -w @rezi-ui/native run test:native:smoke
 
 ## Design and constraints
 
-- Engine ownership lives on a worker thread (never the Node main thread).
+- Engine placement is controlled by `@rezi-ui/node` `executionMode` (`auto` | `worker` | `inline`).
+- `executionMode: "auto"` selects inline when `fpsCap <= 30`, worker otherwise.
 - All buffers across the boundary are caller-owned; binary formats are validated strictly.
 
 See:
 
 - [Native addon docs](../../docs/backend/native.md)
-- [Releasing](RELEASING.md)
+- [Releasing](../../RELEASING.md)

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -2,7 +2,7 @@
 
 Node.js/Bun backend for Rezi. This package owns:
 
-- worker-thread engine ownership (native engine is never called on the main thread)
+- configurable native engine execution mode (`auto` | `worker` | `inline`)
 - frame scheduling and buffer pooling
 - transfer of drawlists/events between core and the native addon
 
@@ -14,7 +14,8 @@ import { createNodeApp } from "@rezi-ui/node";
 
 Use `createNodeApp({ initialState, config })` as the default path. It wires
 `@rezi-ui/core` and `@rezi-ui/node` with matched cursor protocol, event caps,
-and fps settings.
+and fps settings. `executionMode` defaults to `auto` (`fpsCap <= 30` -> inline,
+otherwise worker); set `executionMode: "worker"` or `"inline"` to force a mode.
 
 Legacy `createNodeBackend() + createApp()` wiring is deprecated for standard
 app construction.


### PR DESCRIPTION
## Summary
- update root/site/package docs to use `createNodeApp` as the recommended app-construction path
- document Node backend execution modes (`auto`, `worker`, `inline`) and the `auto` heuristic (`fpsCap <= 30` -> inline)
- correct lifecycle scheduling docs for bounded in-flight frames (`maxFramesInFlight`) and interactive burst behavior
- de-duplicate `create-rezi` docs: keep getting-started as canonical template overview and keep package page as CLI reference
- align `create-rezi` option docs with implemented flags/aliases
- rewrite examples page to reflect current runnable repository examples
- include previously unlisted docs pages in `mkdocs.yml` nav and clarify `create-rezi CLI` label
- fix broken release-doc link in `packages/native/README.md`

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run docs:build`
- `npm run check:docs`
- `npm test`
