### PR TITLE
chore: clean npm publish contents

### DIFF
--- a/packages/core/.npmignore
+++ b/packages/core/.npmignore
@@ -1,0 +1,5 @@
+# Exclude compiled test artifacts from published tarballs.
+dist/**/__tests__/
+dist/**/__tests__/**
+dist/**/__e2e__/
+dist/**/__e2e__/**

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -88,7 +88,7 @@
       "default": "./dist/widgets/index.js"
     }
   },
-  "files": ["dist/", "README.md"],
+  "files": ["dist/", "README.md", "!dist/**/__tests__/**", "!dist/**/__e2e__/**"],
   "engines": {
     "node": ">=18",
     "bun": ">=1.3.0"

--- a/packages/create-rezi/.npmignore
+++ b/packages/create-rezi/.npmignore
@@ -1,0 +1,5 @@
+# Exclude compiled test artifacts from published tarballs.
+dist/**/__tests__/
+dist/**/__tests__/**
+dist/**/__e2e__/
+dist/**/__e2e__/**

--- a/packages/create-rezi/package.json
+++ b/packages/create-rezi/package.json
@@ -16,7 +16,7 @@
   "bin": {
     "create-rezi": "dist/index.js"
   },
-  "files": ["dist/", "templates/", "README.md"],
+  "files": ["dist/", "templates/", "README.md", "!dist/**/__tests__/**", "!dist/**/__e2e__/**"],
   "engines": {
     "node": ">=18",
     "bun": ">=1.3.0"

--- a/packages/jsx/.npmignore
+++ b/packages/jsx/.npmignore
@@ -1,0 +1,5 @@
+# Exclude compiled test artifacts from published tarballs.
+dist/**/__tests__/
+dist/**/__tests__/**
+dist/**/__e2e__/
+dist/**/__e2e__/**

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -28,7 +28,7 @@
       "default": "./dist/jsx-dev-runtime.js"
     }
   },
-  "files": ["dist/", "README.md"],
+  "files": ["dist/", "README.md", "!dist/**/__tests__/**", "!dist/**/__e2e__/**"],
   "engines": {
     "node": ">=18",
     "bun": ">=1.3.0"

--- a/packages/node/.npmignore
+++ b/packages/node/.npmignore
@@ -1,0 +1,5 @@
+# Exclude compiled test artifacts from published tarballs.
+dist/**/__tests__/
+dist/**/__tests__/**
+dist/**/__e2e__/
+dist/**/__e2e__/**

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -20,7 +20,7 @@
       "default": "./dist/index.js"
     }
   },
-  "files": ["dist/", "README.md"],
+  "files": ["dist/", "README.md", "!dist/**/__tests__/**", "!dist/**/__e2e__/**"],
   "engines": {
     "node": ">=18",
     "bun": ">=1.3.0"

--- a/packages/testkit/.npmignore
+++ b/packages/testkit/.npmignore
@@ -1,0 +1,5 @@
+# Exclude compiled test artifacts from published tarballs.
+dist/**/__tests__/
+dist/**/__tests__/**
+dist/**/__e2e__/
+dist/**/__e2e__/**

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -20,7 +20,7 @@
       "default": "./dist/index.js"
     }
   },
-  "files": ["dist/", "fixtures/", "README.md"],
+  "files": ["dist/", "fixtures/", "README.md", "!dist/**/__tests__/**", "!dist/**/__e2e__/**"],
   "engines": {
     "node": ">=18"
   }


### PR DESCRIPTION
## Summary
- add `.npmignore` to published workspace packages (`core`, `node`, `jsx`, `testkit`, `create-rezi`)
- exclude compiled `dist/**/__tests__/**` and `dist/**/__e2e__/**` from npm tarballs
- keep existing package file whitelists while adding explicit negated `files` patterns so publish output is actually trimmed

## Validation
- `npm run lint`
- `npm run build`
- `npm pack --dry-run --json -w @rezi-ui/core` (bad test/e2e paths: 0)
- `npm pack --dry-run --json -w @rezi-ui/node` (bad test/e2e paths: 0)
- `npm pack --dry-run --json -w @rezi-ui/jsx` (bad test/e2e paths: 0)
- `npm pack --dry-run --json -w @rezi-ui/testkit` (bad test/e2e paths: 0)
- `npm pack --dry-run --json -w create-rezi` (bad test/e2e paths: 0)
