### PR TITLE
renderer: clamp input/richText cursor bounds

### DIFF
--- a/packages/core/src/app/widgetRenderer.ts
+++ b/packages/core/src/app/widgetRenderer.ts
@@ -2737,11 +2737,14 @@ export class WidgetRenderer<S> {
     const input = this.inputById.get(focusedId);
     if (input && !input.disabled) {
       const rect = this._pooledRectByInstanceId.get(input.instanceId);
-      if (!rect || rect.w <= 0 || rect.h <= 0) return hidden;
+      if (!rect || rect.w <= 1 || rect.h <= 0) return hidden;
 
       const graphemeOffset =
         this.inputCursorByInstanceId.get(input.instanceId) ?? input.value.length;
-      const cursorX = measureTextCells(input.value.slice(0, graphemeOffset));
+      const cursorX = Math.max(
+        0,
+        Math.min(Math.max(0, rect.w - 2), measureTextCells(input.value.slice(0, graphemeOffset))),
+      );
       return Object.freeze({
         visible: true,
         x: rect.x + 1 + cursorX,
@@ -2811,13 +2814,16 @@ export class WidgetRenderer<S> {
     }
 
     const rect = this._pooledRectByInstanceId.get(input.instanceId);
-    if (!rect || rect.w <= 0 || rect.h <= 0) {
+    if (!rect || rect.w <= 1 || rect.h <= 0) {
       this.builder.hideCursor();
       return this.collectRuntimeBreadcrumbs ? this.resolveRuntimeCursorSummary(cursorInfo) : null;
     }
 
     const graphemeOffset = this.inputCursorByInstanceId.get(input.instanceId) ?? input.value.length;
-    const cursorX = measureTextCells(input.value.slice(0, graphemeOffset));
+    const cursorX = Math.max(
+      0,
+      Math.min(Math.max(0, rect.w - 2), measureTextCells(input.value.slice(0, graphemeOffset))),
+    );
     this.builder.setCursor({
       x: rect.x + 1 + cursorX,
       y: rect.y,


### PR DESCRIPTION
## Summary
- clamp input cursor X position to inner input content width
- guard against cursor emission when input width cannot contain a cursor cell
- clamp richText cursor X position to widget rect bounds

## Validation
- npm run typecheck
- npm run test:packages
