### PR TITLE
runtime: enforce safe caps for fps and event payload size

### DIFF
--- a/docs/backend/engine-config.md
+++ b/docs/backend/engine-config.md
@@ -44,7 +44,7 @@ default to `undefined`.
 
 | Detail   | Value |
 |----------|-------|
-| Type     | `number` (positive integer) |
+| Type     | `number` (positive integer, `<= 1000`) |
 | Default  | `60` |
 
 Controls the maximum frames per second the runtime will attempt to render. The
@@ -62,7 +62,7 @@ config: {
 
 | Detail   | Value |
 |----------|-------|
-| Type     | `number` (positive integer) |
+| Type     | `number` (positive integer, `<= 4 << 20`) |
 | Default  | `1 << 20` (1 MiB) |
 
 Upper limit on the byte size of a single event batch received from the backend.

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -115,6 +115,8 @@ const app = createNodeApp<State>({
 
 - `createNodeApp<State>` creates a typed application instance and compatible Node/Bun backend
 - `config` controls app/backend runtime knobs in one place (`fpsCap`, `maxEventBytes`, `useV2Cursor`)
+- `fpsCap` must be a positive integer `<= 1000` (default `60`)
+- `maxEventBytes` must be a positive integer `<= 4 MiB` (default `1 MiB`)
 - `initialState` provides the initial application state
 
 ### Defining the View

--- a/packages/core/src/app/__tests__/config.bounds.test.ts
+++ b/packages/core/src/app/__tests__/config.bounds.test.ts
@@ -1,0 +1,36 @@
+import { assert, test } from "@rezi-ui/testkit";
+import { ZrUiError } from "../../abi.js";
+import { createApp } from "../createApp.js";
+import { StubBackend } from "./stubBackend.js";
+
+test("config bounds: fpsCap must be <= 1000", () => {
+  const backend = new StubBackend();
+  assert.throws(
+    () =>
+      createApp({
+        backend,
+        initialState: { value: 0 },
+        config: { fpsCap: 1001 },
+      }),
+    (err: unknown) =>
+      err instanceof ZrUiError &&
+      err.code === "ZRUI_INVALID_PROPS" &&
+      err.message.includes("fpsCap must be <= 1000"),
+  );
+});
+
+test("config bounds: maxEventBytes must be <= 4 MiB", () => {
+  const backend = new StubBackend();
+  assert.throws(
+    () =>
+      createApp({
+        backend,
+        initialState: { value: 0 },
+        config: { maxEventBytes: (4 << 20) + 1 },
+      }),
+    (err: unknown) =>
+      err instanceof ZrUiError &&
+      err.code === "ZRUI_INVALID_PROPS" &&
+      err.message.includes("maxEventBytes must be <= 4194304"),
+  );
+});

--- a/packages/core/src/app/createApp.ts
+++ b/packages/core/src/app/createApp.ts
@@ -122,6 +122,9 @@ const DEFAULT_CONFIG: ResolvedAppConfig = Object.freeze({
   internal_onRender: undefined,
   internal_onLayout: undefined,
 });
+
+const MAX_SAFE_FPS_CAP = 1000;
+const MAX_SAFE_EVENT_BYTES = 4 << 20 /* 4 MiB */;
 const SYNC_FRAME_ACK_MARKER = "__reziSyncFrameAck";
 export const APP_INTERNAL_REQUEST_VIEW_LAYOUT_MARKER = "__reziRequestViewLayout";
 export const APP_INTERNAL_SET_RUNTIME_BREADCRUMB_HOOKS_MARKER = "__reziSetRuntimeBreadcrumbHooks";
@@ -138,6 +141,12 @@ function invalidProps(detail: string): never {
 function requirePositiveInt(name: string, v: number): number {
   if (!Number.isInteger(v) || v <= 0) invalidProps(`${name} must be a positive integer`);
   return v;
+}
+
+function requirePositiveIntAtMost(name: string, v: number, max: number): number {
+  const parsed = requirePositiveInt(name, v);
+  if (parsed > max) invalidProps(`${name} must be <= ${String(max)}`);
+  return parsed;
 }
 
 function requireNonNegativeInt(name: string, v: number): number {
@@ -229,11 +238,11 @@ export function resolveAppConfig(config: AppConfig | undefined): ResolvedAppConf
   const fpsCap =
     config.fpsCap === undefined
       ? DEFAULT_CONFIG.fpsCap
-      : requirePositiveInt("fpsCap", config.fpsCap);
+      : requirePositiveIntAtMost("fpsCap", config.fpsCap, MAX_SAFE_FPS_CAP);
   const maxEventBytes =
     config.maxEventBytes === undefined
       ? DEFAULT_CONFIG.maxEventBytes
-      : requirePositiveInt("maxEventBytes", config.maxEventBytes);
+      : requirePositiveIntAtMost("maxEventBytes", config.maxEventBytes, MAX_SAFE_EVENT_BYTES);
   const maxDrawlistBytes =
     config.maxDrawlistBytes === undefined
       ? DEFAULT_CONFIG.maxDrawlistBytes

--- a/packages/node/src/__tests__/config_guards.test.ts
+++ b/packages/node/src/__tests__/config_guards.test.ts
@@ -127,3 +127,51 @@ test("createNodeApp constructs a compatible app/backend pair", () => {
   });
   app.dispose();
 });
+
+test("config guard: createNodeBackend rejects fpsCap above safe bound", () => {
+  assert.throws(
+    () => createNodeBackend({ fpsCap: 1001 }),
+    (err) =>
+      err instanceof ZrUiError &&
+      err.code === "ZRUI_INVALID_PROPS" &&
+      err.message.includes("fpsCap must be <= 1000"),
+  );
+});
+
+test("config guard: createNodeBackend rejects maxEventBytes above safe bound", () => {
+  assert.throws(
+    () => createNodeBackend({ maxEventBytes: (4 << 20) + 1 }),
+    (err) =>
+      err instanceof ZrUiError &&
+      err.code === "ZRUI_INVALID_PROPS" &&
+      err.message.includes("maxEventBytes must be <= 4194304"),
+  );
+});
+
+test("config guard: createNodeApp rejects fpsCap above safe bound", () => {
+  assert.throws(
+    () =>
+      createNodeApp({
+        initialState: { value: 0 },
+        config: { fpsCap: 1001 },
+      }),
+    (err) =>
+      err instanceof ZrUiError &&
+      err.code === "ZRUI_INVALID_PROPS" &&
+      err.message.includes("fpsCap must be <= 1000"),
+  );
+});
+
+test("config guard: createNodeApp rejects maxEventBytes above safe bound", () => {
+  assert.throws(
+    () =>
+      createNodeApp({
+        initialState: { value: 0 },
+        config: { maxEventBytes: (4 << 20) + 1 },
+      }),
+    (err) =>
+      err instanceof ZrUiError &&
+      err.code === "ZRUI_INVALID_PROPS" &&
+      err.message.includes("maxEventBytes must be <= 4194304"),
+  );
+});


### PR DESCRIPTION
## Summary
- enforce hard runtime caps in core app config: `fpsCap <= 1000`, `maxEventBytes <= 4 MiB`
- apply matching bounded validation in both node backends (worker + inline)
- surface explicit `ZRUI_INVALID_PROPS` errors for out-of-range values
- add coverage for bounds in core and node config guard tests
- update quickstart + engine-config docs with cap limits

## Validation
- npm run build -- packages/core packages/node
- node scripts/run-tests.mjs --scope packages --match config.bounds
- node scripts/run-tests.mjs --scope packages --match config_guards
- validated with 2 independent validator subagent passes
