### PR TITLE
fix(unicode): stabilize emoji width across terminal presentations

### DIFF
--- a/packages/core/src/layout/__tests__/textMeasure.golden.test.ts
+++ b/packages/core/src/layout/__tests__/textMeasure.golden.test.ts
@@ -20,7 +20,7 @@ function assertFixture(f: TextMeasureFixture, rel: string): void {
 
 describe("measureTextCells (pinned) - golden fixtures", () => {
   test("ZRUI_TEXT_MEASURE_VERSION is pinned", () => {
-    assert.equal(ZRUI_TEXT_MEASURE_VERSION, 1);
+    assert.equal(ZRUI_TEXT_MEASURE_VERSION, 2);
   });
 
   test("graphemes.json", async () => {

--- a/packages/core/src/layout/textMeasure.ts
+++ b/packages/core/src/layout/textMeasure.ts
@@ -9,7 +9,7 @@
  *   - Unicode version: 15.1.0
  *   - Grapheme segmentation: UAX #29 (core rules)
  *   - East Asian Width: based on EAW property
- *   - Emoji width: wide (2 cells) for Extended_Pictographic sequences
+ *   - Emoji width: policy-controlled for emoji-presented graphemes
  *
  * Width rules:
  *   - ASCII printable: 1 cell
@@ -22,10 +22,16 @@
  * @see docs/guide/layout.md
  */
 
-import { GCB, gcbClass, isEawWide, isEmoji, isExtendedPictographic } from "./unicode/props.js";
+import {
+  GCB,
+  gcbClass,
+  isEawWide,
+  isEmojiPresentation,
+  isExtendedPictographic,
+} from "./unicode/props.js";
 
 /** Version pin for text measurement algorithm. Increment on any change. */
-export const ZRUI_TEXT_MEASURE_VERSION = 1 as const;
+export const ZRUI_TEXT_MEASURE_VERSION = 2 as const;
 
 /**
  * Emoji width policy used by text measurement.
@@ -127,6 +133,31 @@ function decodeUtf16One(text: string, off: number): DecodeOne {
 
 function isAsciiControl(scalar: number): boolean {
   return scalar < 0x20 || scalar === 0x7f;
+}
+
+const VARIATION_SELECTOR_15 = 0xfe0e;
+const VARIATION_SELECTOR_16 = 0xfe0f;
+const COMBINING_ENCLOSING_KEYCAP = 0x20e3;
+
+type KeycapState = "start" | "after-base" | "after-base-vs16" | "matched" | "invalid";
+
+function isKeycapBase(scalar: number): boolean {
+  if (scalar === 0x23 || scalar === 0x2a) return true;
+  return scalar >= 0x30 && scalar <= 0x39;
+}
+
+function keycapNext(state: KeycapState, scalar: number): KeycapState {
+  if (state === "start") return isKeycapBase(scalar) ? "after-base" : "invalid";
+  if (state === "after-base") {
+    if (scalar === VARIATION_SELECTOR_16) return "after-base-vs16";
+    if (scalar === COMBINING_ENCLOSING_KEYCAP) return "matched";
+    return "invalid";
+  }
+  if (state === "after-base-vs16") {
+    if (scalar === COMBINING_ENCLOSING_KEYCAP) return "matched";
+    return "invalid";
+  }
+  return "invalid";
 }
 
 /**
@@ -276,14 +307,21 @@ function scanGraphemeClusters(text: string, onCluster?: GraphemeVisitor): number
     let lastNonExtendIsEp = prevClass !== GCB.EXTEND ? prevIsEp : false;
     let prevZwjAfterEp = prevClass === GCB.ZWJ ? lastNonExtendIsEp : false;
 
-    // Grapheme width tracking (engine policy: max codepoint width, then apply emoji override)
-    let width = 0 as 0 | 1 | 2;
-    let hasEmoji = false;
+    // Grapheme width tracking mirrors native engine behavior.
+    let widthText = 0 as 0 | 1 | 2;
+    let widthEmojiNormalized = 0 as 0 | 1 | 2;
+    let hasEmojiPresentation = isEmojiPresentation(prevDec.scalar);
+    let hasExtendedPictographic = prevIsEp;
+    let hasZwj = prevClass === GCB.ZWJ;
+    let hasVs15 = prevDec.scalar === VARIATION_SELECTOR_15;
+    let hasVs16 = prevDec.scalar === VARIATION_SELECTOR_16;
+    let keycapState: KeycapState = keycapNext("start", prevDec.scalar);
 
-    const firstIsEmoji = isEmoji(prevDec.scalar);
-    if (firstIsEmoji) hasEmoji = true;
-    const firstW = firstIsEmoji ? 1 : widthCodepoint(prevDec.scalar);
-    if (firstW > width) width = firstW;
+    const firstWText = widthCodepoint(prevDec.scalar);
+    if (firstWText > widthText) widthText = firstWText;
+    const firstEmojiCapable = hasEmojiPresentation || hasExtendedPictographic;
+    const firstWEmoji = firstEmojiCapable ? 1 : firstWText;
+    if (firstWEmoji > widthEmojiNormalized) widthEmojiNormalized = firstWEmoji;
 
     while (off < text.length) {
       const nextOff = off;
@@ -306,14 +344,35 @@ function scanGraphemeClusters(text: string, onCluster?: GraphemeVisitor): number
 
       prevClass = nextClass;
 
-      const nextIsEmoji = isEmoji(nextDec.scalar);
-      if (nextIsEmoji) hasEmoji = true;
-      const nextW = nextIsEmoji ? 1 : widthCodepoint(nextDec.scalar);
-      if (nextW > width) width = nextW;
+      const nextIsEmojiPresentation = isEmojiPresentation(nextDec.scalar);
+      if (nextIsEmojiPresentation) hasEmojiPresentation = true;
+      if (nextIsEp) hasExtendedPictographic = true;
+      if (nextClass === GCB.ZWJ) hasZwj = true;
+      if (nextDec.scalar === VARIATION_SELECTOR_15) hasVs15 = true;
+      if (nextDec.scalar === VARIATION_SELECTOR_16) hasVs16 = true;
+      keycapState = keycapNext(keycapState, nextDec.scalar);
+
+      const nextWText = widthCodepoint(nextDec.scalar);
+      if (nextWText > widthText) widthText = nextWText;
+      const nextEmojiCapable = nextIsEmojiPresentation || nextIsEp;
+      const nextWEmoji = nextEmojiCapable ? 1 : nextWText;
+      if (nextWEmoji > widthEmojiNormalized) widthEmojiNormalized = nextWEmoji;
     }
 
+    const keycapEmoji = keycapState === "matched";
+    let hasEmoji = false;
+    if (keycapEmoji) hasEmoji = true;
+    else if (hasEmojiPresentation) hasEmoji = true;
+    else if (hasExtendedPictographic && (hasVs16 || hasZwj)) hasEmoji = true;
+
+    // FE0E (text presentation) suppresses emoji coercion for text-default pictographs.
+    if (hasVs15 && !hasVs16 && !hasEmojiPresentation && !keycapEmoji) {
+      hasEmoji = false;
+    }
+
+    let width = hasEmoji ? widthEmojiNormalized : widthText;
     const emojiMinWidth: 1 | 2 = textMeasureEmojiPolicy === "wide" ? 2 : 1;
-    if (hasEmoji && width < emojiMinWidth) width = emojiMinWidth;
+    if (hasEmoji && width < emojiMinWidth) width = emojiMinWidth as 1 | 2;
     total += width;
     onCluster?.(start, off, width);
 

--- a/packages/node/src/backend/emojiWidthPolicy.ts
+++ b/packages/node/src/backend/emojiWidthPolicy.ts
@@ -6,7 +6,7 @@ export type ResolvedEmojiWidthPolicy = "wide" | "narrow";
 const NATIVE_WIDTH_POLICY_NARROW = 0 as const;
 const NATIVE_WIDTH_POLICY_WIDE = 1 as const;
 const PROBE_TIMEOUT_MS_DEFAULT = 80;
-const PROBE_GLYPHS = Object.freeze(["👁", "😀", "🧪"]);
+const PROBE_GLYPHS = Object.freeze(["😀", "🚀", "🧪"]);
 const ENV_EMOJI_WIDTH_POLICY = "ZRUI_EMOJI_WIDTH_POLICY" as const;
 const ENV_EMOJI_WIDTH_PROBE = "ZRUI_EMOJI_WIDTH_PROBE" as const;
 

--- a/packages/testkit/fixtures/text-measure/graphemes.json
+++ b/packages/testkit/fixtures/text-measure/graphemes.json
@@ -13,6 +13,19 @@
       "width": 2
     },
     { "name": "regional_indicator_pair_flag", "text": "\ud83c\uddfa\ud83c\uddf8", "width": 2 },
-    { "name": "cjk_wide", "text": "\u754c", "width": 2 }
+    { "name": "cjk_wide", "text": "\u754c", "width": 2 },
+    { "name": "text_default_eye", "text": "\ud83d\udc41", "width": 1 },
+    { "name": "emoji_eye_vs16", "text": "\ud83d\udc41\ufe0f", "width": 2 },
+    { "name": "text_default_satellite", "text": "\ud83d\udef0", "width": 1 },
+    { "name": "emoji_satellite_vs16", "text": "\ud83d\udef0\ufe0f", "width": 2 },
+    { "name": "text_default_airplane", "text": "\u2708", "width": 1 },
+    { "name": "emoji_airplane_vs16", "text": "\u2708\ufe0f", "width": 2 },
+    { "name": "text_airplane_vs15", "text": "\u2708\ufe0e", "width": 1 },
+    { "name": "text_default_heart", "text": "\u2764", "width": 1 },
+    { "name": "emoji_heart_vs16", "text": "\u2764\ufe0f", "width": 2 },
+    { "name": "keycap_digit", "text": "1\ufe0f\u20e3", "width": 2 },
+    { "name": "keycap_hash", "text": "#\ufe0f\u20e3", "width": 2 },
+    { "name": "keycap_asterisk", "text": "*\ufe0f\u20e3", "width": 2 },
+    { "name": "emoji_zwj_rainbow_flag", "text": "\ud83c\udff3\ufe0f\u200d\ud83c\udf08", "width": 2 }
   ]
 }

--- a/packages/testkit/fixtures/text-measure/strings.json
+++ b/packages/testkit/fixtures/text-measure/strings.json
@@ -10,6 +10,13 @@
     { "name": "emoji_in_string", "text": "A\ud83d\ude00B", "width": 4 },
     { "name": "combining_clusters", "text": "a\u0301b", "width": 2 },
     { "name": "leading_combining_mark", "text": "\u0301a", "width": 1 },
-    { "name": "two_flags", "text": "\ud83c\uddfa\ud83c\uddf8\ud83c\udde8\ud83c\udde6", "width": 4 }
+    { "name": "two_flags", "text": "\ud83c\uddfa\ud83c\uddf8\ud83c\udde8\ud83c\udde6", "width": 4 },
+    { "name": "text_default_eye_in_string", "text": "A\ud83d\udc41B", "width": 3 },
+    { "name": "emoji_eye_vs16_in_string", "text": "A\ud83d\udc41\ufe0fB", "width": 4 },
+    { "name": "text_default_satellite_in_string", "text": "A\ud83d\udef0B", "width": 3 },
+    { "name": "emoji_satellite_vs16_in_string", "text": "A\ud83d\udef0\ufe0fB", "width": 4 },
+    { "name": "keycap_in_string", "text": "A1\ufe0f\u20e3B", "width": 4 },
+    { "name": "text_heart_in_string", "text": "A\u2764B", "width": 3 },
+    { "name": "emoji_heart_in_string", "text": "A\u2764\ufe0fB", "width": 4 }
   ]
 }


### PR DESCRIPTION
## Summary
- align core text measurement with presentation-aware emoji width rules
  - text-default pictographs stay text-width unless emoji presentation is explicit (VS16/ZWJ/emoji-presentation/keycap)
- mirror the same logic in vendored native engine width code
- harden emoji-width auto-probe glyph set to avoid ambiguous text-default glyphs
- add regression fixtures/tests for:
  - `👁` vs `👁️`
  - `🛰` vs `🛰️`
  - `✈`/`❤` text vs emoji presentation
  - keycaps (`1️⃣`, `#️⃣`, `*️⃣`)

## Linked upstream
- Zireael PR: https://github.com/RtlZeroMemory/Zireael/pull/73

## Files
- `packages/core/src/layout/textMeasure.ts`
- `packages/core/src/layout/__tests__/textMeasure.golden.test.ts`
- `packages/core/src/layout/__tests__/sweep.robustness.test.ts`
- `packages/testkit/fixtures/text-measure/graphemes.json`
- `packages/testkit/fixtures/text-measure/strings.json`
- `packages/node/src/backend/emojiWidthPolicy.ts`
- `packages/native/vendor/zireael/src/unicode/zr_width.c`

## Validation
```bash
npm run build
node --test \
  packages/core/dist/layout/__tests__/textMeasure.golden.test.js \
  packages/core/dist/layout/__tests__/sweep.robustness.test.js \
  packages/core/dist/app/__tests__/partialDrawlistEmission.test.js \
  packages/core/dist/app/__tests__/interactivePriority.test.js \
  packages/node/dist/__tests__/emoji_width_policy.test.js \
  packages/node/dist/__tests__/worker_integration.test.js
npm run check:unicode
```
