### PR TITLE
docs: comprehensive documentation overhaul and AI development guides

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,182 @@
+# AGENTS.md — Multi-Agent Workflow Guide for Rezi
+
+This file guides AI agents (Claude Code, OpenAI Codex) on how to explore, modify, test, and verify changes in the Rezi codebase. Follow these protocols for reliable results.
+
+## Project Overview
+
+Rezi is a runtime-agnostic TypeScript TUI framework. Monorepo with `npm` workspaces (NOT pnpm).
+
+**Packages:**
+
+| Package | Path | Purpose |
+|---------|------|---------|
+| `@rezi-ui/core` | `packages/core/` | Runtime-agnostic core framework |
+| `@rezi-ui/node` | `packages/node/` | Node.js backend (terminal I/O) |
+| `@rezi-ui/jsx` | `packages/jsx/` | JSX transform layer |
+| `@rezi-ui/native` | `packages/native/` | Native engine bindings |
+| `@rezi-ui/testkit` | `packages/testkit/` | Test utilities |
+| `create-rezi` | `packages/create-rezi/` | Project scaffolding CLI |
+| `@rezi-ui/bench` | `packages/bench/` | Benchmark suite |
+
+## Exploration Protocol
+
+When investigating Rezi code, follow this order:
+
+1. **Start with exports.** Read `packages/core/src/index.ts` to understand the full public API surface. This is the single source of truth for what the framework exposes.
+2. **Widget API.** `packages/core/src/widgets/ui.ts` has all 60+ widget factory functions (`ui.text()`, `ui.box()`, `ui.column()`, etc.).
+3. **Types.** `packages/core/src/widgets/types.ts` has all prop interfaces (`TextProps`, `BoxProps`, `ButtonProps`, etc.).
+4. **Templates are reference implementations.** Check `packages/create-rezi/templates/` for canonical app patterns. Four templates exist: `minimal`, `dashboard`, `cli-tool`, `stress-test`.
+5. **Tests show expected behavior.** `packages/core/src/**/__tests__/` contains 240+ test files. Read tests before making assumptions about how a module works.
+
+**Render pipeline (execution order):**
+
+```
+State -> view(state) -> VNode tree -> commitVNodeTree (reconciliation)
+     -> layout -> metadata_collect -> renderToDrawlist
+     -> builder.build() -> backend.requestFrame()
+```
+
+Key pipeline files:
+- `packages/core/src/app/widgetRenderer.ts` — orchestrates full pipeline
+- `packages/core/src/runtime/commit.ts` — VNode to RuntimeInstance tree
+- `packages/core/src/runtime/reconcile.ts` — child matching (keyed/unkeyed)
+- `packages/core/src/renderer/renderToDrawlist/renderTree.ts` — stack-based DFS renderer
+- `packages/core/src/drawlist/builder_v1.ts` — ZRDL binary drawlist builder
+
+## Modification Protocol
+
+### Before changing code
+
+1. Read the target file fully.
+2. Check existing tests for the module (`__tests__/` directory adjacent to or near the file).
+3. Understand where the target sits in the render pipeline.
+
+### Safe modification zones
+
+These areas tolerate changes well and have good test coverage:
+
+- `packages/core/src/widgets/ui.ts` — adding new widget factory functions
+- `packages/core/src/widgets/types.ts` — adding new prop types
+- `packages/create-rezi/templates/` — template modifications
+- `docs/` — documentation changes
+- Test files (`**/__tests__/*.test.ts`)
+- `packages/core/src/theme/` — theme definitions and presets
+- `packages/core/src/icons/` — icon registries
+
+### Danger zones (require extra care)
+
+Changes here affect all rendering and can introduce subtle regressions:
+
+- `packages/core/src/runtime/commit.ts` — reconciliation logic
+- `packages/core/src/runtime/reconcile.ts` — child matching, key algorithm
+- `packages/core/src/app/createApp.ts` — app lifecycle, error handling
+- `packages/core/src/layout/` — layout engine, constraint resolution
+- `packages/core/src/renderer/` — drawlist generation
+- `packages/core/src/drawlist/` — binary protocol builders
+- `packages/core/src/binary/` — binary reader/writer
+
+### Module boundary rules
+
+These boundaries are strict. Violating them breaks the runtime-agnostic guarantee.
+
+- `@rezi-ui/core` MUST NOT import from `@rezi-ui/node`, `@rezi-ui/jsx`, or `@rezi-ui/native`
+- `@rezi-ui/node` imports from `@rezi-ui/core` only
+- `@rezi-ui/jsx` imports from `@rezi-ui/core` only
+
+## Testing Protocol
+
+```bash
+# Run all tests
+node scripts/run-tests.mjs
+
+# Run specific test file
+node --test packages/core/src/widgets/__tests__/basicWidgets.test.ts
+
+# Run tests matching pattern
+node scripts/run-tests.mjs --filter "widget"
+```
+
+**Test locations:**
+
+| Category | Path |
+|----------|------|
+| Unit tests | `packages/core/src/**/__tests__/*.test.ts` |
+| Integration tests | `packages/core/src/__tests__/integration/` |
+| Stress/fuzz tests | `packages/core/src/__tests__/stress/` |
+| Template tests | `packages/create-rezi/templates/*/src/__tests__/` |
+
+**After any code change:**
+
+1. Run tests for the affected module first.
+2. If changing runtime, layout, or renderer code, also run integration tests.
+3. Run the full suite before committing.
+
+## Verification Protocol (Two-Agent Verification)
+
+When verifying documentation or code changes, split into two passes:
+
+**Agent 1 — Accuracy Checker:**
+- Verify all file paths referenced in docs actually exist on disk.
+- Verify all function signatures match actual exports in `packages/core/src/index.ts`.
+- Verify all prop types match actual type definitions in `packages/core/src/widgets/types.ts`.
+- Verify code examples would compile and run with the current API.
+
+**Agent 2 — Completeness Checker:**
+- Check that no important exports are missing from docs.
+- Check that no deprecated APIs are recommended.
+- Check patterns match the template reference implementations in `packages/create-rezi/templates/`.
+- Check guardrails and limits match actual constants in code (e.g., `MAX_UNDO_STACK`, `MAX_LOG_ENTRIES`).
+
+## Building TUIs with Rezi
+
+When creating demo apps or TUI implementations, follow the template structure:
+
+```
+src/
+  main.ts              -- App bootstrap, keybindings, event loop
+  types.ts             -- State and action types
+  theme.ts             -- Theme selection
+  helpers/
+    state.ts           -- Initial state + reducer function
+    keybindings.ts     -- Keybinding command resolver
+  screens/
+    *.ts               -- Pure view functions per screen
+  __tests__/
+    reducer.test.ts    -- State logic tests
+    render.test.ts     -- Render output tests
+    keybindings.test.ts -- Keybinding tests
+```
+
+**Required patterns:**
+
+1. Define state type and action union in `types.ts`.
+2. Create reducer in `helpers/state.ts`.
+3. Create pure screen functions in `screens/` (each returns a `VNode`).
+4. Wire keybindings via `app.keys()` in `main.ts`.
+5. Use `createNodeBackend({ fpsCap: 30 })` for production apps.
+
+**Widget usage hierarchy (prefer higher):**
+
+1. `ui.*` factory functions — `text`, `box`, `column`, `row`, `button`, `input`, `select`, `table`, etc.
+2. `defineWidget()` — for stateful reusable components with hooks.
+3. `useTable()`, `useModalStack()`, `useForm()` — for complex interaction patterns.
+4. `each()`, `show()`, `when()`, `maybe()`, `match()` — rendering control flow utilities.
+
+## PR and Commit Protocol
+
+- Run full test suite before commits: `node scripts/run-tests.mjs`
+- Commit message format: `feat(scope):`, `fix(scope):`, `docs(scope):`, `refactor(scope):`, `test(scope):`
+- Keep commits atomic — one logical change per commit.
+- Update `CHANGELOG.md` for user-facing changes.
+- Do not use `pnpm`. This project uses `npm` workspaces.
+
+## Common Mistakes to Avoid
+
+1. **Importing from internal paths** instead of package exports. Always import from `@rezi-ui/core`, not from `@rezi-ui/core/dist/widgets/ui.js`.
+2. **Forgetting `id` prop on interactive widgets.** Buttons, inputs, checkboxes, selects, and other focusable widgets require a unique `id`. Omitting it causes a runtime crash.
+3. **Calling hooks conditionally.** `defineWidget` hooks (`useAsync`, `useDebounce`, `usePrevious`, etc.) must be called in the same order every render. No conditional hook calls.
+4. **Mutating state directly.** Always use `app.update()` with an updater function or new state object. Never mutate the state reference.
+5. **Creating duplicate widget IDs.** Two widgets with the same `id` in the same render tree will cause a fatal error. Use `ctx.id()` for dynamic lists inside `defineWidget`.
+6. **Using `pnpm`.** This project uses `npm` workspaces. Running `pnpm install` will break the workspace links.
+7. **Skipping tests after pipeline changes.** Any change to commit, reconcile, layout, or renderer files requires running the full test suite. Subtle regressions are common.
+8. **Breaking module boundaries.** Core must remain runtime-agnostic. Never add Node.js-specific imports (`Buffer`, `worker_threads`, `node:*`) to `@rezi-ui/core`.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,0 +1,210 @@
+# Rezi AI Development Guide
+
+## Project Overview
+
+Rezi is a high-performance TypeScript TUI framework with a native C rendering engine (Zireael).
+Monorepo with npm workspaces (NOT pnpm).
+Packages: `@rezi-ui/core` (runtime-agnostic framework), `@rezi-ui/node` (Node.js backend), `@rezi-ui/jsx` (JSX transform), `create-rezi` (scaffolding CLI).
+
+## Quick Commands
+
+```bash
+npm install                          # Install all workspaces
+node scripts/run-tests.mjs           # Run all tests (~900+ tests, node:test)
+npx tsx packages/bench/src/...       # Run benchmarks (bypasses tsc)
+REZI_PERF=1 REZI_PERF_DETAIL=1      # Enable profiling (env vars, prefix any command)
+```
+
+## Project Map
+
+```
+packages/core/src/
+  app/
+    createApp.ts              # createApp() factory, App interface, app.run()/app.stop()
+    widgetRenderer.ts         # Render orchestrator, full frame pipeline
+  widgets/
+    ui.ts                     # ui.* factory functions (60+ widgets) — THE recommended API
+    types.ts                  # All widget prop types (VNode discriminated union)
+    composition.ts            # defineWidget(), WidgetContext, hooks
+    conditionals.ts           # show(), when(), match(), maybe()
+    collections.ts            # each(), eachInline() — keyed list rendering
+    useTable.ts               # useTable() hook for table state
+    useModalStack.ts          # useModalStack() hook for modal state
+  runtime/
+    commit.ts                 # VNode -> RuntimeInstance reconciliation
+    reconcile.ts              # Child matching (keyed/unkeyed diffing)
+    instances.ts              # Hook state registry (useState, useEffect, etc.)
+    focus.ts                  # Focus traversal and management
+  layout/
+    layout.ts                 # Public facade (re-exports from engine/)
+    engine/layoutEngine.ts    # Constraint-based layout algorithm
+    kinds/                    # Per-widget layout implementations (stack, box, grid, leaf, etc.)
+  renderer/
+    renderToDrawlist.ts       # Public entry for drawlist rendering
+    renderToDrawlist/
+      renderTree.ts           # Stack-based DFS renderer
+  drawlist/
+    builder_v1.ts             # ZRDL binary drawlist builder (v1)
+    builder_v2.ts             # Drawlist builder v2 (cursor protocol)
+    builder_v3.ts             # Drawlist builder v3
+  keybindings/
+    manager.ts                # Modal keybinding system
+    parser.ts                 # Key sequence parsing
+  router/
+    router.ts                 # Page routing with guards + nested outlets
+    helpers.ts                # routerBreadcrumb(), routerTabs()
+  forms/
+    useForm.ts                # Form management hook
+    validation.ts             # Form field validation
+    bind.ts                   # Two-way binding helpers
+  testing/
+    renderer.ts               # createTestRenderer() — full pipeline test helper
+    events.ts                 # TestEventBuilder, encodeZrevBatchV1
+  __tests__/
+    integration/              # Integration test suites (dashboard, form-editor, etc.)
+    stress/                   # Fuzzing and stress tests (large trees, rapid events)
+
+packages/node/src/
+  backend/
+    nodeBackend.ts            # Node.js backend factory (async, worker-based)
+    nodeBackendInline.ts      # Inline (sync) backend for simple apps
+
+packages/create-rezi/templates/
+  minimal/                    # Bare-minimum counter app
+  cli-tool/                   # Multi-screen app with routing
+  dashboard/                  # Real-time dashboard with charts
+  stress-test/                # Stress/performance testing template
+  (each template follows: main.ts, types.ts, theme.ts, helpers/, screens/)
+```
+
+## Architecture — Render Pipeline
+
+```
+State -> view(state) -> VNode tree -> commitVNodeTree -> layout -> metadata_collect -> renderToDrawlist -> builder.build() -> backend.requestFrame()
+```
+
+1. **State**: Application state managed via `app.update()` or `useReducer` pattern.
+2. **view(state)**: Pure function returns a VNode tree describing the UI.
+3. **VNode tree**: Declarative widget descriptions (discriminated union by `kind`).
+4. **commitVNodeTree**: Reconciles new VNodes against previous RuntimeInstance tree (keyed/unkeyed diffing).
+5. **layout**: Constraint-based engine computes absolute position/size for every widget.
+6. **metadata_collect**: Gathers focus targets, hit-test regions, and accessibility info.
+7. **renderToDrawlist**: Stack-based DFS walks the layout tree, emitting draw operations.
+8. **builder.build()**: Serializes draw operations into ZRDL binary format.
+9. **backend.requestFrame()**: Sends binary drawlist to the native Zireael renderer.
+
+## API Layers (safest to lowest-level)
+
+### Layer 1 — Widget API (ALWAYS prefer this)
+
+```typescript
+import { ui, createApp } from "@rezi-ui/core";
+
+const view = (state: AppState) =>
+  ui.column({ gap: 1 }, [
+    ui.text(`Count: ${state.count}`),
+    ui.button({ id: "inc", label: "+1", onPress: () => app.update(s => ({ ...s, count: s.count + 1 })) }),
+  ]);
+```
+
+### Layer 2 — Composition API (for reusable widgets)
+
+```typescript
+import { defineWidget } from "@rezi-ui/core";
+
+const Counter = defineWidget<{ initial: number; key?: string }>((props, ctx) => {
+  const [count, setCount] = ctx.useState(props.initial);
+  return ui.column({ gap: 1 }, [
+    ui.text(`Count: ${count}`),
+    ui.button({ id: ctx.id("inc"), label: "+1", onPress: () => setCount(c => c + 1) }),
+  ]);
+});
+```
+
+Available hooks: `ctx.useState()`, `ctx.useEffect()`, `ctx.useRef()`, `ctx.useMemo()`, `ctx.useCallback()`, `ctx.id()`.
+
+### Layer 3 — Domain Hooks (for complex state)
+
+```typescript
+import { useTable, useModalStack, useForm } from "@rezi-ui/core";
+```
+
+### Layer 4 — Raw VNodes (avoid unless necessary)
+
+```typescript
+const node: VNode = { kind: "text", text: "hello", props: {} };
+```
+
+## Conditional and List Rendering
+
+```typescript
+import { show, when, match, maybe } from "@rezi-ui/core";
+import { each, eachInline } from "@rezi-ui/core";
+
+// Conditional
+show(isVisible, ui.text("shown"));
+when(loading, () => ui.spinner({}), () => ui.text("done"));
+maybe(user, u => ui.text(u.name));
+
+// Lists (always provide key function)
+each(items, (item) => ui.text(item.name), { key: (item) => item.id });
+```
+
+## Code Standards and Guardrails
+
+- All interactive widgets MUST have a unique `id` prop.
+- Hooks must be called in consistent order (no conditional hooks, no hooks in loops).
+- Use `key` prop for list items to enable stable reconciliation.
+- State updates during render are forbidden (throws `ZRUI_UPDATE_DURING_RENDER`).
+- Duplicate interactive widget IDs are fatal (throws `ZRUI_DUPLICATE_ID`).
+- Max nesting depth: 500 (warn at 200). Max composite render depth: 100.
+- Prefer `useReducer` pattern (reducer + dispatch) over raw `app.update()`.
+- Import from package exports only (`@rezi-ui/core`, `@rezi-ui/node`), never from internal paths.
+
+## Patterns
+
+### DO
+
+- Use `ui.*` functions for all widget construction.
+- Use `each()` / `eachInline()` for list rendering with keys.
+- Use `show()` / `when()` / `maybe()` / `match()` for conditional rendering.
+- Use `defineWidget()` for reusable stateful components.
+- Use `useTable()` for table state, `useModalStack()` for modal state.
+- Follow template structure: separate `screens/`, `helpers/state.ts`, `helpers/keybindings.ts`, `theme.ts`, `types.ts`.
+- Test with `createTestRenderer()` from the testing module.
+
+### DON'T
+
+- Don't construct raw VNode objects `{ kind: ..., props: ... }`.
+- Don't call hooks conditionally or in loops.
+- Don't use `app.update()` inside view functions.
+- Don't duplicate widget IDs across the tree.
+- Don't exceed 500 nesting depth.
+- Don't import from internal paths (use package exports only).
+
+## Testing
+
+```typescript
+import { createTestRenderer } from "@rezi-ui/core";
+
+const renderer = createTestRenderer({ viewport: { cols: 80, rows: 24 } });
+const result = renderer.render(myView(state));
+
+// Query the rendered tree
+result.findById("my-button");      // Find node by widget ID
+result.findText("Hello");          // Find node containing text
+result.findAll("button");          // Find all nodes of a kind
+result.toText();                   // Render to plain text for snapshots
+```
+
+Test runner: `node:test`. Run all tests with `node scripts/run-tests.mjs`.
+
+## Performance Notes
+
+- Layout stability signatures (FNV-1a hash) auto-skip relayout for unchanged subtrees.
+- Builder `validateParams` defaults to false in production (fast path).
+- Leaf node reuse eliminates allocation for unchanged text/spacer/divider nodes.
+- Container reuse skips reconciliation when children are structurally identical.
+- Use `ctx.useMemo()` for expensive computations in widget render functions.
+- Profile with `REZI_PERF=1 REZI_PERF_DETAIL=1` environment variables.
+- Benchmark scripts: `packages/bench/src/profile-phases.ts`, `profile-construction.ts`.

