### PR TITLE
fix(native): support Bun --compile binary loading

### DIFF
--- a/packages/native/index.js
+++ b/packages/native/index.js
@@ -1,33 +1,4 @@
-import { readdirSync } from "node:fs";
-import { createRequire } from "node:module";
-import { dirname, join } from "node:path";
-import { fileURLToPath } from "node:url";
-
-const require = createRequire(import.meta.url);
-const rootDir = dirname(fileURLToPath(import.meta.url));
-
-const discoveredNodeFiles = readdirSync(rootDir).filter((f) => f.endsWith(".node"));
-
-const candidates = ["index.node", "rezi_ui_native.node", ...discoveredNodeFiles];
-
-let native = null;
-let lastErr = null;
-for (const file of new Set(candidates)) {
-  try {
-    native = require(join(rootDir, file));
-    break;
-  } catch (err) {
-    lastErr = err;
-  }
-}
-
-if (!native) {
-  const extra =
-    lastErr instanceof Error ? `\n\nLast error:\n${lastErr.stack ?? lastErr.message}` : "";
-  throw new Error(
-    `Failed to load @rezi-ui/native binary. Tried: ${[...new Set(candidates)].join(", ")}${extra}`,
-  );
-}
+import native from "./loader.cjs";
 
 export const {
   engineCreate,

--- a/packages/native/loader.cjs
+++ b/packages/native/loader.cjs
@@ -1,0 +1,134 @@
+const { readdirSync } = require("node:fs");
+
+let native = null;
+let lastErr = null;
+const tried = [];
+
+function tryDynamicRequire(file) {
+  tried.push(file);
+  try {
+    return require(`./${file}`);
+  } catch (err) {
+    lastErr = err;
+    return null;
+  }
+}
+
+if (process.platform === "linux" && process.arch === "x64") {
+  tried.push("rezi_ui_native.linux-x64-gnu.node");
+  try {
+    native = require("./rezi_ui_native.linux-x64-gnu.node");
+  } catch (err) {
+    lastErr = err;
+  }
+
+  if (!native) {
+    tried.push("rezi_ui_native.linux-x64-musl.node");
+    try {
+      native = require("./rezi_ui_native.linux-x64-musl.node");
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+
+  if (!native) {
+    tried.push("rezi_ui_native.linux-x64.node");
+    try {
+      native = require("./rezi_ui_native.linux-x64.node");
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+} else if (process.platform === "linux" && process.arch === "arm64") {
+  tried.push("rezi_ui_native.linux-arm64-gnu.node");
+  try {
+    native = require("./rezi_ui_native.linux-arm64-gnu.node");
+  } catch (err) {
+    lastErr = err;
+  }
+
+  if (!native) {
+    tried.push("rezi_ui_native.linux-arm64-musl.node");
+    try {
+      native = require("./rezi_ui_native.linux-arm64-musl.node");
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+
+  if (!native) {
+    tried.push("rezi_ui_native.linux-arm64.node");
+    try {
+      native = require("./rezi_ui_native.linux-arm64.node");
+    } catch (err) {
+      lastErr = err;
+    }
+  }
+} else if (process.platform === "darwin" && process.arch === "x64") {
+  tried.push("rezi_ui_native.darwin-x64.node");
+  try {
+    native = require("./rezi_ui_native.darwin-x64.node");
+  } catch (err) {
+    lastErr = err;
+  }
+} else if (process.platform === "darwin" && process.arch === "arm64") {
+  tried.push("rezi_ui_native.darwin-arm64.node");
+  try {
+    native = require("./rezi_ui_native.darwin-arm64.node");
+  } catch (err) {
+    lastErr = err;
+  }
+} else if (process.platform === "win32" && process.arch === "x64") {
+  tried.push("rezi_ui_native.win32-x64-msvc.node");
+  try {
+    native = require("./rezi_ui_native.win32-x64-msvc.node");
+  } catch (err) {
+    lastErr = err;
+  }
+} else if (process.platform === "win32" && process.arch === "arm64") {
+  tried.push("rezi_ui_native.win32-arm64-msvc.node");
+  try {
+    native = require("./rezi_ui_native.win32-arm64-msvc.node");
+  } catch (err) {
+    lastErr = err;
+  }
+}
+
+if (!native) {
+  const platformCandidates = [
+    "rezi_ui_native.linux-x64-gnu.node",
+    "rezi_ui_native.linux-x64-musl.node",
+    "rezi_ui_native.linux-x64.node",
+    "rezi_ui_native.linux-arm64-gnu.node",
+    "rezi_ui_native.linux-arm64-musl.node",
+    "rezi_ui_native.linux-arm64.node",
+    "rezi_ui_native.darwin-x64.node",
+    "rezi_ui_native.darwin-arm64.node",
+    "rezi_ui_native.win32-x64-msvc.node",
+    "rezi_ui_native.win32-arm64-msvc.node",
+  ];
+
+  let discovered = [];
+  try {
+    discovered = readdirSync(__dirname).filter((file) => file.endsWith(".node"));
+  } catch {
+    discovered = [];
+  }
+
+  const candidates = ["index.node", "rezi_ui_native.node", ...platformCandidates, ...discovered];
+
+  for (const file of new Set(candidates)) {
+    native = tryDynamicRequire(file);
+    if (native) break;
+  }
+}
+
+if (!native) {
+  const extra =
+    lastErr instanceof Error ? `\n\nLast error:\n${lastErr.stack ?? lastErr.message}` : "";
+  throw new Error(
+    `Failed to load @rezi-ui/native binary. Tried: ${[...new Set(tried)].join(", ")}${extra}`,
+  );
+}
+
+module.exports = native;

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -21,7 +21,7 @@
       "default": "./index.js"
     }
   },
-  "files": ["index.js", "index.d.ts", "*.node", "scripts/*.mjs", "package.json"],
+  "files": ["index.js", "loader.cjs", "index.d.ts", "*.node", "scripts/*.mjs", "package.json"],
   "scripts": {
     "build:native": "node ./scripts/build-native.mjs",
     "test:native:smoke": "node ./scripts/smoke.mjs"


### PR DESCRIPTION
## Summary
- fix `@rezi-ui/native` loader for Bun single-file executables (`bun build --compile`)
- move native binary loading into a CommonJS loader (`loader.cjs`) so Bun can statically recognize direct `.node` `require()` calls
- keep runtime fallback scanning for Node/Bun non-compiled installs and preserve detailed error reporting
- include `loader.cjs` in published package files

## Problem
`@rezi-ui/native` used `createRequire(import.meta.url)` + dynamic path joins and `readdirSync`.
In Bun-compiled binaries this failed during startup (for example: `ENOENT ... '/$bunfs/root'`) and the addon did not load.

## Validation
- `npx biome check packages/native/index.js packages/native/loader.cjs packages/native/package.json`
- `npm -w @rezi-ui/native run test:native:smoke`
- `npm run build`
- Bun compile smoke:
  - `bun build --compile .tmp-bun-compile-smoke.mjs --outfile /tmp/rezi-native-bun-compile-smoke-bin`
  - `/tmp/rezi-native-bun-compile-smoke-bin` prints `native-bun-compile-smoke -6` (loader succeeds)
