### PR TITLE
docs: add machine-readable widget catalog

### DIFF
--- a/docs/widgets/catalog.json
+++ b/docs/widgets/catalog.json
@@ -2,65 +2,365 @@
   "schema": "rezi-widget-catalog-v1",
   "version": 1,
   "widgets": [
-    { "name": "text", "requiredProps": ["content"], "commonProps": ["style", "variant"], "example": "ui.text('Hello')" },
-    { "name": "box", "requiredProps": [], "commonProps": ["border", "p", "style", "children"], "example": "ui.box({ border: 'rounded', p: 1 }, [ui.text('Body')])" },
-    { "name": "row", "requiredProps": [], "commonProps": ["gap", "align", "justify", "children"], "example": "ui.row({ gap: 1 }, [ui.text('A'), ui.text('B')])" },
-    { "name": "column", "requiredProps": [], "commonProps": ["gap", "align", "justify", "children"], "example": "ui.column({ gap: 1 }, [ui.text('A'), ui.text('B')])" },
-    { "name": "grid", "requiredProps": ["columns"], "commonProps": ["gap", "children"], "example": "ui.grid({ columns: 2, gap: 1 }, ui.text('A'), ui.text('B'))" },
-    { "name": "spacer", "requiredProps": [], "commonProps": ["size", "flex"], "example": "ui.spacer({ flex: 1 })" },
-    { "name": "divider", "requiredProps": [], "commonProps": ["label", "style"], "example": "ui.divider({ label: 'Section' })" },
-    { "name": "icon", "requiredProps": ["name"], "commonProps": ["fallback", "style"], "example": "ui.icon('status.success')" },
-    { "name": "spinner", "requiredProps": [], "commonProps": ["variant", "label", "style"], "example": "ui.spinner({ variant: 'dots' })" },
-    { "name": "progress", "requiredProps": ["value"], "commonProps": ["width", "label"], "example": "ui.progress(0.42, { width: 20 })" },
-    { "name": "skeleton", "requiredProps": [], "commonProps": ["width", "height", "variant"], "example": "ui.skeleton({ width: 20 })" },
-    { "name": "richText", "requiredProps": ["spans"], "commonProps": ["maxWidth"], "example": "ui.richText({ spans: [{ text: 'Hello', style: { bold: true } }] })" },
-    { "name": "kbd", "requiredProps": ["keys"], "commonProps": ["separator", "style"], "example": "ui.kbd(['Ctrl', 'S'])" },
-    { "name": "badge", "requiredProps": ["text"], "commonProps": ["variant"], "example": "ui.badge('beta')" },
-    { "name": "status", "requiredProps": ["label"], "commonProps": ["tone"], "example": "ui.status({ label: 'Online', tone: 'success' })" },
-    { "name": "tag", "requiredProps": ["text"], "commonProps": ["variant"], "example": "ui.tag('stable')" },
-    { "name": "gauge", "requiredProps": ["value"], "commonProps": ["min", "max", "label"], "example": "ui.gauge(64, { max: 100 })" },
-    { "name": "empty", "requiredProps": ["title"], "commonProps": ["description", "action"], "example": "ui.empty('No data')" },
-    { "name": "errorDisplay", "requiredProps": ["message"], "commonProps": ["title", "onRetry"], "example": "ui.errorDisplay('Request failed')" },
-    { "name": "callout", "requiredProps": ["message"], "commonProps": ["variant", "title"], "example": "ui.callout('Saved', { variant: 'success' })" },
-    { "name": "sparkline", "requiredProps": ["data"], "commonProps": ["min", "max", "width"], "example": "ui.sparkline([1, 2, 3, 2])" },
-    { "name": "barChart", "requiredProps": ["data"], "commonProps": ["orientation", "showValues"], "example": "ui.barChart([{ label: 'A', value: 10 }])" },
-    { "name": "miniChart", "requiredProps": ["values"], "commonProps": ["variant"], "example": "ui.miniChart([{ label: 'CPU', value: 42 }])" },
-    { "name": "link", "requiredProps": ["url"], "commonProps": ["label", "onPress"], "example": "ui.link('https://example.com', 'Open')" },
-    { "name": "canvas", "requiredProps": ["width", "height", "draw"], "commonProps": ["fallback"], "example": "ui.canvas({ width: 20, height: 5, draw: (c) => c.text(0, 0, 'Hi') })" },
-    { "name": "image", "requiredProps": ["src"], "commonProps": ["width", "height", "fit"], "example": "ui.image({ src: bytes, width: 32, height: 12 })" },
-    { "name": "lineChart", "requiredProps": ["series"], "commonProps": ["height", "showAxes"], "example": "ui.lineChart({ series: [{ name: 'A', values: [1, 2, 3] }] })" },
-    { "name": "scatter", "requiredProps": ["points"], "commonProps": ["width", "height"], "example": "ui.scatter({ points: [{ x: 1, y: 2 }] })" },
-    { "name": "heatmap", "requiredProps": ["values", "rows", "cols"], "commonProps": ["palette"], "example": "ui.heatmap({ rows: 3, cols: 3, values: [0,1,2,3,4,5,6,7,8] })" },
-    { "name": "button", "requiredProps": ["id", "label"], "commonProps": ["disabled", "onPress"], "example": "ui.button('save', 'Save')" },
-    { "name": "input", "requiredProps": ["id", "value"], "commonProps": ["placeholder", "onInput"], "example": "ui.input('name', state.name)" },
-    { "name": "slider", "requiredProps": ["id", "value", "onChange"], "commonProps": ["min", "max", "step"], "example": "ui.slider({ id: 'vol', value: 42, onChange: setVol })" },
-    { "name": "focusZone", "requiredProps": ["id"], "commonProps": ["children"], "example": "ui.focusZone({ id: 'zone' }, [ui.button('a', 'A')])" },
-    { "name": "focusTrap", "requiredProps": ["id"], "commonProps": ["children"], "example": "ui.focusTrap({ id: 'trap' }, [ui.input('q', '')])" },
-    { "name": "virtualList", "requiredProps": ["id", "items", "renderItem"], "commonProps": ["itemHeight", "overscan"], "example": "ui.virtualList({ id: 'list', items, renderItem: (it) => ui.text(String(it)) })" },
-    { "name": "layers", "requiredProps": [], "commonProps": ["children"], "example": "ui.layers([AppView(), ui.modal({ id: 'm', content: ui.text('X') })])" },
-    { "name": "modal", "requiredProps": ["id", "content"], "commonProps": ["title", "actions", "onClose"], "example": "ui.modal({ id: 'confirm', content: ui.text('Proceed?') })" },
-    { "name": "dropdown", "requiredProps": ["id", "anchorId", "items"], "commonProps": ["position", "onSelect", "onClose"], "example": "ui.dropdown({ id: 'menu', anchorId: 'btn', items })" },
-    { "name": "layer", "requiredProps": ["id", "content"], "commonProps": ["zIndex", "modal"], "example": "ui.layer({ id: 'tooltip', content: ui.text('info') })" },
-    { "name": "table", "requiredProps": ["id", "columns", "data"], "commonProps": ["selection", "onSort"], "example": "ui.table({ id: 't', columns, data })" },
-    { "name": "tree", "requiredProps": ["id", "data", "getKey"], "commonProps": ["expanded", "onToggle"], "example": "ui.tree({ id: 'fs', data, getKey: (n) => n.id })" },
-    { "name": "field", "requiredProps": ["label", "children"], "commonProps": ["required", "error", "hint"], "example": "ui.field({ label: 'Email', children: ui.input('email', '') })" },
-    { "name": "select", "requiredProps": ["id", "value", "options", "onChange"], "commonProps": ["placeholder", "disabled"], "example": "ui.select({ id: 'country', value, options, onChange })" },
-    { "name": "checkbox", "requiredProps": ["id", "checked", "onChange"], "commonProps": ["label", "disabled"], "example": "ui.checkbox({ id: 'agree', checked, onChange })" },
-    { "name": "radioGroup", "requiredProps": ["id", "value", "options", "onChange"], "commonProps": ["direction", "disabled"], "example": "ui.radioGroup({ id: 'plan', value, options, onChange })" },
-    { "name": "tabs", "requiredProps": ["id", "tabs", "activeTab"], "commonProps": ["onChange", "content"], "example": "ui.tabs({ id: 'tabs', tabs, activeTab, onChange })" },
-    { "name": "accordion", "requiredProps": ["id", "items"], "commonProps": ["expanded", "onToggle"], "example": "ui.accordion({ id: 'acc', items })" },
-    { "name": "breadcrumb", "requiredProps": ["items"], "commonProps": ["separator", "onSelect"], "example": "ui.breadcrumb({ items })" },
-    { "name": "pagination", "requiredProps": ["id", "page", "totalPages", "onPageChange"], "commonProps": ["showFirstLast"], "example": "ui.pagination({ id: 'p', page, totalPages, onPageChange })" },
-    { "name": "commandPalette", "requiredProps": ["id", "open"], "commonProps": ["query", "onClose", "onSelect"], "example": "ui.commandPalette({ id: 'cmd', open: true })" },
-    { "name": "filePicker", "requiredProps": ["id", "entries"], "commonProps": ["selected", "onSelect"], "example": "ui.filePicker({ id: 'fp', entries })" },
-    { "name": "fileTreeExplorer", "requiredProps": ["id", "nodes"], "commonProps": ["expanded", "onToggle"], "example": "ui.fileTreeExplorer({ id: 'tree', nodes })" },
-    { "name": "splitPane", "requiredProps": ["id", "direction", "children"], "commonProps": ["ratio", "onResize"], "example": "ui.splitPane({ id: 'split', direction: 'horizontal' }, [left, right])" },
-    { "name": "panelGroup", "requiredProps": ["id", "direction", "children"], "commonProps": ["sizes", "onResize"], "example": "ui.panelGroup({ id: 'pg', direction: 'horizontal' }, [a, b])" },
-    { "name": "resizablePanel", "requiredProps": ["id", "children"], "commonProps": ["minSize", "maxSize"], "example": "ui.resizablePanel({ id: 'left' }, [ui.text('Left')])" },
-    { "name": "codeEditor", "requiredProps": ["id", "lines", "cursor", "onChange"], "commonProps": ["language", "diagnostics"], "example": "ui.codeEditor({ id: 'code', lines, cursor, onChange })" },
-    { "name": "diffViewer", "requiredProps": ["id", "left", "right"], "commonProps": ["contextLines", "focusedHunk"], "example": "ui.diffViewer({ id: 'diff', left, right })" },
-    { "name": "toolApprovalDialog", "requiredProps": ["id", "request"], "commonProps": ["onAllow", "onDeny"], "example": "ui.toolApprovalDialog({ id: 'approve', request })" },
-    { "name": "logsConsole", "requiredProps": ["id", "entries"], "commonProps": ["filter", "follow"], "example": "ui.logsConsole({ id: 'logs', entries })" },
-    { "name": "toastContainer", "requiredProps": ["id"], "commonProps": ["toasts", "position"], "example": "ui.toastContainer({ id: 'toasts', toasts })" }
+    {
+      "name": "text",
+      "requiredProps": ["content"],
+      "commonProps": ["style", "variant"],
+      "example": "ui.text('Hello')"
+    },
+    {
+      "name": "box",
+      "requiredProps": [],
+      "commonProps": ["border", "p", "style", "children"],
+      "example": "ui.box({ border: 'rounded', p: 1 }, [ui.text('Body')])"
+    },
+    {
+      "name": "row",
+      "requiredProps": [],
+      "commonProps": ["gap", "align", "justify", "children"],
+      "example": "ui.row({ gap: 1 }, [ui.text('A'), ui.text('B')])"
+    },
+    {
+      "name": "column",
+      "requiredProps": [],
+      "commonProps": ["gap", "align", "justify", "children"],
+      "example": "ui.column({ gap: 1 }, [ui.text('A'), ui.text('B')])"
+    },
+    {
+      "name": "grid",
+      "requiredProps": ["columns"],
+      "commonProps": ["gap", "children"],
+      "example": "ui.grid({ columns: 2, gap: 1 }, ui.text('A'), ui.text('B'))"
+    },
+    {
+      "name": "spacer",
+      "requiredProps": [],
+      "commonProps": ["size", "flex"],
+      "example": "ui.spacer({ flex: 1 })"
+    },
+    {
+      "name": "divider",
+      "requiredProps": [],
+      "commonProps": ["label", "style"],
+      "example": "ui.divider({ label: 'Section' })"
+    },
+    {
+      "name": "icon",
+      "requiredProps": ["name"],
+      "commonProps": ["fallback", "style"],
+      "example": "ui.icon('status.success')"
+    },
+    {
+      "name": "spinner",
+      "requiredProps": [],
+      "commonProps": ["variant", "label", "style"],
+      "example": "ui.spinner({ variant: 'dots' })"
+    },
+    {
+      "name": "progress",
+      "requiredProps": ["value"],
+      "commonProps": ["width", "label"],
+      "example": "ui.progress(0.42, { width: 20 })"
+    },
+    {
+      "name": "skeleton",
+      "requiredProps": ["width"],
+      "commonProps": ["height", "variant", "style"],
+      "example": "ui.skeleton(20, { height: 1 })"
+    },
+    {
+      "name": "richText",
+      "requiredProps": ["spans"],
+      "commonProps": ["maxWidth"],
+      "example": "ui.richText({ spans: [{ text: 'Hello', style: { bold: true } }] })"
+    },
+    {
+      "name": "kbd",
+      "requiredProps": ["keys"],
+      "commonProps": ["separator", "style"],
+      "example": "ui.kbd(['Ctrl', 'S'])"
+    },
+    {
+      "name": "badge",
+      "requiredProps": ["text"],
+      "commonProps": ["variant"],
+      "example": "ui.badge('beta')"
+    },
+    {
+      "name": "status",
+      "requiredProps": ["status"],
+      "commonProps": ["label", "showLabel", "style"],
+      "example": "ui.status(\"online\", { label: \"Online\" })"
+    },
+    {
+      "name": "tag",
+      "requiredProps": ["text"],
+      "commonProps": ["variant"],
+      "example": "ui.tag('stable')"
+    },
+    {
+      "name": "gauge",
+      "requiredProps": ["value"],
+      "commonProps": ["min", "max", "label"],
+      "example": "ui.gauge(64, { max: 100 })"
+    },
+    {
+      "name": "empty",
+      "requiredProps": ["title"],
+      "commonProps": ["description", "action"],
+      "example": "ui.empty('No data')"
+    },
+    {
+      "name": "errorDisplay",
+      "requiredProps": ["message"],
+      "commonProps": ["title", "onRetry"],
+      "example": "ui.errorDisplay('Request failed')"
+    },
+    {
+      "name": "callout",
+      "requiredProps": ["message"],
+      "commonProps": ["variant", "title"],
+      "example": "ui.callout('Saved', { variant: 'success' })"
+    },
+    {
+      "name": "sparkline",
+      "requiredProps": ["data"],
+      "commonProps": ["min", "max", "width"],
+      "example": "ui.sparkline([1, 2, 3, 2])"
+    },
+    {
+      "name": "barChart",
+      "requiredProps": ["data"],
+      "commonProps": ["orientation", "showValues"],
+      "example": "ui.barChart([{ label: 'A', value: 10 }])"
+    },
+    {
+      "name": "miniChart",
+      "requiredProps": ["values"],
+      "commonProps": ["variant"],
+      "example": "ui.miniChart([{ label: 'CPU', value: 42 }])"
+    },
+    {
+      "name": "link",
+      "requiredProps": ["url"],
+      "commonProps": ["label", "onPress"],
+      "example": "ui.link('https://example.com', 'Open')"
+    },
+    {
+      "name": "canvas",
+      "requiredProps": ["width", "height", "draw"],
+      "commonProps": ["fallback"],
+      "example": "ui.canvas({ width: 20, height: 5, draw: (c) => c.text(0, 0, 'Hi') })"
+    },
+    {
+      "name": "image",
+      "requiredProps": ["src"],
+      "commonProps": ["width", "height", "fit"],
+      "example": "ui.image({ src: bytes, width: 32, height: 12 })"
+    },
+    {
+      "name": "lineChart",
+      "requiredProps": ["series"],
+      "commonProps": ["height", "showAxes"],
+      "example": "ui.lineChart({ series: [{ name: 'A', values: [1, 2, 3] }] })"
+    },
+    {
+      "name": "scatter",
+      "requiredProps": ["points"],
+      "commonProps": ["width", "height"],
+      "example": "ui.scatter({ points: [{ x: 1, y: 2 }] })"
+    },
+    {
+      "name": "heatmap",
+      "requiredProps": ["values", "rows", "cols"],
+      "commonProps": ["palette"],
+      "example": "ui.heatmap({ rows: 3, cols: 3, values: [0,1,2,3,4,5,6,7,8] })"
+    },
+    {
+      "name": "button",
+      "requiredProps": ["id", "label"],
+      "commonProps": ["disabled", "onPress"],
+      "example": "ui.button('save', 'Save')"
+    },
+    {
+      "name": "input",
+      "requiredProps": ["id", "value"],
+      "commonProps": ["placeholder", "onInput"],
+      "example": "ui.input('name', state.name)"
+    },
+    {
+      "name": "slider",
+      "requiredProps": ["id", "value", "onChange"],
+      "commonProps": ["min", "max", "step"],
+      "example": "ui.slider({ id: 'vol', value: 42, onChange: setVol })"
+    },
+    {
+      "name": "focusZone",
+      "requiredProps": ["id"],
+      "commonProps": ["children"],
+      "example": "ui.focusZone({ id: 'zone' }, [ui.button('a', 'A')])"
+    },
+    {
+      "name": "focusTrap",
+      "requiredProps": ["id"],
+      "commonProps": ["children"],
+      "example": "ui.focusTrap({ id: 'trap' }, [ui.input('q', '')])"
+    },
+    {
+      "name": "virtualList",
+      "requiredProps": ["id", "items", "renderItem"],
+      "commonProps": ["itemHeight", "overscan"],
+      "example": "ui.virtualList({ id: 'list', items, renderItem: (it) => ui.text(String(it)) })"
+    },
+    {
+      "name": "layers",
+      "requiredProps": [],
+      "commonProps": ["children"],
+      "example": "ui.layers([AppView(), ui.modal({ id: 'm', content: ui.text('X') })])"
+    },
+    {
+      "name": "modal",
+      "requiredProps": ["id", "content"],
+      "commonProps": ["title", "actions", "onClose"],
+      "example": "ui.modal({ id: 'confirm', content: ui.text('Proceed?') })"
+    },
+    {
+      "name": "dropdown",
+      "requiredProps": ["id", "anchorId", "items"],
+      "commonProps": ["position", "onSelect", "onClose"],
+      "example": "ui.dropdown({ id: 'menu', anchorId: 'btn', items })"
+    },
+    {
+      "name": "layer",
+      "requiredProps": ["id", "content"],
+      "commonProps": ["zIndex", "modal"],
+      "example": "ui.layer({ id: 'tooltip', content: ui.text('info') })"
+    },
+    {
+      "name": "table",
+      "requiredProps": ["id", "columns", "data"],
+      "commonProps": ["selection", "onSort"],
+      "example": "ui.table({ id: 't', columns, data })"
+    },
+    {
+      "name": "tree",
+      "requiredProps": ["id", "data", "getKey"],
+      "commonProps": ["expanded", "onToggle"],
+      "example": "ui.tree({ id: 'fs', data, getKey: (n) => n.id })"
+    },
+    {
+      "name": "field",
+      "requiredProps": ["label", "children"],
+      "commonProps": ["required", "error", "hint"],
+      "example": "ui.field({ label: 'Email', children: ui.input('email', '') })"
+    },
+    {
+      "name": "select",
+      "requiredProps": ["id", "value", "options", "onChange"],
+      "commonProps": ["placeholder", "disabled"],
+      "example": "ui.select({ id: 'country', value, options, onChange })"
+    },
+    {
+      "name": "checkbox",
+      "requiredProps": ["id", "checked", "onChange"],
+      "commonProps": ["label", "disabled"],
+      "example": "ui.checkbox({ id: 'agree', checked, onChange })"
+    },
+    {
+      "name": "radioGroup",
+      "requiredProps": ["id", "value", "options", "onChange"],
+      "commonProps": ["direction", "disabled"],
+      "example": "ui.radioGroup({ id: 'plan', value, options, onChange })"
+    },
+    {
+      "name": "tabs",
+      "requiredProps": ["id", "tabs", "activeTab"],
+      "commonProps": ["onChange", "content"],
+      "example": "ui.tabs({ id: 'tabs', tabs, activeTab, onChange })"
+    },
+    {
+      "name": "accordion",
+      "requiredProps": ["id", "items"],
+      "commonProps": ["expanded", "onToggle"],
+      "example": "ui.accordion({ id: 'acc', items })"
+    },
+    {
+      "name": "breadcrumb",
+      "requiredProps": ["items"],
+      "commonProps": ["separator", "onSelect"],
+      "example": "ui.breadcrumb({ items })"
+    },
+    {
+      "name": "pagination",
+      "requiredProps": ["id", "page", "totalPages", "onPageChange"],
+      "commonProps": ["showFirstLast"],
+      "example": "ui.pagination({ id: 'p', page, totalPages, onPageChange })"
+    },
+    {
+      "name": "commandPalette",
+      "requiredProps": ["id", "open"],
+      "commonProps": ["query", "onClose", "onSelect"],
+      "example": "ui.commandPalette({ id: 'cmd', open: true })"
+    },
+    {
+      "name": "filePicker",
+      "requiredProps": ["id", "entries"],
+      "commonProps": ["selected", "onSelect"],
+      "example": "ui.filePicker({ id: 'fp', entries })"
+    },
+    {
+      "name": "fileTreeExplorer",
+      "requiredProps": ["id", "nodes"],
+      "commonProps": ["expanded", "onToggle"],
+      "example": "ui.fileTreeExplorer({ id: 'tree', nodes })"
+    },
+    {
+      "name": "splitPane",
+      "requiredProps": ["id", "direction", "children"],
+      "commonProps": ["ratio", "onResize"],
+      "example": "ui.splitPane({ id: 'split', direction: 'horizontal' }, [left, right])"
+    },
+    {
+      "name": "panelGroup",
+      "requiredProps": ["id", "direction", "children"],
+      "commonProps": ["sizes", "onResize"],
+      "example": "ui.panelGroup({ id: 'pg', direction: 'horizontal' }, [a, b])"
+    },
+    {
+      "name": "resizablePanel",
+      "requiredProps": ["id", "children"],
+      "commonProps": ["minSize", "maxSize"],
+      "example": "ui.resizablePanel({ id: 'left' }, [ui.text('Left')])"
+    },
+    {
+      "name": "codeEditor",
+      "requiredProps": ["id", "lines", "cursor", "onChange"],
+      "commonProps": ["language", "diagnostics"],
+      "example": "ui.codeEditor({ id: 'code', lines, cursor, onChange })"
+    },
+    {
+      "name": "diffViewer",
+      "requiredProps": ["id", "left", "right"],
+      "commonProps": ["contextLines", "focusedHunk"],
+      "example": "ui.diffViewer({ id: 'diff', left, right })"
+    },
+    {
+      "name": "toolApprovalDialog",
+      "requiredProps": ["id", "request"],
+      "commonProps": ["onAllow", "onDeny"],
+      "example": "ui.toolApprovalDialog({ id: 'approve', request })"
+    },
+    {
+      "name": "logsConsole",
+      "requiredProps": ["id", "entries"],
+      "commonProps": ["filter", "follow"],
+      "example": "ui.logsConsole({ id: 'logs', entries })"
+    },
+    {
+      "name": "toastContainer",
+      "requiredProps": ["toasts", "onDismiss"],
+      "commonProps": ["position", "maxVisible", "frameStyle"],
+      "example": "ui.toastContainer({ toasts, onDismiss: (id) => dismissToast(id) })"
+    }
   ]
 }


### PR DESCRIPTION
## Summary
- add `docs/widgets/catalog.json` as a machine-readable widget reference
- include widget name, required/common props, and compact usage examples per entry

## Validation
- npm run typecheck
- npm run test:packages