### PR TITLE
create-rezi: add scaffold safety metadata and stress guardrails

### DIFF
--- a/docs/getting-started/create-rezi.md
+++ b/docs/getting-started/create-rezi.md
@@ -24,18 +24,20 @@ If `--template` is omitted, the CLI prompts you to choose (default: `dashboard`)
   Highlights: live-updating table with stable row keys, filter/sort/pin controls + incident telemetry.
 - `stress-test`: Visual benchmark matrix with deterministic simulation + real runtime diagnostics.
   Highlights: three visual stress lanes (geometry/text/matrix), phase escalation, measured CPU/RSS/lag/sink I/O.
-  Alias: `dash` (also accepted in interactive prompt).
-- `stress-test`: Visual benchmark matrix with deterministic simulation + real runtime diagnostics.
-  Highlights: three visual stress lanes (geometry/text/matrix), phase escalation, measured CPU/RSS/lag/sink I/O.
   Aliases: `stress`, `chaos`, `bench`.
+- `cli-tool`: Multi-screen product workflow app with first-party page routing.
+  Highlights: home/logs/settings/detail routes, breadcrumb+tabs helpers wired to live router state.
+  Aliases: `cli`, `tool`, `multiscreen`.
 
 Choose directly with `--template`:
 
 ```bash
 npm create rezi my-app -- --template dashboard
 npm create rezi my-app -- --template stress-test
+npm create rezi my-app -- --template cli-tool
 bun create rezi my-app -- --template dashboard
 bun create rezi my-app -- --template stress-test
+bun create rezi my-app -- --template cli-tool
 ```
 
 Inspect all templates and highlights from the CLI:
@@ -48,11 +50,15 @@ bun create rezi -- --list-templates
 
 ## Options
 
-- `--template, -t <name>`: Select a template (`dashboard` or `stress-test`; aliases: `dash`, `stress`, `chaos`, `bench`).
+- `--template, -t <name>`:
+  Select a template (`dashboard`, `stress-test`, `cli-tool`; aliases: `dash`, `stress`, `chaos`, `bench`, `cli`, `tool`, `multiscreen`).
 - `--no-install, --skip-install`: Skip dependency installation.
 - `--pm, --package-manager <npm|pnpm|yarn|bun>`: Choose a package manager.
 - `--list-templates, --templates`: Print available templates and highlights.
 - `--help, -h`: Show help.
+
+When `stress-test` is selected, the CLI asks for explicit confirmation because
+the generated app intentionally drives higher CPU/IO pressure.
 
 For package-level CLI reference (invocation forms and options), see [packages/create-rezi](../packages/create-rezi.md).
 

--- a/packages/create-rezi/src/scaffold.ts
+++ b/packages/create-rezi/src/scaffold.ts
@@ -8,6 +8,8 @@ export type TemplateDefinition = {
   key: TemplateKey;
   label: string;
   description: string;
+  safetyTag: string;
+  safetyNote: string;
   highlights: readonly string[];
   dir: string;
 };
@@ -17,6 +19,8 @@ export const TEMPLATE_DEFINITIONS: readonly TemplateDefinition[] = [
     key: "dashboard",
     label: "EdgeOps Dashboard",
     description: "Product-grade operations console with deterministic updates",
+    safetyTag: "safe-default",
+    safetyNote: "Balanced runtime profile for everyday app development.",
     highlights: [
       "fleet control plane with stable live telemetry",
       "incident feed + inspector + escalation runbook",
@@ -28,6 +32,8 @@ export const TEMPLATE_DEFINITIONS: readonly TemplateDefinition[] = [
     label: "Visual Benchmark Matrix",
     description:
       "Three-lane visual benchmark with deterministic sim model + real runtime diagnostics",
+    safetyTag: "high-cpu-io",
+    safetyNote: "Generates heavy CPU/IO pressure; intended for benchmarking only.",
     highlights: [
       "geometry + text/file activity + matrix rain lanes with phase-based intensity ramp",
       "deterministic sim scorecard and measured CPU/RSS/lag/timing/sink throughput",
@@ -38,6 +44,8 @@ export const TEMPLATE_DEFINITIONS: readonly TemplateDefinition[] = [
     key: "cli-tool",
     label: "Multi-Screen CLI Tool",
     description: "Task-oriented multi-screen TUI with first-party page routing",
+    safetyTag: "safe-default",
+    safetyNote: "Lightweight template focused on product workflows and routing.",
     highlights: [
       "home/logs/settings/detail screens with router history and focus restoration",
       "global route keybindings plus breadcrumb + tabs helpers wired to router state",

--- a/packages/create-rezi/templates/dashboard/README.md
+++ b/packages/create-rezi/templates/dashboard/README.md
@@ -34,6 +34,11 @@ bun run start
 - Stable table + inspector + active events workflow using high-level Rezi widgets only.
 - Escalation-oriented UX: critical banner, service inspector guidance, and runbook panel.
 
+## Runtime Guardrails
+
+- Keep the scaffolded app config defaults (`fpsCap`, `maxEventBytes`, `executionMode`) unless you have a measured reason to change them.
+- The defaults are tuned for predictable local iteration and stable CI behavior.
+
 ## Key Code Patterns
 
 - Bounded live update loop and lifecycle cleanup in `src/main.ts` (`simulateTick`, interval setup/teardown).

--- a/packages/create-rezi/templates/stress-test/README.md
+++ b/packages/create-rezi/templates/stress-test/README.md
@@ -68,6 +68,14 @@ No random external input or external host telemetry is used.
 - `escape`: Close help modal
 - `q`: Quit
 
+## Safety Notes
+
+- This template is a benchmark rig, not a normal starter app.
+- `z` (`turbo`) and `w` (`write-flood`) increase CPU and I/O pressure on purpose.
+- The real I/O sink targets the null device when available (`/dev/null` or `NUL`);
+  if unavailable it falls back to a temp-file sink under the OS temp directory.
+- Later phases raise update rate and memory ballast. Use `r` to reset back to phase 1.
+
 ## Quickstart
 
 ```bash


### PR DESCRIPTION
## Summary
- add `safetyTag`/`safetyNote` metadata to scaffold template definitions
- surface template safety metadata in `--list-templates` and interactive template prompt
- add stress-test safety confirmation for interactive sessions
- prevent CI/script hangs by skipping the prompt in non-interactive sessions with a safety notice
- align getting-started/template docs (template list, aliases, safety notes)

## Validation
- npm run typecheck -- packages/create-rezi
- npm run build -- packages/create-rezi
- npm run check:create-rezi-templates
- non-interactive smoke test: `node packages/create-rezi/dist/index.js <tmp> --template stress-test --no-install`
- validated with 2 independent validator subagent passes