--- a/SKILLS.md
+++ b/SKILLS.md
@@ -1,0 +1,217 @@
+# Rezi AI Skills Reference
+
+Repeatable recipes for AI agents working with Rezi. Each skill includes trigger conditions, implementation steps, and verification criteria.
+
+---
+
+## Skill 1: Add a New Widget
+
+**When:** User asks to add a new widget type to the framework.
+
+**Steps:**
+1. Add props type to `packages/core/src/widgets/types.ts` (use the `Readonly<{...}>` pattern).
+2. Add factory function to `packages/core/src/widgets/ui.ts` (with JSDoc + `@example`).
+3. Add VNode kind entry to the `VNode` discriminated union in `types.ts`.
+4. Add layout handler in `packages/core/src/layout/kinds/` (`leaf.ts` for non-containers, `box.ts`/`stack.ts` for containers, `collections.ts` for data widgets, `overlays.ts` for layered).
+5. Add render handler in `packages/core/src/renderer/renderToDrawlist/widgets/` (`basic.ts`, `containers.ts`, `collections.ts`, `editors.ts`, `overlays.ts`, `navigation.ts`, or `files.ts`).
+6. If JSX support is needed, add JSX component wrapper in `packages/jsx/src/components.ts`.
+7. Export both props type and factory from `packages/core/src/index.ts`.
+8. Write tests in `packages/core/src/widgets/__tests__/`.
+9. Add docs in `docs/widgets/{widget-name}.md`.
+
+**Verify:** `node scripts/run-tests.mjs` passes; widget + props exported from index; renders correctly via `createTestRenderer`.
+
+---
+
+## Skill 2: Create a New Screen
+
+**When:** User asks to add a screen/page to a Rezi app.
+
+**Steps:**
+1. Create `src/screens/{screen-name}.ts` with signature `(state: State) => VNode`.
+2. Use `ui.column()` or `ui.row()` as root container.
+3. If using the router, add a route definition (see Skill 10).
+4. Add keybindings for navigation in `src/helpers/keybindings.ts`.
+5. Wire into `main.ts` via the router or a view switch.
+
+**Verify:** Screen renders without errors; navigation keybindings work; state types updated if needed.
+
+---
+
+## Skill 3: Set Up Keybindings
+
+**When:** User needs keyboard shortcuts.
+
+**Steps:**
+1. Define commands using `app.keys()`:
+   ```typescript
+   app.keys({
+     "q": () => shutdown(),
+     "Ctrl+s": () => save(),
+     "g g": () => scrollToTop(),  // chord binding
+   });
+   ```
+2. For modal modes: `app.keys("edit-mode", { "Escape": () => exitEditMode() })`.
+3. Add `ui.keybindingHelp()` widget for discoverability.
+
+**Verify:** Keys trigger correct actions; no conflicts in same mode; chords complete correctly.
+
+---
+
+## Skill 4: Add a Data Table
+
+**When:** User needs tabular data display.
+
+**Steps:**
+1. Use the `useTable()` hook:
+   ```typescript
+   const table = useTable(ctx, {
+     rows: data,
+     columns: [
+       { key: "name", header: "Name", flex: 1 },
+       { key: "size", header: "Size", width: 10, align: "right" },
+     ],
+     getRowKey: (row) => row.id,
+     selectable: "multi",
+   });
+   return ui.table(table.props);
+   ```
+2. Handle selection via `table.selection`.
+3. Handle sorting via `table.sortColumn` / `table.sortDirection`.
+
+**Verify:** Correct columns render; selection updates; sorting works both directions.
+
+---
+
+## Skill 5: Add Modal Dialogs
+
+**When:** User needs overlay dialogs.
+
+**Steps:**
+1. Use `useModalStack()` for lifecycle management:
+   ```typescript
+   const modals = useModalStack(ctx);
+   modals.push("confirm", { title: "Confirm", content: body, onClose: () => modals.pop() });
+   ```
+2. Include in view: `return ui.layers([mainContent, ...modals.render()])`.
+3. Or use `ui.modal()` directly with a state-controlled `open` flag.
+
+**Verify:** Modal opens/closes; focus traps within modal; focus returns on close.
+
+---
+
+## Skill 6: Set Up Forms
+
+**When:** User needs form input handling.
+
+**Steps:**
+1. Use the `useForm()` hook:
+   ```typescript
+   const form = useForm(ctx, {
+     initialValues: { name: "", email: "" },
+     validate: (values) => {
+       const errors: Record<string, string> = {};
+       if (!values.name) errors.name = "Required";
+       return errors;
+     },
+     onSubmit: async (values) => { /* handle */ },
+   });
+   ```
+2. Bind fields: `ui.input({ ...form.bind("name") })`.
+3. Use `ui.field()` for labeled fields with error display.
+
+**Verify:** Validation errors display; submission works; touched/dirty state tracked.
+
+---
+
+## Skill 7: Write Tests
+
+**When:** Need to test Rezi components or app logic.
+
+**Steps:**
+1. Create test file in the appropriate `__tests__/` directory.
+2. Use `createTestRenderer()`:
+   ```typescript
+   import { describe, it, assert } from "node:test";
+   import { createTestRenderer, ui } from "@rezi-ui/core";
+   describe("MyWidget", () => {
+     it("renders correctly", () => {
+       const r = createTestRenderer({ viewport: { cols: 80, rows: 24 } });
+       const result = r.render(ui.text("hello"));
+       assert.ok(result.findText("hello"));
+     });
+   });
+   ```
+3. State tests: test reducer functions directly.
+4. Keybinding tests: test resolver functions directly.
+5. Use `result.toText()` for snapshot-style assertions.
+
+**Run:** `node scripts/run-tests.mjs` (full suite) or `node --test path/to/test.ts` (single file).
+
+---
+
+## Skill 8: Debug Rendering Issues
+
+**When:** UI does not look right or has layout problems.
+
+**Steps:**
+1. Enable profiling: `REZI_PERF=1 REZI_PERF_DETAIL=1`.
+2. Check VNode tree structure -- ensure no missing children.
+3. Check widget IDs -- must be unique across the entire tree.
+4. Check nesting depth -- warning at 200, fatal at 500.
+5. Check `key` props on list items -- missing keys cause full re-render.
+6. Use `createTestRenderer()` to capture and inspect output; use `result.findById()` to locate nodes.
+7. Review layout props: `width`, `height`, `flex`, `p`, `gap`, `align`.
+
+---
+
+## Skill 9: Performance Profiling
+
+**When:** App feels slow or frames drop.
+
+**Steps:**
+1. Set `REZI_PERF=1 REZI_PERF_DETAIL=1` environment variables.
+2. Run app and observe phase timings (view, commit, layout, render, build).
+3. Common fixes:
+   - `useMemo()` for expensive view computations.
+   - `key` props on list items for stable reconciliation.
+   - Reduce nesting depth.
+   - `virtualList` for large data sets.
+4. Systematic profiling:
+   ```bash
+   npx tsx packages/bench/src/profile-phases.ts
+   npx tsx packages/bench/src/profile-construction.ts
+   ```
+
+---
+
+## Skill 10: Add Routing
+
+**When:** App needs multiple pages/screens.
+
+**Steps:**
+1. Define routes with optional guards and nested children:
+   ```typescript
+   const routes = {
+     home: { view: (state) => HomeScreen(state) },
+     settings: {
+       view: (state) => SettingsScreen(state),
+       guard: (from, to, meta) => {
+         if (!meta.isAuthenticated) return { redirect: "home" };
+         return { allow: true };
+       },
+     },
+     dashboard: {
+       view: (state, context) => ui.column([Header(state), context.outlet]),
+       children: {
+         overview: { view: (state) => OverviewPanel(state) },
+         stats: { view: (state) => StatsPanel(state) },
+       },
+     },
+   };
+   ```
+2. Pass to app: `const app = createApp({ routes, initialRoute: "home" })`.
+3. Navigate: `app.router.navigate("settings")`.
+4. Nested routes render via `context.outlet`.
+
+**Verify:** Correct screens render; guards block unauthorized access; nested outlet renders children.

--- a/docs/guide/concepts.md
+++ b/docs/guide/concepts.md
@@ -1,13 +1,13 @@
 # Concepts
 
-Understanding Rezi's core concepts will help you build effective terminal applications.
+Understanding Rezi's core concepts will help you build effective terminal applications. This page covers the mental model, the key abstractions, and how they fit together.
 
-## Widget Tree (VNode)
+## VNode Trees (Declarative UI)
 
-Rezi applications render a tree of **virtual nodes** (VNodes) through a pure `view(state)` function:
+Rezi applications describe their UI as a tree of **virtual nodes** (VNodes). You never write terminal escape codes or manage cursor positions directly. Instead, you declare _what_ the UI should look like, and Rezi figures out _how_ to render it.
 
 ```typescript
-app.view((state) =>
+app.view(state =>
   ui.column({ gap: 1 }, [
     ui.text("Hello, World!"),
     ui.button({ id: "ok", label: "OK" }),
@@ -15,25 +15,21 @@ app.view((state) =>
 );
 ```
 
+Each call to a `ui.*` function returns a VNode -- a lightweight plain object with a `kind` field and typed `props`. The `ui.*` helpers are the recommended way to build VNode trees. They provide type safety and a clean API without requiring you to construct discriminated union objects by hand.
+
 ### Key Properties
 
-**Widgets are plain objects**
-: Each widget is a discriminated union with a `kind` field. The `ui.*` helpers are convenience functions that create these objects.
-
 **`key` for reconciliation**
-: When rendering dynamic lists, the `key` prop helps Rezi track which items changed, were added, or were removed:
+: When rendering dynamic lists, the `key` prop helps Rezi track which items changed, were added, or were removed. Always provide keys for list items derived from data:
 
 ```typescript
 ui.column(
-  items.map((item) => ui.text(item.name, { key: item.id }))
+  items.map(item => ui.text(item.name, { key: item.id }))
 )
 ```
 
 **`id` for interactivity**
-: Focusable widgets require an `id` prop. This is used for:
-- Focus management (Tab/Shift+Tab navigation)
-- Event routing (which button was pressed)
-- Focus restoration after modal closes
+: Focusable widgets require an `id` prop. This is used for focus management (Tab/Shift+Tab navigation), event routing (which button was pressed), and focus restoration after modal closes:
 
 ```typescript
 ui.button({ id: "submit", label: "Submit" })
@@ -42,135 +38,259 @@ ui.input({ id: "email", value: state.email })
 
 ## State-Driven Rendering
 
-Rezi follows a unidirectional data flow:
+Rezi follows a strict unidirectional data flow:
 
 ```
-State → View → VNode Tree → Render
-  ↑                           ↓
-  └─── Events ← User Input ←──┘
+State --> View --> VNode Tree --> Render
+  ^                                 |
+  +--- Events <-- User Input <------+
 ```
+
+Your application state is the single source of truth. The view function transforms state into a VNode tree. User interactions produce events that update state, which triggers a new render cycle.
 
 ### State Updates
 
 State changes through `app.update()`:
 
 ```typescript
-// Functional update (recommended)
-app.update((prev) => ({ ...prev, count: prev.count + 1 }));
+// Functional update (recommended -- avoids stale closures)
+app.update(prev => ({ ...prev, count: prev.count + 1 }));
 
 // Direct replacement
 app.update({ count: 0 });
 ```
 
-Updates are batched and coalesced. Multiple `update()` calls in the same event loop tick produce a single re-render.
+Updates are batched and coalesced. Multiple `update()` calls in the same event loop tick produce a single re-render, so you do not need to worry about redundant renders when dispatching several updates in a row.
 
-### Pure View Function
+### Pure View Functions
 
-The view function should be pure:
+The view function should be **pure** -- given the same state, it should return the same VNode tree:
 
 ```typescript
-// Good: Pure function, same input → same output
-app.view((state) => ui.text(`Count: ${state.count}`));
+// Good: Pure function, same input produces same output
+app.view(state => ui.text(`Count: ${state.count}`));
 
 // Bad: Side effects in view
-app.view((state) => {
+app.view(state => {
   console.log("Rendering..."); // Side effect
-  fetchData(); // Side effect
+  fetchData();                 // Side effect
   return ui.text(`Count: ${state.count}`);
 });
 ```
 
-## Deterministic Rendering
+Side effects belong in event handlers, keybinding callbacks, or `useEffect` hooks inside `defineWidget()`.
 
-Rezi is designed so that:
+### Reducer Pattern (Recommended)
 
-- The same initial state
-- Plus the same sequence of input events
-- Produces the same frames and routed events
+For non-trivial apps, use a **reducer pattern** to manage state transitions. This keeps your state logic pure, testable, and separate from your UI:
 
-This determinism is achieved through:
+```typescript
+type State = { count: number; items: string[] };
+type Action =
+  | { type: "increment" }
+  | { type: "addItem"; text: string }
+  | { type: "removeItem"; index: number };
 
-### Version-Pinned Unicode
+function reduce(state: State, action: Action): State {
+  switch (action.type) {
+    case "increment":  return { ...state, count: state.count + 1 };
+    case "addItem":    return { ...state, items: [...state.items, action.text] };
+    case "removeItem": return { ...state, items: state.items.filter((_, i) => i !== action.index) };
+  }
+}
 
-Text measurement and grapheme segmentation use a pinned Unicode version. The same string always measures to the same cell width.
-
-### Strict Binary Protocols
-
-The ZRDL (drawlist) and ZREV (event batch) protocols are versioned and validated. Invalid input fails deterministically with structured errors.
-
-### Locked Update Contract
-
-The update and scheduling contract is strictly defined:
-- Updates during render throw `ZRUI_UPDATE_DURING_RENDER`
-- Reentrant calls throw `ZRUI_REENTRANT_CALL`
-
-## Package Architecture
-
-Rezi uses a layered architecture with strict boundaries:
-
-```
-┌─────────────────────────────────────┐
-│         Your Application            │
-└─────────────────────────────────────┘
-                  │
-                  ▼
-┌─────────────────────────────────────┐
-│          @rezi-ui/core              │
-│  (Runtime-agnostic TypeScript)      │
-│  • Widgets, Layout, Themes          │
-│  • Forms, Keybindings, Focus        │
-│  • Protocol builders/parsers        │
-└─────────────────────────────────────┘
-                  │
-                  ▼
-┌─────────────────────────────────────┐
-│          @rezi-ui/node              │
-│  (Node.js/Bun Runtime Integration)      │
-│  • Worker threads                   │
-│  • Event loop integration           │
-└─────────────────────────────────────┘
-                  │
-                  ▼
-┌─────────────────────────────────────┐
-│         @rezi-ui/native             │
-│  (N-API Addon)                      │
-│  • Zireael C engine binding         │
-│  • Terminal I/O                     │
-└─────────────────────────────────────┘
+function dispatch(action: Action) {
+  app.update(s => reduce(s, action));
+}
 ```
 
-### Why This Structure?
+The reducer is a plain function. You can test it in isolation with no framework dependencies.
 
-**Portability**
-: `@rezi-ui/core` contains no Node.js-specific APIs. It could theoretically run in any JavaScript runtime.
+## Widget Composition via `ui.*`
 
-**Testability**
-: Core logic can be tested without a terminal or native addon.
-
-**Binary Boundary**
-: The native engine communicates through versioned binary formats, enabling stable ABI and language interop.
-
-## Widget Categories
-
-Rezi widgets fall into several categories:
+The `ui` namespace provides factory functions for every built-in widget. These are organized into categories:
 
 ### Structural Widgets
-Container and layout: `box`, `row`, `column`, `spacer`, `divider`
+Container and layout: `ui.box()`, `ui.row()`, `ui.column()`, `ui.spacer()`, `ui.divider()`, `ui.grid()`
 
 ### Content Widgets
-Display information: `text`, `richText`, `icon`, `badge`, `status`
+Display information: `ui.text()`, `ui.richText()`, `ui.icon()`, `ui.badge()`, `ui.callout()`
 
 ### Interactive Widgets
-Accept user input via keyboard and mouse: `button`, `input`, `checkbox`, `select`, `radioGroup`
+Accept user input: `ui.button()`, `ui.input()`, `ui.checkbox()`, `ui.select()`, `ui.radioGroup()`, `ui.slider()`
 
 ### Data Widgets
-Display structured data: `table`, `virtualList`, `tree`
+Display structured data: `ui.table()`, `ui.virtualList()`, `ui.tree()`
 
 ### Overlay Widgets
-Modal interfaces: `modal`, `dropdown`, `toast`, `layers`
+Modal interfaces: `ui.modal()`, `ui.dropdown()`, `ui.toast()`, `ui.layers()`
 
 ### Feedback Widgets
-Loading and error states: `spinner`, `progress`, `skeleton`, `errorDisplay`
+Loading and error states: `ui.spinner()`, `ui.progress()`, `ui.skeleton()`, `ui.errorDisplay()`, `ui.errorBoundary()`
+
+### Custom Widgets with `defineWidget()`
+
+For reusable components with local state and lifecycle, use `defineWidget()`:
+
+```typescript
+import { defineWidget, ui } from "@rezi-ui/core";
+
+type CounterProps = { initial: number; key?: string };
+
+const Counter = defineWidget<CounterProps>(
+  (props, ctx) => {
+    const [count, setCount] = ctx.useState(props.initial);
+
+    return ui.row({ gap: 1 }, [
+      ui.text(`Count: ${count}`),
+      ui.button({
+        id: ctx.id("inc"),
+        label: "+1",
+        onPress: () => setCount(c => c + 1),
+      }),
+    ]);
+  },
+  { name: "Counter" }
+);
+
+// Usage in a view:
+app.view(() =>
+  ui.column([
+    Counter({ initial: 0 }),
+    Counter({ initial: 10, key: "counter-2" }),
+  ])
+);
+```
+
+`defineWidget()` gives each instance its own `WidgetContext` with hooks:
+
+- `ctx.useState()` -- Local state that persists across renders
+- `ctx.useRef()` -- Mutable ref without triggering re-render
+- `ctx.useMemo()` -- Memoize expensive computations
+- `ctx.useCallback()` -- Stable callback references
+- `ctx.useEffect()` -- Side effects with cleanup
+- `ctx.useAppState()` -- Select a slice of app state
+- `ctx.id()` -- Generate scoped IDs to prevent collisions
+
+## The Render Pipeline
+
+When state changes, Rezi runs through a multi-phase pipeline:
+
+```
+State --> view(state) --> VNode Tree --> Reconcile --> Layout --> Render --> Drawlist --> Backend
+```
+
+1. **View** -- Your view function produces a new VNode tree
+2. **Reconcile** -- The new tree is diffed against the previous tree using keys and structural matching
+3. **Layout** -- Widget sizes and positions are computed (flexbox-inspired model)
+4. **Render** -- The layout tree is walked to produce draw commands
+5. **Drawlist** -- Commands are encoded into the ZRDL binary format
+6. **Backend** -- The native engine processes the drawlist and paints the terminal
+
+You rarely need to think about these phases directly. The framework handles them automatically, including optimizations like layout stability detection (skip relayout when the tree structure has not changed) and update batching.
+
+## Hooks for Stateful Widgets
+
+Hooks are available inside `defineWidget()` render functions through the `WidgetContext`. They follow the same rules as React hooks -- call them unconditionally and in the same order every render.
+
+```typescript
+const SearchList = defineWidget<SearchListProps, AppState>(
+  (props, ctx) => {
+    const [query, setQuery] = ctx.useState("");
+    const items = ctx.useAppState(s => s.items);
+
+    // Memoize filtered results
+    const filtered = ctx.useMemo(
+      () => items.filter(item => item.name.includes(query)),
+      [items, query]
+    );
+
+    // Stable callback for input handler
+    const onInput = ctx.useCallback(
+      (value: string) => setQuery(value),
+      []
+    );
+
+    return ui.column({ gap: 1 }, [
+      ui.input({ id: ctx.id("search"), value: query, onInput }),
+      ...filtered.map(item =>
+        ui.text(item.name, { key: item.id })
+      ),
+    ]);
+  },
+  { name: "SearchList" }
+);
+```
+
+Additional utility hooks are exported from `@rezi-ui/core`:
+
+- `useDebounce(ctx, value, delayMs)` -- Debounce a value
+- `usePrevious(ctx, value)` -- Track the previous render's value
+- `useAsync(ctx, asyncFn, deps)` -- Manage async data loading
+
+## Keybinding System
+
+Rezi provides two layers of keyboard handling:
+
+### Global Keybindings
+
+Register application-wide shortcuts with `app.keys()`:
+
+```typescript
+app.keys({
+  "ctrl+s": () => save(),
+  "ctrl+q": () => app.stop(),
+  q: () => app.stop(),
+  "g g": () => scrollToTop(),    // Chord: press g twice
+});
+```
+
+Key names support modifiers (`ctrl`, `alt`, `shift`, `meta`) and chord sequences (space-separated keys pressed in sequence).
+
+### Modal / Vim-Style Modes
+
+For applications with distinct input modes, use `app.modes()`:
+
+```typescript
+app.modes({
+  normal: {
+    i: () => app.setMode("insert"),
+    j: () => moveCursorDown(),
+    k: () => moveCursorUp(),
+    "/": () => app.setMode("search"),
+  },
+  insert: {
+    escape: () => app.setMode("normal"),
+  },
+  search: {
+    escape: () => app.setMode("normal"),
+    enter: () => executeSearch(),
+  },
+});
+```
+
+### Widget-Level Events
+
+Individual widgets handle input through callback props:
+
+```typescript
+ui.button({
+  id: "submit",
+  label: "Submit",
+  onPress: () => handleSubmit(),
+});
+
+ui.input({
+  id: "name",
+  value: state.name,
+  onInput: value => app.update(s => ({ ...s, name: value })),
+  onBlur: () => validate("name"),
+});
+```
+
+### Recommended Practice
+
+Centralize keybindings in a dedicated file and dispatch actions rather than performing logic inline. See [Recommended Patterns](recommended-patterns.md) for the full pattern.
 
 ## Focus Model
 
@@ -205,55 +325,57 @@ ui.focusTrap({ id: "modal-trap", active: true }, [
 ])
 ```
 
-## Event Handling
+## Deterministic Rendering
 
-### Widget Events
-Widgets receive events through callback props:
+Rezi is designed so that the same initial state plus the same sequence of input events produces the same frames and routed events. This determinism is achieved through:
 
-```typescript
-ui.button({
-  id: "submit",
-  label: "Submit",
-  onPress: () => handleSubmit(),
-});
+- **Version-pinned Unicode** -- Text measurement uses a pinned Unicode version; the same string always measures to the same cell width
+- **Strict binary protocols** -- The ZRDL (drawlist) and ZREV (event batch) formats are versioned and validated
+- **Locked update contract** -- Updates during render throw `ZRUI_UPDATE_DURING_RENDER`; reentrant calls throw `ZRUI_REENTRANT_CALL`
 
-ui.input({
-  id: "name",
-  value: state.name,
-  onInput: (value) => app.update({ ...state, name: value }),
-  onBlur: () => validate("name"),
-});
+## Package Architecture
+
+Rezi uses a layered architecture with strict boundaries:
+
+```
++-------------------------------------+
+|         Your Application            |
++-------------------------------------+
+                  |
+                  v
++-------------------------------------+
+|          @rezi-ui/core              |
+|  (Runtime-agnostic TypeScript)      |
+|  Widgets, Layout, Themes            |
+|  Forms, Keybindings, Focus          |
+|  Protocol builders/parsers          |
++-------------------------------------+
+                  |
+                  v
++-------------------------------------+
+|          @rezi-ui/node              |
+|  (Node.js/Bun Runtime Integration)  |
+|  Worker threads, Event loop         |
++-------------------------------------+
+                  |
+                  v
++-------------------------------------+
+|         @rezi-ui/native             |
+|  (N-API Addon)                      |
+|  Zireael C engine binding           |
+|  Terminal I/O                       |
++-------------------------------------+
 ```
 
-### Global Keybindings
-Register application-wide keyboard shortcuts:
+**Portability**: `@rezi-ui/core` contains no Node.js-specific APIs. It could theoretically run in any JavaScript runtime.
 
-```typescript
-app.keys({
-  "ctrl+s": () => save(),
-  "ctrl+q": () => app.stop(),
-  "escape": () => closeModal(),
-});
-```
+**Testability**: Core logic can be tested without a terminal or native addon.
 
-### Modal Keybindings
-For Vim-style modes:
-
-```typescript
-app.modes({
-  normal: {
-    i: () => app.setMode("insert"),
-    j: () => moveCursorDown(),
-    k: () => moveCursorUp(),
-  },
-  insert: {
-    escape: () => app.setMode("normal"),
-  },
-});
-```
+**Binary Boundary**: The native engine communicates through versioned binary formats, enabling a stable ABI and language interop.
 
 ## Next Steps
 
+- [Recommended Patterns](recommended-patterns.md) - Best practices for production apps
 - [Lifecycle & Updates](lifecycle-and-updates.md) - State management in depth
 - [Layout](layout.md) - Spacing, alignment, and constraints
 - [Input & Focus](input-and-focus.md) - Keyboard and mouse navigation

--- a/docs/guide/hooks-reference.md
+++ b/docs/guide/hooks-reference.md
@@ -1,0 +1,762 @@
+# Hooks Reference
+
+Hooks are functions available on the `WidgetContext` (`ctx`) inside `defineWidget` render functions. They let composite widgets manage local state, run side effects, and access app-level data without breaking the declarative VNode model.
+
+```typescript
+import { defineWidget, ui } from "@rezi-ui/core";
+
+const MyWidget = defineWidget<{ key?: string }>((props, ctx) => {
+  const [count, setCount] = ctx.useState(0);
+  // ... use hooks here ...
+  return ui.text(`Count: ${count}`);
+});
+```
+
+## Core Hooks
+
+### `ctx.useState`
+
+Create local state that persists across renders. Returns a `[value, setter]` tuple.
+
+**Signature:**
+
+```typescript
+ctx.useState<T>(initial: T | (() => T)): [T, (v: T | ((prev: T) => T)) => void]
+```
+
+**Description:**
+
+- The `initial` argument is used only on the first render. Pass a function for lazy initialization (useful when the initial value is expensive to compute).
+- The setter accepts either a new value or an updater function that receives the previous value.
+- Calling the setter schedules a re-render of the widget.
+
+**Example:**
+
+```typescript
+const MyWidget = defineWidget<{ key?: string }>((props, ctx) => {
+  const [count, setCount] = ctx.useState(0);
+  const [items, setItems] = ctx.useState<string[]>(() => []);
+
+  return ui.column({ gap: 1 }, [
+    ui.text(`Count: ${count}`),
+    ui.button({
+      id: ctx.id("inc"),
+      label: "Increment",
+      onPress: () => setCount((prev) => prev + 1),
+    }),
+    ui.button({
+      id: ctx.id("add"),
+      label: "Add Item",
+      onPress: () => setItems((prev) => [...prev, `Item ${prev.length + 1}`]),
+    }),
+  ]);
+});
+```
+
+**Rules:**
+
+- Must be called in the same order every render (no conditional calls).
+- The setter is stable across renders -- you do not need to memoize it.
+
+---
+
+### `ctx.useRef`
+
+Create a mutable ref that persists across renders without triggering re-renders.
+
+**Signature:**
+
+```typescript
+ctx.useRef<T>(initial: T): { current: T }
+```
+
+**Description:**
+
+- Returns an object with a mutable `current` property.
+- Changing `current` does **not** cause a re-render.
+- Useful for storing values that need to survive across renders but should not trigger UI updates (timers, DOM references, mutable counters).
+
+**Example:**
+
+```typescript
+const Timer = defineWidget<{ key?: string }>((props, ctx) => {
+  const [elapsed, setElapsed] = ctx.useState(0);
+  const intervalRef = ctx.useRef<ReturnType<typeof setInterval> | null>(null);
+
+  ctx.useEffect(() => {
+    intervalRef.current = setInterval(() => {
+      setElapsed((e) => e + 1);
+    }, 1000);
+    return () => {
+      if (intervalRef.current !== null) {
+        clearInterval(intervalRef.current);
+      }
+    };
+  }, []);
+
+  return ui.text(`Elapsed: ${elapsed}s`);
+});
+```
+
+---
+
+### `ctx.useEffect`
+
+Register a side effect to run after the commit phase. Similar to React's `useEffect`.
+
+**Signature:**
+
+```typescript
+ctx.useEffect(effect: () => void | (() => void), deps?: readonly unknown[]): void
+```
+
+**Description:**
+
+- The `effect` function runs after the widget's VNode tree is committed.
+- If `effect` returns a cleanup function, that cleanup runs before the next effect execution and when the widget unmounts.
+- The `deps` array controls when the effect re-runs:
+  - Omitted: runs after every render.
+  - Empty array `[]`: runs once on mount, cleanup on unmount.
+  - With values: re-runs when any dependency changes (compared with `Object.is`).
+
+**Example:**
+
+```typescript
+const SearchBox = defineWidget<{ query: string; key?: string }>((props, ctx) => {
+  const [results, setResults] = ctx.useState<string[]>([]);
+
+  ctx.useEffect(() => {
+    if (props.query.length === 0) {
+      setResults([]);
+      return;
+    }
+
+    let cancelled = false;
+    fetchResults(props.query).then((data) => {
+      if (!cancelled) setResults(data);
+    });
+
+    return () => { cancelled = true; };
+  }, [props.query]);
+
+  return ui.column({ gap: 1 }, [
+    ui.text(`Results for "${props.query}":`),
+    ...results.map((r, i) => ui.text(r, { key: String(i) })),
+  ]);
+});
+```
+
+---
+
+### `ctx.useMemo`
+
+Memoize a computed value until dependencies change.
+
+**Signature:**
+
+```typescript
+ctx.useMemo<T>(factory: () => T, deps?: readonly unknown[]): T
+```
+
+**Description:**
+
+- Calls `factory` on the first render and caches the result.
+- On subsequent renders, returns the cached result unless one of the `deps` has changed (compared with `Object.is`).
+- Use for expensive computations that depend on specific inputs.
+
+**Example:**
+
+```typescript
+const FilteredList = defineWidget<{ items: Item[]; filter: string; key?: string }>(
+  (props, ctx) => {
+    const filtered = ctx.useMemo(
+      () => props.items.filter((item) =>
+        item.name.toLowerCase().includes(props.filter.toLowerCase())
+      ),
+      [props.items, props.filter],
+    );
+
+    return ui.column({ gap: 0 },
+      filtered.map((item) => ui.text(item.name, { key: item.id })),
+    );
+  },
+);
+```
+
+---
+
+### `ctx.useCallback`
+
+Memoize a callback reference until dependencies change.
+
+**Signature:**
+
+```typescript
+ctx.useCallback<T extends (...args: never[]) => unknown>(
+  callback: T,
+  deps?: readonly unknown[],
+): T
+```
+
+**Description:**
+
+- Returns a stable function reference that only changes when a dependency changes.
+- Useful when passing callbacks to child widgets or hooks that compare by reference.
+
+**Example:**
+
+```typescript
+const Editor = defineWidget<{ key?: string }>((props, ctx) => {
+  const [text, setText] = ctx.useState("");
+
+  const handleInput = ctx.useCallback(
+    (value: string) => setText(value),
+    [],
+  );
+
+  return ui.input({
+    id: ctx.id("editor"),
+    value: text,
+    onInput: handleInput,
+  });
+});
+```
+
+---
+
+## App Hooks
+
+### `ctx.useAppState`
+
+Select a slice of the application-level state. Available when the widget has access to app state (the `State` type parameter of `WidgetContext<State>`).
+
+**Signature:**
+
+```typescript
+ctx.useAppState<T>(selector: (state: State) => T): T
+```
+
+**Description:**
+
+- Runs `selector` against the current app state and returns the result.
+- The widget re-renders when the selected slice changes.
+
+**Example:**
+
+```typescript
+const UserBadge = defineWidget<{ key?: string }, AppState>((props, ctx) => {
+  const userName = ctx.useAppState((s) => s.user.name);
+  const isOnline = ctx.useAppState((s) => s.user.online);
+
+  return ui.row({ gap: 1 }, [
+    ui.status(isOnline ? "online" : "offline"),
+    ui.text(userName),
+  ]);
+});
+```
+
+---
+
+## Utility Hooks
+
+These are standalone functions (not on `ctx`) that accept a context argument. They compose core hooks internally.
+
+### `useDebounce`
+
+Return a debounced copy of a value that updates only after a delay.
+
+**Signature:**
+
+```typescript
+import { useDebounce } from "@rezi-ui/core";
+
+useDebounce<T>(ctx: WidgetContext, value: T, delayMs: number): T
+```
+
+**Description:**
+
+- The returned value updates only after `delayMs` milliseconds have elapsed without a new input value.
+- Non-positive or non-finite delays apply the value on the next effect pass (effectively no delay).
+- Internally uses `ctx.useState` and `ctx.useEffect`.
+
+**Example:**
+
+```typescript
+import { defineWidget, useDebounce, ui } from "@rezi-ui/core";
+
+const SearchInput = defineWidget<{ key?: string }>((props, ctx) => {
+  const [query, setQuery] = ctx.useState("");
+  const debouncedQuery = useDebounce(ctx, query, 300);
+
+  ctx.useEffect(() => {
+    if (debouncedQuery.length > 0) {
+      performSearch(debouncedQuery);
+    }
+  }, [debouncedQuery]);
+
+  return ui.input({
+    id: ctx.id("search"),
+    value: query,
+    onInput: (v) => setQuery(v),
+  });
+});
+```
+
+---
+
+### `usePrevious`
+
+Track the previous render's value.
+
+**Signature:**
+
+```typescript
+import { usePrevious } from "@rezi-ui/core";
+
+usePrevious<T>(ctx: WidgetContext, value: T): T | undefined
+```
+
+**Description:**
+
+- Returns `undefined` on the first render.
+- On subsequent renders, returns the value from the previous render cycle.
+- Internally uses `ctx.useRef` and `ctx.useEffect`.
+
+**Example:**
+
+```typescript
+import { defineWidget, usePrevious, ui } from "@rezi-ui/core";
+
+const CounterWithDelta = defineWidget<{ count: number; key?: string }>(
+  (props, ctx) => {
+    const prevCount = usePrevious(ctx, props.count);
+    const delta = prevCount !== undefined ? props.count - prevCount : 0;
+
+    return ui.row({ gap: 1 }, [
+      ui.text(`Count: ${props.count}`),
+      delta !== 0 && ui.text(`(${delta > 0 ? "+" : ""}${delta})`, { dim: true }),
+    ]);
+  },
+);
+```
+
+---
+
+### `useAsync`
+
+Run an async operation when dependencies change. Manages loading/data/error state automatically.
+
+**Signature:**
+
+```typescript
+import { useAsync, type UseAsyncState } from "@rezi-ui/core";
+
+useAsync<T>(
+  ctx: WidgetContext,
+  task: () => Promise<T>,
+  deps: readonly unknown[],
+): UseAsyncState<T>
+
+type UseAsyncState<T> = Readonly<{
+  data: T | undefined;
+  loading: boolean;
+  error: unknown;
+}>;
+```
+
+**Description:**
+
+- Sets `loading` to `true` while the operation is in-flight.
+- Stores the resolved value in `data`.
+- Stores any thrown/rejected value in `error`.
+- Ignores stale completions from older dependency runs (race condition safe).
+- Internally uses `ctx.useState`, `ctx.useRef`, and `ctx.useEffect`.
+
+**Example:**
+
+```typescript
+import { defineWidget, useAsync, ui } from "@rezi-ui/core";
+
+const UserProfile = defineWidget<{ userId: string; key?: string }>(
+  (props, ctx) => {
+    const { data: user, loading, error } = useAsync(
+      ctx,
+      () => fetchUser(props.userId),
+      [props.userId],
+    );
+
+    if (loading) return ui.spinner({ label: "Loading profile..." });
+    if (error) return ui.errorDisplay("Failed to load profile");
+    if (!user) return ui.empty("No user found");
+
+    return ui.column({ gap: 1 }, [
+      ui.text(user.name, { style: { bold: true } }),
+      ui.text(user.email, { dim: true }),
+    ]);
+  },
+);
+```
+
+---
+
+## Widget Hooks
+
+Higher-level hooks that manage complex widget state patterns. These are standalone functions that accept a `WidgetContext` as their first argument.
+
+### `useTable`
+
+Convenience hook that wires up sorting, selection, and row-key management for `ui.table`. Returns a `props` object that can be spread directly into `ui.table(...)`.
+
+**Signature:**
+
+```typescript
+import { useTable, type UseTableOptions, type UseTableResult } from "@rezi-ui/core";
+
+useTable<T, State = void>(
+  ctx: WidgetContext<State>,
+  options: UseTableOptions<T>,
+): UseTableResult<T>
+```
+
+**Key options:**
+
+```typescript
+type UseTableOptions<T> = {
+  id?: string;                                   // Table widget ID (auto-generated if omitted)
+  rows: readonly T[];                            // Data rows
+  columns: readonly TableColumn<T>[];            // Column definitions
+  getRowKey?: (row: T, index: number) => string; // Row identity (defaults to row.id or index)
+  selectable?: TableSelectionMode;               // "none" | "single" | "multi" (default: "none")
+  sortable?: boolean;                            // Enable sorting on all columns (default: false)
+  defaultSelection?: readonly string[];          // Initial selection
+  defaultSortColumn?: string;                    // Initial sort column key
+  defaultSortDirection?: SortDirection;           // "asc" | "desc" (default: "asc")
+  onSelectionChange?: (keys: readonly string[]) => void;
+  onSortChange?: (column: string, direction: SortDirection) => void;
+  // ... plus any other TableProps (passed through)
+};
+```
+
+**Return value:**
+
+```typescript
+type UseTableResult<T> = {
+  props: TableProps<T>;                          // Spread into ui.table(...)
+  rows: readonly T[];                            // Sorted rows (for external use)
+  selection: readonly string[];                  // Current selection keys
+  sortColumn: string | undefined;
+  sortDirection: SortDirection | undefined;
+  clearSelection: () => void;
+  setSort: (column: string, direction: SortDirection) => void;
+};
+```
+
+**Example:**
+
+```typescript
+import { defineWidget, useTable, ui } from "@rezi-ui/core";
+
+type FileRow = { id: string; name: string; size: number };
+
+const FileTable = defineWidget<{ files: FileRow[]; key?: string }>(
+  (props, ctx) => {
+    const table = useTable(ctx, {
+      rows: props.files,
+      columns: [
+        { key: "name", header: "Name", flex: 1 },
+        { key: "size", header: "Size", width: 10, align: "right" },
+      ],
+      selectable: "multi",
+      sortable: true,
+    });
+
+    return ui.column({ gap: 1 }, [
+      ui.text(`${table.selection.length} selected`),
+      ui.table(table.props),
+    ]);
+  },
+);
+```
+
+---
+
+### `useModalStack`
+
+Manage a LIFO stack of modals with automatic focus restoration between layers.
+
+**Signature:**
+
+```typescript
+import { useModalStack, type UseModalStack } from "@rezi-ui/core";
+
+useModalStack<State = void>(ctx: WidgetContext<State>): UseModalStack
+```
+
+**Return value:**
+
+```typescript
+type UseModalStack = {
+  push: (id: string, props: Omit<ModalProps, "id">) => void;   // Push a new modal
+  pop: () => void;                                               // Remove top modal
+  clear: () => void;                                             // Remove all modals
+  current: () => string | null;                                  // ID of top modal
+  size: number;                                                  // Number of stacked modals
+  render: () => readonly VNode[];                                // Render all modals
+};
+```
+
+**Description:**
+
+- Modals are stacked in LIFO order; only the top modal captures focus.
+- When a modal is popped, focus returns to the first action button of the modal beneath it (or the element specified by `returnFocusTo`).
+- Each modal's `onClose` is automatically wired to `pop()` (or remove-by-id for non-top modals).
+- Keys are auto-versioned so `initialFocus` re-applies when a covered modal is revealed.
+
+**Example:**
+
+```typescript
+import { defineWidget, useModalStack, ui } from "@rezi-ui/core";
+
+const App = defineWidget<{ key?: string }>((props, ctx) => {
+  const modals = useModalStack(ctx);
+
+  const openConfirm = () => {
+    modals.push("confirm", {
+      title: "Confirm Action",
+      content: ui.text("Are you sure?"),
+      actions: [
+        ui.button({ id: "yes", label: "Yes", onPress: () => {
+          modals.pop();
+          performAction();
+        }}),
+        ui.button({ id: "no", label: "No", onPress: () => modals.pop() }),
+      ],
+    });
+  };
+
+  return ui.layers([
+    ui.column({ gap: 1 }, [
+      ui.button({ id: "open", label: "Open Dialog", onPress: openConfirm }),
+    ]),
+    ...modals.render(),
+  ]);
+});
+```
+
+---
+
+### `useForm`
+
+Full-featured form management hook with validation, touched/dirty tracking, submission, array fields, disabled/read-only state, and multi-step wizard support.
+
+**Signature:**
+
+```typescript
+import { useForm, type UseFormOptions, type UseFormReturn } from "@rezi-ui/core";
+
+useForm<T extends Record<string, unknown>, State = void>(
+  ctx: WidgetContext<State>,
+  options: UseFormOptions<T>,
+): UseFormReturn<T>
+```
+
+**Key options:**
+
+```typescript
+type UseFormOptions<T> = {
+  initialValues: T;                                         // Initial field values
+  validate?: (values: T) => Partial<Record<keyof T, string>>; // Sync validation
+  validateAsync?: (values: T) => Promise<ValidationResult<T>>; // Async validation
+  validateAsyncDebounce?: number;                           // Async debounce (default: 300ms)
+  validateOnChange?: boolean;                               // Validate on every change (default: false)
+  validateOnBlur?: boolean;                                 // Validate on blur (default: true)
+  onSubmit: (values: T) => void | Promise<void>;           // Submit handler
+  resetOnSubmit?: boolean;                                  // Reset after submit (default: false)
+  disabled?: boolean;                                       // Form-level disabled
+  readOnly?: boolean;                                       // Form-level read-only
+  fieldDisabled?: Partial<Record<keyof T, boolean>>;        // Per-field disabled overrides
+  fieldReadOnly?: Partial<Record<keyof T, boolean>>;        // Per-field read-only overrides
+  wizard?: { steps: FormWizardStep<T>[]; initialStep?: number }; // Multi-step wizard
+};
+```
+
+**Key return properties:**
+
+| Property | Type | Description |
+|----------|------|-------------|
+| `values` | `T` | Current form field values |
+| `errors` | `Partial<Record<keyof T, FieldErrorValue>>` | Validation errors by field |
+| `touched` | `Partial<Record<keyof T, FieldBooleanValue>>` | Which fields have been blurred |
+| `dirty` | `Partial<Record<keyof T, FieldBooleanValue>>` | Which fields differ from initial |
+| `isValid` | `boolean` | True if no validation errors |
+| `isDirty` | `boolean` | True if any field modified |
+| `isSubmitting` | `boolean` | True during async submission |
+| `bind(field)` | `UseFormInputBinding` | Spread-ready props for `ui.input(...)` |
+| `field(field, opts?)` | `VNode` | Fully wired `ui.field(...)` with child `ui.input(...)` |
+| `handleChange(field)` | `(value) => void` | Change handler factory |
+| `handleBlur(field)` | `() => void` | Blur handler factory |
+| `handleSubmit` | `() => void` | Submit (validates then calls `onSubmit`) |
+| `reset` | `() => void` | Reset to initial values |
+| `setFieldValue` | `(field, value) => void` | Programmatic field update |
+| `setFieldError` | `(field, error) => void` | Programmatic error |
+| `validateField` | `(field) => error` | Validate single field |
+| `validateForm` | `() => errors` | Validate all fields |
+| `useFieldArray(field)` | `UseFieldArrayReturn` | Dynamic array field helpers |
+| `nextStep` | `() => boolean` | Wizard: advance (validates current step) |
+| `previousStep` | `() => void` | Wizard: go back (no validation) |
+| `goToStep(index)` | `() => boolean` | Wizard: jump to step (validates forward) |
+
+**Example:**
+
+```typescript
+import { defineWidget, useForm, ui } from "@rezi-ui/core";
+
+type LoginForm = { username: string; password: string };
+
+const LoginWidget = defineWidget<{ key?: string }>((props, ctx) => {
+  const form = useForm<LoginForm>(ctx, {
+    initialValues: { username: "", password: "" },
+    validate: (values) => {
+      const errors: Partial<Record<keyof LoginForm, string>> = {};
+      if (values.username.length === 0) errors.username = "Required";
+      if (values.password.length < 8) errors.password = "Min 8 characters";
+      return errors;
+    },
+    onSubmit: async (values) => {
+      await login(values.username, values.password);
+    },
+  });
+
+  return ui.form([
+    // form.field() auto-wires label, error display, and input binding
+    form.field("username", { label: "Username", required: true }),
+    form.field("password", { label: "Password", required: true }),
+
+    ui.actions([
+      ui.button({
+        id: ctx.id("submit"),
+        label: form.isSubmitting ? "Submitting..." : "Log In",
+        onPress: form.handleSubmit,
+        disabled: form.isSubmitting,
+      }),
+    ]),
+  ]);
+});
+```
+
+**Array fields example:**
+
+```typescript
+const TagEditor = defineWidget<{ key?: string }>((props, ctx) => {
+  const form = useForm<{ tags: string[] }>(ctx, {
+    initialValues: { tags: ["default"] },
+    onSubmit: (values) => saveTags(values.tags),
+  });
+
+  const tags = form.useFieldArray("tags");
+
+  return ui.column({ gap: 1 }, [
+    ...tags.values.map((tag, i) =>
+      ui.row({ key: tags.keys[i], gap: 1 }, [
+        ui.text(tag),
+        ui.button({
+          id: ctx.id(`remove-${String(i)}`),
+          label: "X",
+          onPress: () => tags.remove(i),
+        }),
+      ]),
+    ),
+    ui.button({
+      id: ctx.id("add"),
+      label: "Add Tag",
+      onPress: () => tags.append("new-tag"),
+    }),
+  ]);
+});
+```
+
+---
+
+## Rules of Hooks
+
+Hooks have ordering requirements that must be followed for correct behavior:
+
+### 1. Call hooks in the same order every render
+
+Hooks are tracked by **call order**, not by name. You must never conditionally call a hook -- the sequence of hook calls must be identical on every render of a given widget instance.
+
+```typescript
+// WRONG -- conditional hook call
+const Widget = defineWidget<{ showExtra: boolean; key?: string }>((props, ctx) => {
+  const [count, setCount] = ctx.useState(0);
+  if (props.showExtra) {
+    const [extra, setExtra] = ctx.useState("");  // Hook order changes!
+  }
+  return ui.text(`${count}`);
+});
+
+// CORRECT -- always call, conditionally use
+const Widget = defineWidget<{ showExtra: boolean; key?: string }>((props, ctx) => {
+  const [count, setCount] = ctx.useState(0);
+  const [extra, setExtra] = ctx.useState("");    // Always called
+  return ui.column({}, [
+    ui.text(`${count}`),
+    props.showExtra && ui.text(extra),            // Conditionally render
+  ]);
+});
+```
+
+### 2. Only call hooks inside `defineWidget` render functions
+
+Hooks rely on the `WidgetContext` (`ctx`) which is only available inside the render function passed to `defineWidget`. Do not call hooks outside of this context.
+
+```typescript
+// WRONG -- hooks outside defineWidget
+function badHelper() {
+  const [x, setX] = ctx.useState(0);  // ctx is not available here
+}
+
+// CORRECT -- pass ctx explicitly for utility hooks
+function goodHelper(ctx: WidgetContext) {
+  return useDebounce(ctx, someValue, 300);
+}
+```
+
+### 3. Never call hooks in loops with variable iteration counts
+
+If the loop count can change between renders, the hook call count changes too.
+
+```typescript
+// WRONG -- variable loop count
+items.forEach((item) => {
+  const [selected, setSelected] = ctx.useState(false);
+});
+
+// CORRECT -- use a single state for the collection
+const [selected, setSelected] = ctx.useState<Set<string>>(new Set());
+```
+
+### 4. Utility hooks consume multiple hook slots
+
+Functions like `useDebounce`, `usePrevious`, `useAsync`, `useTable`, `useModalStack`, and `useForm` internally call multiple core hooks. Their position in the call sequence matters just like any other hook.
+
+### 5. Effect cleanup runs before re-execution
+
+When an effect's dependencies change, the cleanup function from the previous execution runs **before** the new effect runs. On unmount, all effect cleanups run. Always return cleanup functions for resources like timers, subscriptions, or abort controllers.
+
+```typescript
+ctx.useEffect(() => {
+  const controller = new AbortController();
+  fetch(url, { signal: controller.signal }).then(handleResponse);
+  return () => controller.abort();  // Cleanup on deps change or unmount
+}, [url]);
+```
+
+### 6. `ctx.id()` for scoped widget IDs
+
+Always use `ctx.id(suffix)` to generate interactive widget IDs inside `defineWidget`. This ensures each widget instance gets unique IDs that do not collide with other instances of the same widget.
+
+```typescript
+// Generates IDs like "Counter_0_inc", "Counter_1_inc" for different instances
+ui.button({ id: ctx.id("inc"), label: "+" })
+```

--- a/docs/guide/recommended-patterns.md
+++ b/docs/guide/recommended-patterns.md
@@ -1,0 +1,616 @@
+# Recommended Patterns
+
+This guide documents the best practices for building Rezi applications. These patterns are demonstrated in the `create-rezi` templates and have proven effective in production TUI apps.
+
+## App Structure
+
+Follow the template project layout to keep your app organized, testable, and maintainable:
+
+```
+my-tui-app/
+  src/
+    types.ts              # State type, action union, domain types
+    theme.ts              # Theme configuration and switching
+    helpers/
+      keybindings.ts      # Centralized key mappings
+      actions.ts          # Reducer and dispatch logic
+    screens/
+      main.ts             # Main screen view function
+      settings.ts         # Settings screen view function
+    widgets/
+      statusBar.ts        # Reusable custom widgets
+    index.ts              # App entry point (createNodeApp + wiring)
+  tsconfig.json
+  package.json
+```
+
+The entry point (`index.ts`) should be thin -- it creates the app, wires up keybindings, sets the view, and calls `app.run()`. All logic lives in the other modules.
+
+```typescript
+// src/index.ts
+import { createNodeApp } from "@rezi-ui/node";
+import type { State } from "./types.js";
+import { initialState } from "./helpers/actions.js";
+import { registerKeybindings } from "./helpers/keybindings.js";
+import { mainScreen } from "./screens/main.js";
+
+const app = createNodeApp<State>({ initialState });
+
+app.view(mainScreen(app));
+registerKeybindings(app);
+await app.run();
+```
+
+## State Management
+
+Use a **reducer pattern** with typed actions. This is the single most impactful pattern for keeping Rezi apps maintainable.
+
+### Define Types
+
+```typescript
+// src/types.ts
+export type Todo = { id: string; text: string; done: boolean };
+
+export type State = {
+  todos: Todo[];
+  selectedIndex: number;
+  filter: "all" | "active" | "done";
+  input: string;
+};
+
+export type Action =
+  | { type: "addTodo"; text: string }
+  | { type: "toggleTodo"; index: number }
+  | { type: "removeTodo"; index: number }
+  | { type: "setFilter"; filter: State["filter"] }
+  | { type: "setInput"; value: string }
+  | { type: "moveSelection"; direction: "up" | "down" };
+```
+
+### Implement the Reducer
+
+```typescript
+// src/helpers/actions.ts
+import type { State, Action } from "../types.js";
+
+export const initialState: State = {
+  todos: [],
+  selectedIndex: 0,
+  filter: "all",
+  input: "",
+};
+
+export function reduce(state: State, action: Action): State {
+  switch (action.type) {
+    case "addTodo":
+      if (!action.text.trim()) return state;
+      return {
+        ...state,
+        todos: [...state.todos, { id: Date.now().toString(), text: action.text.trim(), done: false }],
+        input: "",
+      };
+
+    case "toggleTodo":
+      return {
+        ...state,
+        todos: state.todos.map((t, i) =>
+          i === action.index ? { ...t, done: !t.done } : t
+        ),
+      };
+
+    case "removeTodo":
+      return {
+        ...state,
+        todos: state.todos.filter((_, i) => i !== action.index),
+        selectedIndex: Math.min(state.selectedIndex, state.todos.length - 2),
+      };
+
+    case "setFilter":
+      return { ...state, filter: action.filter, selectedIndex: 0 };
+
+    case "setInput":
+      return { ...state, input: action.value };
+
+    case "moveSelection": {
+      const maxIndex = state.todos.length - 1;
+      const delta = action.direction === "up" ? -1 : 1;
+      return {
+        ...state,
+        selectedIndex: Math.max(0, Math.min(state.selectedIndex + delta, maxIndex)),
+      };
+    }
+  }
+}
+
+export function createDispatch(app: { update: (fn: (s: State) => State) => void }) {
+  return function dispatch(action: Action) {
+    app.update(s => reduce(s, action));
+  };
+}
+```
+
+Benefits of this approach:
+
+- **Testable** -- `reduce()` is a pure function; test it with plain assertions, no UI needed
+- **Predictable** -- Every state transition is an explicit action
+- **Debuggable** -- Log dispatched actions to trace what happened
+- **Composable** -- Multiple UI elements (buttons, keys, modes) dispatch the same actions
+
+## Screen Architecture
+
+Each screen is a **pure view function** that takes state and returns a VNode tree. Screens should not call `app.update()` directly; they receive a dispatch function or wire callbacks through props.
+
+```typescript
+// src/screens/main.ts
+import { ui, rgb } from "@rezi-ui/core";
+import type { App } from "@rezi-ui/core";
+import type { State, Action } from "../types.js";
+import { reduce } from "../helpers/actions.js";
+
+export function mainScreen(app: App<State>) {
+  const dispatch = (action: Action) => app.update(s => reduce(s, action));
+
+  return (state: State) => {
+    const { todos, selectedIndex, filter, input } = state;
+    const filtered = todos.filter(t =>
+      filter === "all" ? true : filter === "active" ? !t.done : t.done
+    );
+
+    return ui.column({ p: 1, gap: 1 }, [
+      // Header
+      ui.text("Todo List", { style: { fg: rgb(120, 200, 255), bold: true } }),
+
+      // Filter tabs
+      ui.row({ gap: 2 }, [
+        ui.button({
+          id: "filter-all",
+          label: filter === "all" ? "[All]" : "All",
+          onPress: () => dispatch({ type: "setFilter", filter: "all" }),
+        }),
+        ui.button({
+          id: "filter-active",
+          label: filter === "active" ? "[Active]" : "Active",
+          onPress: () => dispatch({ type: "setFilter", filter: "active" }),
+        }),
+        ui.button({
+          id: "filter-done",
+          label: filter === "done" ? "[Done]" : "Done",
+          onPress: () => dispatch({ type: "setFilter", filter: "done" }),
+        }),
+      ]),
+
+      // Todo items
+      ui.box({ title: `Items (${filtered.length})`, p: 1 }, [
+        filtered.length === 0
+          ? ui.text("No items", { style: { dim: true } })
+          : ui.column(
+              { gap: 0 },
+              filtered.map((todo, i) =>
+                ui.text(
+                  `${i === selectedIndex ? "> " : "  "}${todo.done ? "[x]" : "[ ]"} ${todo.text}`,
+                  { key: todo.id, style: { dim: todo.done } }
+                )
+              ),
+            ),
+      ]),
+
+      // Input row
+      ui.row({ gap: 1 }, [
+        ui.input({
+          id: "new-todo",
+          value: input,
+          onInput: v => dispatch({ type: "setInput", value: v }),
+        }),
+        ui.button({
+          id: "add",
+          label: "Add",
+          onPress: () => dispatch({ type: "addTodo", text: input }),
+        }),
+      ]),
+    ]);
+  };
+}
+```
+
+Notice that `mainScreen()` returns a closure. The outer function captures `app` for dispatch wiring; the inner function is the pure view that receives state each render.
+
+## Widget Composition
+
+Use `ui.*` for built-in widgets and `defineWidget()` for reusable custom components with local state.
+
+### Simple Composition (No Local State)
+
+For stateless reusable pieces, plain functions returning VNodes are sufficient:
+
+```typescript
+// src/widgets/header.ts
+import { ui, rgb } from "@rezi-ui/core";
+
+export function header(title: string, subtitle?: string) {
+  return ui.column({ gap: 0 }, [
+    ui.text(title, { style: { fg: rgb(120, 200, 255), bold: true } }),
+    ...(subtitle ? [ui.text(subtitle, { style: { dim: true } })] : []),
+    ui.divider(),
+  ]);
+}
+```
+
+### Stateful Widgets with `defineWidget()`
+
+When a component needs its own local state, use `defineWidget()`:
+
+```typescript
+// src/widgets/toggleSection.ts
+import { defineWidget, ui } from "@rezi-ui/core";
+
+type ToggleSectionProps = {
+  title: string;
+  children: VNode[];
+  key?: string;
+};
+
+export const ToggleSection = defineWidget<ToggleSectionProps>(
+  (props, ctx) => {
+    const [expanded, setExpanded] = ctx.useState(true);
+
+    return ui.column({ gap: 0 }, [
+      ui.button({
+        id: ctx.id("toggle"),
+        label: `${expanded ? "v" : ">"} ${props.title}`,
+        onPress: () => setExpanded(prev => !prev),
+      }),
+      ...(expanded ? props.children : []),
+    ]);
+  },
+  { name: "ToggleSection" }
+);
+
+// Usage:
+ui.column([
+  ToggleSection({
+    title: "Details",
+    children: [
+      ui.text("Line 1"),
+      ui.text("Line 2"),
+    ],
+  }),
+]);
+```
+
+Key rules for `defineWidget()`:
+
+- Use `ctx.id("suffix")` for all interactive widget IDs to prevent collisions between instances
+- Hooks must be called in the same order every render (no conditional hooks)
+- Use `ctx.useAppState()` to read app-level state from within a widget
+
+## Error Handling
+
+### Error Boundaries
+
+Wrap risky subtrees with `ui.errorBoundary()` to prevent one broken widget from crashing your entire app:
+
+```typescript
+ui.errorBoundary({
+  children: RiskyWidget({ data }),
+  fallback: error =>
+    ui.column({}, [
+      ui.errorDisplay(error.message, { title: error.code }),
+      ui.button({ id: "retry", label: "Retry", onPress: error.retry }),
+    ]),
+})
+```
+
+### Application-Level Error Handling
+
+Use `app.onEvent()` to handle errors and other events at the app level:
+
+```typescript
+app.onEvent(event => {
+  if (event.type === "error") {
+    app.update(s => ({
+      ...s,
+      lastError: event.message,
+      showErrorToast: true,
+    }));
+  }
+});
+```
+
+### Defensive State Updates
+
+Guard your reducer against invalid states:
+
+```typescript
+case "removeTodo": {
+  const newTodos = state.todos.filter((_, i) => i !== action.index);
+  return {
+    ...state,
+    todos: newTodos,
+    selectedIndex: Math.max(0, Math.min(state.selectedIndex, newTodos.length - 1)),
+  };
+}
+```
+
+## Keybindings
+
+### Centralize Keybindings
+
+Keep all key mappings in a single file for discoverability and testability:
+
+```typescript
+// src/helpers/keybindings.ts
+import type { App } from "@rezi-ui/core";
+import type { State, Action } from "../types.js";
+import { reduce } from "./actions.js";
+
+export function registerKeybindings(app: App<State>) {
+  const dispatch = (action: Action) => app.update(s => reduce(s, action));
+
+  app.keys({
+    // Navigation
+    j: () => dispatch({ type: "moveSelection", direction: "down" }),
+    k: () => dispatch({ type: "moveSelection", direction: "up" }),
+
+    // Actions
+    space: () =>
+      app.update(s => reduce(s, { type: "toggleTodo", index: s.selectedIndex })),
+    d: () =>
+      app.update(s => reduce(s, { type: "removeTodo", index: s.selectedIndex })),
+
+    // Filters
+    "1": () => dispatch({ type: "setFilter", filter: "all" }),
+    "2": () => dispatch({ type: "setFilter", filter: "active" }),
+    "3": () => dispatch({ type: "setFilter", filter: "done" }),
+
+    // App
+    q: () => app.stop(),
+    "ctrl+c": () => app.stop(),
+  });
+}
+```
+
+### Use `app.modes()` for Vim-Style Input
+
+When your app has distinct input modes (e.g., normal vs. insert):
+
+```typescript
+app.modes({
+  normal: {
+    i: () => app.setMode("insert"),
+    "/": () => app.setMode("search"),
+    j: () => dispatch({ type: "moveSelection", direction: "down" }),
+    k: () => dispatch({ type: "moveSelection", direction: "up" }),
+  },
+  insert: {
+    escape: () => app.setMode("normal"),
+  },
+  search: {
+    escape: () => app.setMode("normal"),
+    enter: () => dispatch({ type: "executeSearch" }),
+  },
+});
+```
+
+### Show Keybinding Help
+
+Display available keybindings in the UI so users can discover them:
+
+```typescript
+ui.text("j/k: navigate | space: toggle | d: delete | q: quit", {
+  style: { fg: rgb(100, 100, 100) },
+})
+```
+
+## Testing
+
+The reducer + pure screen architecture makes testing straightforward. Test each layer independently.
+
+### Test the Reducer
+
+```typescript
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { reduce, initialState } from "./helpers/actions.js";
+
+describe("reduce", () => {
+  it("adds a todo", () => {
+    const next = reduce(initialState, { type: "addTodo", text: "Buy milk" });
+    assert.equal(next.todos.length, 1);
+    assert.equal(next.todos[0].text, "Buy milk");
+    assert.equal(next.todos[0].done, false);
+  });
+
+  it("ignores empty text", () => {
+    const next = reduce(initialState, { type: "addTodo", text: "   " });
+    assert.equal(next.todos.length, 0);
+  });
+
+  it("toggles a todo", () => {
+    const withTodo = reduce(initialState, { type: "addTodo", text: "Test" });
+    const toggled = reduce(withTodo, { type: "toggleTodo", index: 0 });
+    assert.equal(toggled.todos[0].done, true);
+  });
+
+  it("clamps selection after removal", () => {
+    let state = reduce(initialState, { type: "addTodo", text: "A" });
+    state = reduce(state, { type: "addTodo", text: "B" });
+    state = { ...state, selectedIndex: 1 };
+    state = reduce(state, { type: "removeTodo", index: 1 });
+    assert.equal(state.selectedIndex, 0);
+  });
+});
+```
+
+### Test Screen Functions
+
+Screen view functions are pure -- pass in state, assert the returned VNode tree:
+
+```typescript
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+import { mainScreen } from "./screens/main.js";
+
+describe("mainScreen", () => {
+  it("shows empty message when no todos", () => {
+    // Create a mock app for wiring
+    const updates: Array<(s: State) => State> = [];
+    const mockApp = { update: (fn: any) => updates.push(fn) } as any;
+
+    const view = mainScreen(mockApp);
+    const tree = view({ todos: [], selectedIndex: 0, filter: "all", input: "" });
+
+    // Assert tree structure -- inspect the VNode tree
+    assert.equal(tree.kind, "column");
+  });
+});
+```
+
+### Test Keybindings
+
+Verify that keybindings dispatch the expected actions:
+
+```typescript
+import { describe, it } from "node:test";
+import assert from "node:assert/strict";
+
+describe("keybindings", () => {
+  it("dispatches moveSelection on j/k", () => {
+    const updates: Array<(s: State) => State> = [];
+    const mockApp = {
+      update: (fn: any) => updates.push(fn),
+      keys: (bindings: any) => { /* store bindings for testing */ },
+      stop: () => {},
+    } as any;
+
+    registerKeybindings(mockApp);
+    // Verify the correct bindings were registered
+  });
+});
+```
+
+## Theming
+
+### Use Built-in Themes
+
+Rezi ships with a default theme. Pass a custom theme or theme definition to `createNodeApp()`:
+
+```typescript
+import { createNodeApp } from "@rezi-ui/node";
+import type { ThemeDefinition } from "@rezi-ui/core";
+
+const darkTheme: ThemeDefinition = {
+  colors: {
+    fg: { r: 220, g: 220, b: 220 },
+    bg: { r: 20, g: 20, b: 30 },
+    primary: { r: 100, g: 180, b: 255 },
+    secondary: { r: 180, g: 100, b: 255 },
+    success: { r: 100, g: 220, b: 100 },
+    danger: { r: 255, g: 100, b: 100 },
+    warning: { r: 255, g: 200, b: 50 },
+    info: { r: 100, g: 200, b: 255 },
+    muted: { r: 100, g: 100, b: 100 },
+    border: { r: 60, g: 60, b: 80 },
+  },
+};
+
+const app = createNodeApp<State>({
+  initialState,
+  theme: darkTheme,
+});
+```
+
+### Theme Switching
+
+Store the active theme in state and recreate the theme object:
+
+```typescript
+// src/theme.ts
+import type { ThemeDefinition } from "@rezi-ui/core";
+
+export const themes = {
+  dark: { colors: { /* ... */ } } satisfies ThemeDefinition,
+  light: { colors: { /* ... */ } } satisfies ThemeDefinition,
+  solarized: { colors: { /* ... */ } } satisfies ThemeDefinition,
+} as const;
+
+export type ThemeName = keyof typeof themes;
+```
+
+### NO_COLOR Support
+
+`createNodeApp()` automatically detects the `NO_COLOR` environment variable and strips colors from the theme. You do not need to handle this manually.
+
+## Performance
+
+### Use `useMemo` for Expensive Computations
+
+Inside `defineWidget()`, wrap expensive filtering or sorting with `ctx.useMemo()`:
+
+```typescript
+const filtered = ctx.useMemo(
+  () => items.filter(item => matchesQuery(item, query)).sort(compareFn),
+  [items, query]
+);
+```
+
+### Provide `key` for Dynamic Lists
+
+Always use `key` when rendering lists derived from data. This allows Rezi's reconciler to match items efficiently and preserve widget state:
+
+```typescript
+// Good: keyed list
+ui.column(
+  items.map(item => ui.text(item.name, { key: item.id }))
+)
+
+// Bad: unkeyed list (reconciler falls back to index matching)
+ui.column(
+  items.map(item => ui.text(item.name))
+)
+```
+
+### Use `ui.virtualList()` for Large Data Sets
+
+For lists with hundreds or thousands of items, use `ui.virtualList()` to only render the visible portion:
+
+```typescript
+ui.virtualList<LogEntry>({
+  id: "log-view",
+  items: logEntries,           // Can be thousands of items
+  itemHeight: 1,               // Each item is 1 row tall
+  height: 20,                  // Visible viewport is 20 rows
+  renderItem: (entry, index) =>
+    ui.text(`[${entry.timestamp}] ${entry.message}`, {
+      key: entry.id,
+      style: { fg: levelColor(entry.level) },
+    }),
+})
+```
+
+### Minimize State Size
+
+Keep your state flat and minimal. Deeply nested state leads to more spread operations and harder-to-maintain reducers. Extract computed values in the view function rather than storing them in state.
+
+### Batch Related Updates
+
+Multiple `app.update()` calls in the same tick are batched into a single re-render. You do not need to combine them manually:
+
+```typescript
+// These produce a single re-render
+dispatch({ type: "setFilter", filter: "active" });
+dispatch({ type: "moveSelection", direction: "up" });
+```
+
+## Summary
+
+| Pattern | Why |
+|---------|-----|
+| Template project structure | Separation of concerns, testability |
+| Reducer with typed actions | Pure, testable, debuggable state logic |
+| Pure screen view functions | Predictable rendering, easy to test |
+| `ui.*` + `defineWidget()` | Type-safe composition with local state |
+| `ui.errorBoundary()` | Graceful failure isolation |
+| Centralized keybindings | Discoverable, testable, no duplication |
+| Separate reducer/screen/keybinding tests | Fast, focused, no UI harness needed |
+| Theme definitions | Consistent styling, NO_COLOR support |
+| `useMemo`, keys, `virtualList` | Efficient rendering at scale |

--- a/docs/widgets/index.md
+++ b/docs/widgets/index.md
@@ -1,225 +1,528 @@
-# Widget Catalog
+# Widget API Reference
 
-Rezi provides a broad built-in widget catalog for building terminal UIs. Widgets are plain TypeScript functions that return VNode objects.
+Rezi ships a comprehensive built-in widget catalog. Every widget is a plain TypeScript function that returns a `VNode` -- the virtual-DOM node Rezi reconciles, lays out, and renders to the terminal.
+
+## Recommended Approach: `ui.*` Factory Functions
+
+Always build your views through the `ui` namespace. These factories are the **safest, highest-level API** and are the only surface covered by deterministic VNode contract tests.
 
 ```typescript
+import { ui } from "@rezi-ui/core";
+
 app.view((state) =>
-  ui.column({ gap: 1 }, [
+  ui.column({ p: 1, gap: 1 }, [
     ui.text("Hello, World!"),
     ui.button({ id: "ok", label: "OK" }),
   ])
 );
 ```
 
-High-level composition helpers are available on `ui`:
+Benefits of `ui.*` factories:
 
-- `ui.panel(...)`
-- `ui.form(...)`
-- `ui.actions(...)`
-- `ui.center(...)`
-- `ui.page(...)`
+- Proper VNode construction with correct `kind` discriminants.
+- Automatic filtering of `null`, `false`, and `undefined` children.
+- Automatic flattening of nested child arrays.
+- Default `gap: 1` applied to `row`/`column`/`hstack`/`vstack` when omitted.
+- Interactive widget props validated before layout (e.g. `button` requires non-empty `id`).
 
-## Stability
-
-Widget stability tiers and guarantees are documented in [Widget Stability](stability.md).
-
-Tier labels used in this catalog:
-
-- `stable`: semver-protected behavior contract with deterministic regression tests.
-- `beta`: core invariants are tested; contract may evolve.
-- `experimental`: no compatibility guarantees.
-
-## Widget Categories
-
-### Primitives
-
-Foundation widgets for layout and content:
-
-| Widget | Description | Focusable | Stability |
-|--------|-------------|-----------|-----------|
-| [Text](text.md) | Display text with optional styling | No | `stable` |
-| [Box](box.md) | Container with border, padding, and title | No | `stable` |
-| [Row / Column](stack.md) | Horizontal and vertical stack layouts | No | `stable` |
-| [Spacer](spacer.md) | Fixed-size or flexible spacing | No | `stable` |
-| [Divider](divider.md) | Visual separator line | No | `stable` |
-
-### Indicators
-
-Visual feedback and status display:
-
-| Widget | Description | Focusable | Stability |
-|--------|-------------|-----------|-----------|
-| [Icon](icon.md) | Single-character icon from registry | No | `beta` |
-| [Spinner](spinner.md) | Animated loading indicator | No | `beta` |
-| [Progress](progress.md) | Progress bar with variants | No | `beta` |
-| [Skeleton](skeleton.md) | Loading placeholder | No | `beta` |
-| [RichText](rich-text.md) | Multi-styled text spans | No | `beta` |
-| [Kbd](kbd.md) | Keyboard shortcut display | No | `beta` |
-| [Badge](badge.md) | Small status indicator | No | `beta` |
-| [Status](status.md) | Online/offline status dot | No | `beta` |
-| [Tag](tag.md) | Inline label with background | No | `beta` |
-
-### Form Inputs
-
-Interactive form controls:
-
-| Widget | Description | Focusable | Stability |
-|--------|-------------|-----------|-----------|
-| [Button](button.md) | Clickable button with label | Yes | `beta` |
-| [Input](input.md) | Single-line text input | Yes | `stable` |
-| [Textarea](textarea.md) | Multi-line text input | Yes | `beta` |
-| [Slider](slider.md) | Numeric range input | Yes | `beta` |
-| [Checkbox](checkbox.md) | Toggle checkbox | Yes | `beta` |
-| [Radio Group](radio-group.md) | Single-select options | Yes | `beta` |
-| [Select](select.md) | Dropdown selection | Yes | `beta` |
-| [Field](field.md) | Form field wrapper with label/error | No | `beta` |
-
-### Navigation
-
-Navigation and wayfinding widgets:
-
-| Widget | Description | Focusable | Stability |
-|--------|-------------|-----------|-----------|
-| [Tabs](tabs.md) | Switch between related content panels | Yes | `beta` |
-| [Accordion](accordion.md) | Expand/collapse stacked sections | Yes | `beta` |
-| [Breadcrumb](breadcrumb.md) | Hierarchical location path with jumps | Optional (`id`) | `beta` |
-| [Link](link.md) | Hyperlink text with optional press behavior | Optional (`id`) | `beta` |
-| [Pagination](pagination.md) | Navigate paged datasets | Yes | `beta` |
-
-### Data Display
-
-Tables, lists, and trees:
-
-| Widget | Description | Focusable | Stability |
-|--------|-------------|-----------|-----------|
-| [Table](table.md) | Tabular data with sorting and selection | Yes | `stable` |
-| [Virtual List](virtual-list.md) | Efficiently render large lists | Yes | `stable` |
-| [Tree](tree.md) | Hierarchical data with expand/collapse | Yes | `beta` |
-
-### Overlays
-
-Modal and popup interfaces:
-
-| Widget | Description | Focusable | Stability |
-|--------|-------------|-----------|-----------|
-| [Layers](layers.md) | Layer stack container | No | `beta` |
-| [Modal](modal.md) | Centered modal dialog | Yes | `beta` |
-| [Dropdown](dropdown.md) | Positioned dropdown menu | Yes | `beta` |
-| [Layer](layer.md) | Generic overlay layer | Yes | `beta` |
-| [Toast Container](toast.md) | Non-blocking notifications | No | `beta` |
-| [Focus Announcer](focus-announcer.md) | Live text summary of the current focused widget | No | `beta` |
-| [Focus Zone](focus-zone.md) | Focus group for Tab navigation | Yes | `beta` |
-| [Focus Trap](focus-trap.md) | Constrain focus to region | Yes | `beta` |
+## Quick-Reference Table
 
 ### Layout
 
-Complex layout components:
+Container and spacing primitives for arranging widgets.
 
-| Widget | Description | Focusable | Stability |
-|--------|-------------|-----------|-----------|
-| [Grid](grid.md) | Two-dimensional grid layout | No | `stable` |
-| [Split Pane](split-pane.md) | Resizable split layout | Yes | `beta` |
-| [Panel Group](panel-group.md) | Container for resizable panels | Yes | `beta` |
-| [Resizable Panel](resizable-panel.md) | Panel within group | No | `beta` |
+| Factory | Description | Focusable | Stability |
+|---------|-------------|-----------|-----------|
+| [`ui.box(props, children)`](box.md) | Container with border, padding, title | No | `stable` |
+| [`ui.row(props, children)`](stack.md) | Horizontal stack layout | No | `stable` |
+| [`ui.column(props, children)`](stack.md) | Vertical stack layout | No | `stable` |
+| [`ui.hstack(...)`](stack.md) | Shorthand horizontal stack (accepts gap number, props, or just children) | No | `stable` |
+| [`ui.vstack(...)`](stack.md) | Shorthand vertical stack (accepts gap number, props, or just children) | No | `stable` |
+| [`ui.grid(props, ...children)`](grid.md) | Two-dimensional grid layout | No | `stable` |
+| [`ui.spacer(props?)`](spacer.md) | Fixed-size or flexible spacing | No | `stable` |
+| [`ui.divider(props?)`](divider.md) | Visual separator line | No | `stable` |
+| [`ui.layers(children)` / `ui.layers(props, children)`](layers.md) | Layer stack container (z-ordering) | No | `beta` |
+| [`ui.splitPane(props, children)`](split-pane.md) | Resizable split layout with draggable dividers | Yes | `beta` |
+| [`ui.panelGroup(props, children)`](panel-group.md) | Container for resizable panels | Yes | `beta` |
+| [`ui.resizablePanel(props?, children?)`](resizable-panel.md) | Panel within a panel group | No | `beta` |
 
-### Advanced
+> **Convenience aliases:** `ui.spacedVStack(children)` and `ui.spacedHStack(children)` are shorthand for `vstack`/`hstack` with a default gap. They also accept an explicit gap number as the first argument: `ui.spacedVStack(2, children)`.
 
-Rich, specialized widgets:
+**Quick example:**
 
-| Widget | Description | Focusable | Stability |
-|--------|-------------|-----------|-----------|
-| [Command Palette](command-palette.md) | Quick command search | Yes | `stable` |
-| [File Picker](file-picker.md) | File browser with selection | Yes | `stable` |
-| [File Tree Explorer](file-tree-explorer.md) | File system tree view | Yes | `stable` |
-| [Code Editor](code-editor.md) | Multi-line code editing | Yes | `beta` |
-| [Diff Viewer](diff-viewer.md) | Unified/side-by-side diff | Yes | `beta` |
-| [Logs Console](logs-console.md) | Streaming log output | Yes | `beta` |
-| [Tool Approval Dialog](tool-approval-dialog.md) | Tool execution review | Yes | `experimental` |
+```typescript
+ui.column({ p: 1, gap: 1 }, [
+  ui.text("Title", { variant: "heading" }),
+  ui.row({ gap: 2 }, [
+    ui.button({ id: "ok", label: "OK" }),
+    ui.button({ id: "cancel", label: "Cancel" }),
+  ]),
+])
+```
+
+### Text & Display
+
+Content rendering, labels, and informational widgets.
+
+| Factory | Description | Focusable | Stability |
+|---------|-------------|-----------|-----------|
+| [`ui.text(content, style?)`](text.md) | Display text with optional styling or variant | No | `stable` |
+| [`ui.richText(spans, props?)`](rich-text.md) | Multi-styled text spans | No | `beta` |
+| [`ui.icon(iconPath, props?)`](icon.md) | Single-character icon from the icon registry | No | `beta` |
+| [`ui.badge(text, props?)`](badge.md) | Small status indicator label | No | `beta` |
+| [`ui.status(status, props?)`](status.md) | Online/offline/away/busy status dot | No | `beta` |
+| [`ui.tag(text, props?)`](tag.md) | Inline label with background | No | `beta` |
+| [`ui.kbd(keys, props?)`](kbd.md) | Keyboard shortcut display | No | `beta` |
+| [`ui.empty(title, props?)`](empty.md) | Empty state placeholder with optional icon/action | No | `beta` |
+| [`ui.callout(message, props?)`](callout.md) | Alert/info message box with variants | No | `beta` |
+| [`ui.errorDisplay(message, props?)`](error-display.md) | Error message with optional retry | No | `beta` |
+| [`ui.errorBoundary(props)`](error-boundary.md) | Isolates subtree runtime errors with fallback UI | No | `beta` |
+
+**Quick example:**
+
+```typescript
+ui.column({ gap: 1 }, [
+  ui.richText([
+    { text: "Error: ", style: { fg: { r: 255, g: 0, b: 0 }, bold: true } },
+    { text: "File not found" },
+  ]),
+  ui.callout("This action cannot be undone", { variant: "warning" }),
+  ui.badge("New", { variant: "info" }),
+])
+```
+
+### Indicators
+
+Visual feedback for loading, progress, and data density.
+
+| Factory | Description | Focusable | Stability |
+|---------|-------------|-----------|-----------|
+| [`ui.spinner(props?)`](spinner.md) | Animated loading indicator | No | `beta` |
+| [`ui.progress(value, props?)`](progress.md) | Progress bar (value 0-1) with variants | No | `beta` |
+| [`ui.skeleton(width, props?)`](skeleton.md) | Loading placeholder | No | `beta` |
+| [`ui.gauge(value, props?)`](gauge.md) | Compact progress gauge with label and thresholds | No | `beta` |
+
+**Quick example:**
+
+```typescript
+ui.column({ gap: 1 }, [
+  ui.spinner({ variant: "dots", label: "Loading..." }),
+  ui.progress(0.75, { showPercent: true }),
+  ui.gauge(0.42, { label: "CPU" }),
+])
+```
 
 ### Charts
 
-Data visualization:
+Data visualization for terminal dashboards.
 
-| Widget | Description | Focusable | Stability |
-|--------|-------------|-----------|-----------|
-| [Gauge](gauge.md) | Compact progress with label | No | `beta` |
-| [Sparkline](sparkline.md) | Inline mini chart | No | `beta` |
-| [Bar Chart](bar-chart.md) | Horizontal/vertical bars | No | `beta` |
-| [Mini Chart](mini-chart.md) | Compact multi-value display | No | `beta` |
+| Factory | Description | Focusable | Stability |
+|---------|-------------|-----------|-----------|
+| [`ui.sparkline(data, props?)`](sparkline.md) | Inline mini chart using block characters | No | `beta` |
+| [`ui.barChart(data, props?)`](bar-chart.md) | Horizontal/vertical bar chart | No | `beta` |
+| [`ui.miniChart(values, props?)`](mini-chart.md) | Compact multi-value display | No | `beta` |
+| [`ui.lineChart(props)`](line-chart.md) | Multi-series line visualization (canvas-based) | No | `beta` |
+| [`ui.scatter(props)`](scatter.md) | Cartesian scatter plot (canvas-based) | No | `beta` |
+| [`ui.heatmap(props)`](heatmap.md) | Matrix heat map with color scales (canvas-based) | No | `beta` |
+
+**Quick example:**
+
+```typescript
+ui.row({ gap: 2 }, [
+  ui.sparkline([10, 20, 15, 30, 25], { width: 10 }),
+  ui.barChart([
+    { label: "TypeScript", value: 60 },
+    { label: "JavaScript", value: 30 },
+    { label: "Python", value: 10 },
+  ], { showValues: true }),
+])
+```
+
+### Input & Forms
+
+Interactive form controls. All form widgets require an `id` prop for focus management.
+
+| Factory | Description | Focusable | Stability |
+|---------|-------------|-----------|-----------|
+| [`ui.button(id, label)` / `ui.button(props)`](button.md) | Clickable button with label | Yes | `beta` |
+| [`ui.input(id, value)` / `ui.input(props)`](input.md) | Single-line text input | Yes | `stable` |
+| [`ui.textarea(props)`](textarea.md) | Multi-line text input (multiline input variant) | Yes | `beta` |
+| [`ui.slider(props)`](slider.md) | Numeric range input | Yes | `beta` |
+| [`ui.checkbox(props)`](checkbox.md) | Toggle checkbox | Yes | `beta` |
+| [`ui.radioGroup(props)`](radio-group.md) | Single-select option group | Yes | `beta` |
+| [`ui.select(props)`](select.md) | Dropdown selection | Yes | `beta` |
+| [`ui.field(props)`](field.md) | Form field wrapper with label, error, and hint | No | `beta` |
+
+**Quick example:**
+
+```typescript
+ui.form([
+  ui.field({
+    label: "Username",
+    required: true,
+    error: errors.username,
+    children: ui.input("username", state.username, {
+      onInput: (v) => app.update({ username: v }),
+    }),
+  }),
+  ui.checkbox({
+    id: "remember",
+    checked: state.remember,
+    label: "Remember me",
+    onChange: (c) => app.update({ remember: c }),
+  }),
+  ui.actions([
+    ui.button("submit", "Submit", {
+      onPress: () => handleSubmit(),
+    }),
+  ]),
+])
+```
+
+### Navigation
+
+Widgets for navigating between views, sections, and pages.
+
+| Factory | Description | Focusable | Stability |
+|---------|-------------|-----------|-----------|
+| [`ui.tabs(props)`](tabs.md) | Tab switcher with scoped content | Yes | `beta` |
+| [`ui.accordion(props)`](accordion.md) | Expand/collapse stacked sections | Yes | `beta` |
+| [`ui.breadcrumb(props)`](breadcrumb.md) | Hierarchical location path with jumps | Optional (`id`) | `beta` |
+| [`ui.link(url, label?)` / `ui.link(props)`](link.md) | Hyperlink text with optional press behavior | Optional (`id`) | `beta` |
+| [`ui.pagination(props)`](pagination.md) | Navigate paged datasets | Yes | `beta` |
+| [`ui.routerBreadcrumb(router, routes, props?)`](router-breadcrumb.md) | Breadcrumbs derived from current router history | No | `beta` |
+| [`ui.routerTabs(router, routes, props?)`](router-tabs.md) | Tabs derived from registered routes with current route selection | No | `beta` |
+
+**Quick example:**
+
+```typescript
+ui.tabs({
+  id: "main-tabs",
+  tabs: [
+    { key: "overview", label: "Overview", content: OverviewPanel() },
+    { key: "details", label: "Details", content: DetailsPanel() },
+    { key: "logs", label: "Logs", content: LogsPanel() },
+  ],
+  activeTab: state.activeTab,
+  onChange: (tab) => app.update({ activeTab: tab }),
+})
+```
+
+### Data
+
+Tables, lists, and trees for structured data display.
+
+| Factory | Description | Focusable | Stability |
+|---------|-------------|-----------|-----------|
+| [`ui.table(props)`](table.md) | Tabular data with sorting, selection, virtualization | Yes | `stable` |
+| [`ui.virtualList(props)`](virtual-list.md) | Efficiently render large lists with virtualized scrolling | Yes | `stable` |
+| [`ui.tree(props)`](tree.md) | Hierarchical data with expand/collapse and selection | Yes | `beta` |
+
+**Quick example:**
+
+```typescript
+ui.table({
+  id: "files",
+  columns: [
+    { key: "name", header: "Name", flex: 1, sortable: true },
+    { key: "size", header: "Size", width: 10, align: "right" },
+  ],
+  data: files,
+  getRowKey: (f) => f.id,
+  selection: state.selected,
+  selectionMode: "multi",
+  onSelectionChange: (keys) => app.update({ selected: keys }),
+})
+```
+
+### Overlays
+
+Modal dialogs, dropdown menus, toast notifications, and focus management.
+
+| Factory | Description | Focusable | Stability |
+|---------|-------------|-----------|-----------|
+| [`ui.modal(props)`](modal.md) | Centered modal dialog with backdrop and focus trap | Yes | `beta` |
+| [`ui.dialog(props)`](modal.md) | Declarative dialog sugar over modal (multi-action) | Yes | `beta` |
+| [`ui.dropdown(props)`](dropdown.md) | Positioned dropdown menu with auto-flip | Yes | `beta` |
+| [`ui.layer(props)`](layer.md) | Generic overlay layer with z-order control | Yes | `beta` |
+| [`ui.toastContainer(props)`](toast.md) | Non-blocking notification stack | No | `beta` |
+| [`ui.commandPalette(props)`](command-palette.md) | Quick command search with async sources | Yes | `stable` |
+| [`ui.focusZone(props, children?)`](focus-zone.md) | Focus group for Tab navigation | Yes | `beta` |
+| [`ui.focusTrap(props, children?)`](focus-trap.md) | Constrain focus to region | Yes | `beta` |
+| [`ui.focusAnnouncer(props?)`](focus-announcer.md) | Live text summary of the currently focused widget | No | `beta` |
+
+**Quick example:**
+
+```typescript
+ui.layers([
+  MainContent(),
+  state.showConfirm && ui.dialog({
+    id: "confirm",
+    title: "Confirm Delete",
+    message: "Are you sure you want to delete this item?",
+    actions: [
+      { label: "Delete", intent: "danger", onPress: () => deleteItem() },
+      { label: "Cancel", onPress: () => app.update({ showConfirm: false }) },
+    ],
+    onClose: () => app.update({ showConfirm: false }),
+  }),
+])
+```
+
+### Advanced
+
+Rich, specialized widgets for IDE-like experiences.
+
+| Factory | Description | Focusable | Stability |
+|---------|-------------|-----------|-----------|
+| [`ui.codeEditor(props)`](code-editor.md) | Multi-line code editing with selections, undo/redo | Yes | `beta` |
+| [`ui.diffViewer(props)`](diff-viewer.md) | Unified/side-by-side diff display with hunk staging | Yes | `beta` |
+| [`ui.filePicker(props)`](file-picker.md) | File browser with selection and git status | Yes | `stable` |
+| [`ui.fileTreeExplorer(props)`](file-tree-explorer.md) | File system tree view with expand/collapse | Yes | `stable` |
+| [`ui.logsConsole(props)`](logs-console.md) | Streaming log output with filtering | Yes | `beta` |
+| [`ui.toolApprovalDialog(props)`](tool-approval-dialog.md) | Tool execution review dialog | Yes | `experimental` |
+
+**Quick example:**
+
+```typescript
+ui.codeEditor({
+  id: "editor",
+  lines: state.lines,
+  cursor: state.cursor,
+  selection: state.selection,
+  scrollTop: state.scrollTop,
+  scrollLeft: state.scrollLeft,
+  lineNumbers: true,
+  tabSize: 2,
+  onChange: (lines, cursor) => app.update({ lines, cursor }),
+  onScroll: (top, left) => app.update({ scrollTop: top, scrollLeft: left }),
+})
+```
 
 ### Graphics
 
-Graphics-oriented rendering widgets:
+Pixel-level drawing and image rendering for the terminal.
 
-| Widget | Description | Focusable | Stability |
-|--------|-------------|-----------|-----------|
-| [Canvas](canvas.md) | Pixel-level drawing surface | No | `beta` |
-| [Image](image.md) | Binary image rendering (PNG/RGBA) | No | `beta` |
-| [Line Chart](line-chart.md) | Multi-series line visualization | No | `beta` |
-| [Scatter](scatter.md) | Cartesian scatter plot | No | `beta` |
-| [Heatmap](heatmap.md) | Matrix heat map with color scales | No | `beta` |
+| Factory | Description | Focusable | Stability |
+|---------|-------------|-----------|-----------|
+| [`ui.canvas(props)`](canvas.md) | Pixel-level drawing surface | No | `beta` |
+| [`ui.image(props)`](image.md) | Binary image rendering (PNG/RGBA) | No | `beta` |
 
-### Feedback
+**Quick example:**
 
-User feedback and states:
+```typescript
+ui.canvas({
+  width: 40,
+  height: 20,
+  draw: (ctx) => {
+    ctx.fillRect(0, 0, 40, 20, "#000000");
+    ctx.line(0, 0, 39, 19, "#ffffff");
+  },
+})
+```
 
-| Widget | Description | Focusable | Stability |
-|--------|-------------|-----------|-----------|
-| [Callout](callout.md) | Alert/info message box | No | `beta` |
-| [Error Display](error-display.md) | Error message with retry | No | `beta` |
-| [Error Boundary](error-boundary.md) | Isolates subtree runtime errors with fallback UI | No | `beta` |
-| [Empty](empty.md) | Empty state placeholder | No | `beta` |
+## High-Level Composition Helpers
 
-## Common Patterns
+The `ui` namespace includes convenience wrappers that compose lower-level widgets:
 
-### Widget Props
+| Helper | Expands to | Purpose |
+|--------|-----------|---------|
+| `ui.panel(title, children)` | `ui.box({ border: "rounded", p: 1, title }, ...)` | Bordered panel with title |
+| `ui.form(children)` | `ui.column({ gap: 1 }, children)` | Vertically stacked form layout |
+| `ui.actions(children)` | `ui.row({ justify: "end", gap: 1 }, children)` | Right-aligned action button row |
+| `ui.center(child)` | `ui.column({ width: "100%", height: "100%", align: "center", justify: "center" }, ...)` | Center a single widget |
+| `ui.page(options)` | `ui.column(...)` with optional header/body/footer | Full-page layout scaffold |
+| `ui.keybindingHelp(bindings)` | Formatted table of keyboard shortcuts | Keyboard shortcut reference |
 
-All widgets accept a props object. Common properties include:
+```typescript
+ui.page({
+  header: ui.text("My App", { style: { bold: true } }),
+  body: ui.panel("Content", [
+    ui.text("Main content goes here"),
+    ui.form([
+      ui.field({ label: "Name", children: ui.input("name", state.name) }),
+      ui.actions([
+        ui.button("save", "Save"),
+        ui.button("cancel", "Cancel"),
+      ]),
+    ]),
+  ]),
+  footer: ui.text("Press Ctrl+Q to quit", { dim: true }),
+})
+```
+
+## Composition Patterns
+
+### `each()` for Lists
+
+Render a list of items with automatic key injection and optional empty state:
+
+```typescript
+import { each } from "@rezi-ui/core";
+
+each(
+  state.items,
+  (item, index) => ui.text(`${index + 1}. ${item.name}`),
+  {
+    key: (item) => item.id,
+    container: "column",  // default; also accepts "row"
+    empty: () => ui.text("No items yet", { dim: true }),
+  },
+)
+```
+
+For inline usage within a children array (returns `VNode[]` instead of a container):
+
+```typescript
+import { eachInline } from "@rezi-ui/core";
+
+ui.column({ gap: 1 }, [
+  ui.text("Items:"),
+  ...eachInline(
+    state.items,
+    (item) => ui.text(item.name),
+    { key: (item) => item.id },
+  ),
+])
+```
+
+### `show()` / `when()` / `maybe()` / `match()` for Conditionals
+
+```typescript
+import { show, when, maybe, match } from "@rezi-ui/core";
+
+ui.column({}, [
+  // show(condition, vnode, fallback?) -- eagerly evaluated
+  show(state.isLoggedIn, ui.text("Welcome back!")),
+  show(state.isLoggedIn, ui.text("Welcome!"), ui.text("Please log in")),
+
+  // when(condition, trueFn, falseFn?) -- lazily evaluated
+  when(
+    state.items.length > 0,
+    () => ItemList(),
+    () => ui.empty("No items"),
+  ),
+
+  // maybe(value, render) -- null-safe rendering
+  maybe(state.currentUser, (user) =>
+    ui.text(`Logged in as ${user.name}`),
+  ),
+
+  // match(value, cases) -- pattern matching with _ default
+  match(state.status, {
+    loading: () => ui.spinner(),
+    error: () => ui.errorDisplay("Something went wrong"),
+    _: () => ui.text("Ready"),
+  }),
+])
+```
+
+You can also use plain JavaScript expressions -- falsy values (`false`, `null`, `undefined`) are automatically filtered from children arrays:
+
+```typescript
+ui.column({}, [
+  ui.text("Always visible"),
+  state.showDetails && ui.text("Conditionally visible"),
+])
+```
+
+### `defineWidget()` for Reusable Components
+
+Create stateful, reusable components with local state and lifecycle hooks:
+
+```typescript
+import { defineWidget, ui } from "@rezi-ui/core";
+
+const Counter = defineWidget<{ initial: number; key?: string }>(
+  (props, ctx) => {
+    const [count, setCount] = ctx.useState(props.initial);
+
+    ctx.useEffect(() => {
+      console.log(`Counter mounted with initial=${props.initial}`);
+      return () => console.log("Counter unmounted");
+    }, []);
+
+    return ui.row({ gap: 1 }, [
+      ui.text(`Count: ${count}`),
+      ui.button({
+        id: ctx.id("inc"),
+        label: "+",
+        onPress: () => setCount((c) => c + 1),
+      }),
+      ui.button({
+        id: ctx.id("dec"),
+        label: "-",
+        onPress: () => setCount((c) => c - 1),
+      }),
+    ]);
+  },
+  { name: "Counter" },
+);
+
+// Usage in a view:
+ui.column([
+  Counter({ initial: 0 }),
+  Counter({ initial: 10, key: "counter-2" }),
+]);
+```
+
+See the [Composition Guide](../guide/composition.md) for full details on `defineWidget`, `WidgetContext`, and hook usage.
+
+## Stability Tiers
+
+Widget stability tiers and guarantees are documented in [Widget Stability](stability.md).
+
+| Tier | Meaning |
+|------|---------|
+| `stable` | Semver-protected behavior contract with deterministic regression tests. No breaking changes in minor/patch releases. |
+| `beta` | Core invariants tested; contract may evolve in minor releases. |
+| `experimental` | No compatibility guarantees; APIs can change at any time. |
+
+## Common Props Reference
+
+### Identity and Reconciliation
 
 ```typescript
 // Unique key for reconciliation (required for dynamic lists)
 key?: string
 
-// Interactive widget ID (required for focusable widgets)
+// Interactive widget ID (required for all focusable widgets)
 id: string
 
-// Optional semantic label for accessibility/debug focus announcements
+// Optional semantic label for accessibility / focus announcements
 accessibleLabel?: string
 
-// Visual styling
-style?: TextStyle
+// Whether this widget can receive focus (default depends on widget kind)
+focusable?: boolean
 ```
 
-### Layout Props
+### Spacing Props
 
-`Box`, `Row`, and `Column` support spacing props:
+`box`, `row`, `column`, `hstack`, and `vstack` all accept spacing props. Values are either a number (terminal cells) or a named key.
 
 ```typescript
-// Padding (all sides, or specific)
+// Padding
 p?: SpacingValue    // All sides
-px?: SpacingValue   // Horizontal
-py?: SpacingValue   // Vertical
+px?: SpacingValue   // Horizontal (left + right)
+py?: SpacingValue   // Vertical (top + bottom)
 pt?: SpacingValue   // Top
+pr?: SpacingValue   // Right
 pb?: SpacingValue   // Bottom
 pl?: SpacingValue   // Left
-pr?: SpacingValue   // Right
 
-// Gap between children
-gap?: SpacingValue
-
-// Alignment
-align?: "start" | "center" | "end" | "stretch"
-justify?: "start" | "end" | "center" | "between" | "around" | "evenly"
+// Margin
+m?: SpacingValue
+mx?: SpacingValue
+my?: SpacingValue
+mt?: SpacingValue
+mr?: SpacingValue
+mb?: SpacingValue
+ml?: SpacingValue
 ```
 
-`Grid` has its own layout props (`columns`, `rows`, `gap`, `rowGap`,
-`columnGap`) and does not accept spacing props like `p`/`m`.
+#### Spacing Value Scale
 
-### Spacing Values
-
-Spacing accepts numbers (cells) or named keys:
-
-| Key | Value |
+| Key | Cells |
 |-----|-------|
 | `"none"` | 0 |
 | `"xs"` | 1 |
@@ -229,86 +532,101 @@ Spacing accepts numbers (cells) or named keys:
 | `"xl"` | 4 |
 | `"2xl"` | 6 |
 
-```typescript
-ui.box({ p: "md" }, [
-  ui.column({ gap: "sm" }, [...]),
-])
-ui.column({ p: 2, gap: 1 }, [...])
-```
-
-### Conditional Rendering
-
-Use JavaScript expressions for conditional widgets:
+Numbers are also accepted directly:
 
 ```typescript
-ui.column({}, [
-  ui.text("Always visible"),
-  state.showDetails && ui.text("Conditional"),
-  state.items.length === 0 && ui.text("No items"),
-])
+ui.box({ p: "md" }, [...])   // 2 cells of padding on all sides
+ui.column({ p: 2, gap: 1 }, [...])  // equivalent numeric form
 ```
 
-Falsy values (`false`, `null`, `undefined`) are filtered from children.
-
-### VNode Factory Guarantees
-
-`ui.*` factories are contract-tested for deterministic VNode creation.
-
-- Factories that expose a `key` prop forward it to the resulting VNode for reconciliation.
-- Container-style child arrays filter `null`, `false`, and `undefined` values.
-- Nested child arrays are flattened before VNode children are stored.
-- Interactive widgets validate required runtime props before layout:
-  - `button`: non-empty `id`; `label` must be a string (empty allowed)
-  - `input`: non-empty `id`; `value` must be a string
-  - `textarea`: non-empty `id`; `value` must be a string; optional `rows` controls visible height
-  - `select`: non-empty `id`; `value` must be a string; `options` must be an array (empty allowed)
-  - `slider`: non-empty `id`, finite numeric range with `min <= max`, `step > 0`
-  - `checkbox`: non-empty `id`, boolean `checked`
-  - `radioGroup`: non-empty `id`; `value` must be a string; `options` must be non-empty
-
-### Dynamic Lists
-
-When rendering lists, provide a `key` prop for efficient reconciliation:
+### Layout Props
 
 ```typescript
-ui.column(
-  {},
-  state.items.map((item) => ui.text(item.name, { key: item.id }))
-)
+// Dimensions
+width?: number | string    // Fixed width or percentage ("100%")
+height?: number | string   // Fixed height or percentage
+minWidth?: number
+maxWidth?: number
+minHeight?: number
+maxHeight?: number
+flex?: number              // Flex grow factor
+
+// Gap between children (row, column, hstack, vstack)
+gap?: SpacingValue
+
+// Alignment
+align?: "start" | "center" | "end" | "stretch"
+justify?: "start" | "end" | "center" | "between" | "around" | "evenly"
+items?: "start" | "center" | "end" | "stretch"
 ```
 
-### Event Handlers
+### Visual Props
 
-Interactive widgets support event callbacks. These fire for both keyboard and mouse input:
+```typescript
+// Border style (box)
+border?: "none" | "single" | "double" | "rounded" | "heavy" | "dashed"
+
+// Box title (displayed in border)
+title?: string
+titleAlign?: "left" | "center" | "right"
+
+// Text style (text, richText)
+style?: TextStyle
+```
+
+### Grid-Specific Props
+
+`grid` uses its own layout system and does **not** accept spacing props like `p`/`m`:
+
+```typescript
+ui.grid({
+  columns: 3,           // Number of columns or explicit sizes
+  rows: 2,              // Number of rows or explicit sizes
+  gap: 1,               // Uniform gap
+  rowGap: 1,            // Row-specific gap
+  columnGap: 2,         // Column-specific gap
+}, child1, child2, child3, child4, child5, child6)
+```
+
+## Event Handlers
+
+Interactive widgets fire event callbacks for both keyboard and mouse input:
 
 ```typescript
 ui.button({
   id: "submit",
   label: "Submit",
-  onPress: () => handleSubmit(), // Fires on Enter, Space, or mouse click
+  onPress: () => handleSubmit(),   // Fires on Enter, Space, or mouse click
 })
 
 ui.input({
   id: "name",
   value: state.name,
-  onInput: (value) => app.update({ ...state, name: value }),
+  onInput: (value) => app.update({ name: value }),
   onBlur: () => validateField("name"),
 })
 ```
 
-### Mouse Support
+## Mouse Support
 
-All focusable widgets can be clicked with the mouse to receive focus. Scrollable widgets (VirtualList, CodeEditor, LogsConsole, DiffViewer) respond to the mouse scroll wheel. SplitPane dividers can be dragged to resize panels. See the [Mouse Support guide](../guide/mouse-support.md) for details.
+All focusable widgets can be clicked with the mouse to receive focus. Scrollable widgets (`virtualList`, `codeEditor`, `logsConsole`, `diffViewer`) respond to the mouse scroll wheel. `splitPane` dividers can be dragged to resize panels. See the [Mouse Support Guide](../guide/mouse-support.md) for details.
+
+## VNode Factory Guarantees
+
+`ui.*` factories are contract-tested for deterministic VNode creation:
+
+- Factories that expose a `key` prop forward it to the resulting VNode for reconciliation.
+- Container-style child arrays filter `null`, `false`, and `undefined` values.
+- Nested child arrays are flattened before VNode children are stored.
+- Interactive widgets validate required runtime props before layout:
+  - `button`: non-empty `id`; `label` must be a string (empty allowed).
+  - `input`: non-empty `id`; `value` must be a string.
+  - `textarea`: non-empty `id`; `value` must be a string; optional `rows` controls visible height.
+  - `select`: non-empty `id`; `value` must be a string; `options` must be an array (empty allowed).
+  - `slider`: non-empty `id`, finite numeric range with `min <= max`, `step > 0`.
+  - `checkbox`: non-empty `id`, boolean `checked`.
+  - `radioGroup`: non-empty `id`; `value` must be a string; `options` must be non-empty.
 
 ## API Reference
-
-### Baseline Lock
-
-- Timestamp: `2026-02-18T11:26:33Z`
-- Base commit: `a441bba78ddc99ece4eb76965ce36c0aec9225fe`
-- Branch: `vnode-factory-audit`
-- Node: `v20.19.5`
-- npm: `10.8.2`
-- Baseline tests: `2488` passing
 
 For complete type definitions, see the [API Reference](../api.md).

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -121,6 +121,8 @@ nav:
       - Performance: guide/performance.md
       - Debugging: guide/debugging.md
       - Record & Replay: guide/record-replay.md
+      - Hooks Reference: guide/hooks-reference.md
+      - Recommended Patterns: guide/recommended-patterns.md
   - Widgets:
       - Overview: widgets/index.md
       - Stability: widgets/stability.md


### PR DESCRIPTION
## Summary

- **Added internal AI development docs** (CLAUDE.md, AGENTS.md, SKILLS.md) — gives Claude/Codex full context on Rezi's API layers, code standards, exploration/modification protocols, and 10 repeatable development recipes
- **Overhauled user-facing documentation** — rewrote widget catalog (index.md), quickstart, and concepts guide to emphasize the high-level `ui.*` widget API and recommended patterns (reducer state, defineWidget composition, keybinding system)
- **Added two new comprehensive guides** — hooks-reference.md (all core, utility, and domain hooks with full signatures/examples) and recommended-patterns.md (app structure, state management, testing, performance)

## Files changed (9 files, +2846 / -469)

| File | Status | Description |
|------|--------|-------------|
| `CLAUDE.md` | New | Primary AI context: API layers, pipeline, code standards, guardrails |
| `AGENTS.md` | New | Multi-agent workflow: exploration/modification protocols, verification |
| `SKILLS.md` | New | 10 repeatable AI recipes for common Rezi development tasks |
| `docs/guide/hooks-reference.md` | New | Complete hooks API reference with signatures and examples |
| `docs/guide/recommended-patterns.md` | New | App structure, state, composition, testing, performance patterns |
| `docs/widgets/index.md` | Rewritten | Full widget catalog by category with quick examples |
| `docs/guide/concepts.md` | Overhauled | Restructured around VNodes, state-driven rendering, hooks |
| `docs/getting-started/quickstart.md` | Rewritten | 10-line minimal example, `ui.*` API, reducer pattern |
| `mkdocs.yml` | Modified | Added hooks-reference and recommended-patterns nav entries |

## Verification

All documents were verified by **two independent sub-agents**:
- **Accuracy agent**: Found and fixed 9 issues (defineWidget signature, ui.text() calling convention, import paths, TabsProps key/onChange, canvas API, scopedId→ctx.id)
- **Completeness agent**: Found and fixed 3 HIGH + 6 MEDIUM gaps (import paths, placeholder prop, JSX location)

## Test plan

- [ ] Verify `mkdocs serve` renders all new pages correctly
- [ ] Spot-check code examples in widgets/index.md against actual API signatures
- [ ] Verify hooks-reference.md examples compile with current `@rezi-ui/core` types
- [ ] Confirm CLAUDE.md is picked up correctly by Claude Code sessions

🤖 Generated with [Claude Code](https://claude.com/claude-code)