### PR TITLE
fix: Node.js 18 and 20 compatibility

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -21,12 +21,13 @@ jobs:
         run: bash scripts/guardrails.sh
 
   ci:
-    name: node / ${{ matrix.os }}
+    name: node ${{ matrix.node-version }} / ${{ matrix.os }}
     runs-on: ${{ matrix.os }}
     strategy:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
+        node-version: ["18", "20", "22"]
 
     steps:
       - name: Checkout (with submodules)
@@ -37,7 +38,7 @@ jobs:
       - name: Setup Node
         uses: actions/setup-node@v4
         with:
-          node-version: "22"
+          node-version: ${{ matrix.node-version }}
           cache: npm
 
       - name: Install (Linux)
@@ -73,7 +74,9 @@ jobs:
 
       - name: Repro replay fixtures (headless, explicit gate)
         if: runner.os == 'Linux'
-        run: node --test --test-concurrency=1 packages/core/dist/repro/__tests__/replay.harness.test.js
+        run: |
+          CONCURRENCY=$(node -p "parseInt(process.versions.node)>=19?'--test-concurrency=1':''")
+          node --test $CONCURRENCY packages/core/dist/repro/__tests__/replay.harness.test.js
 
       - name: Setup Rust (stable)
         uses: dtolnay/rust-toolchain@stable

--- a/docs/dev/repro-replay.md
+++ b/docs/dev/repro-replay.md
@@ -15,12 +15,13 @@ The fixture currently exercised by the harness is:
 
 Every PR runs an explicit replay gate in `.github/workflows/ci.yml`:
 
-- job: `node / ubuntu-latest`
+- job: `node <version> / ubuntu-latest`
 - step: `Repro replay fixtures (headless, explicit gate)`
 - command:
 
 ```bash
-node --test --test-concurrency=1 packages/core/dist/repro/__tests__/replay.harness.test.js
+CONCURRENCY=$(node -p "parseInt(process.versions.node)>=19?'--test-concurrency=1':''")
+node --test $CONCURRENCY packages/core/dist/repro/__tests__/replay.harness.test.js
 ```
 
 `npm run test` also covers this area, but this dedicated step keeps replay coverage visible as a standalone gate.
@@ -30,13 +31,14 @@ node --test --test-concurrency=1 packages/core/dist/repro/__tests__/replay.harne
 ```bash
 npm ci
 npm run build
-node --test --test-concurrency=1 packages/core/dist/repro/__tests__/replay.harness.test.js
+CONCURRENCY=$(node -p "parseInt(process.versions.node)>=19?'--test-concurrency=1':''")
+node --test $CONCURRENCY packages/core/dist/repro/__tests__/replay.harness.test.js
 ```
 
 Optional schema/version checks:
 
 ```bash
-node --test --test-concurrency=1 packages/core/dist/repro/__tests__/schema.versioning.test.js
+node --test $CONCURRENCY packages/core/dist/repro/__tests__/schema.versioning.test.js
 ```
 
 ## Updating Replay Fixtures
@@ -46,4 +48,3 @@ Follow the golden fixture policy in `packages/testkit/fixtures/README.md`:
 1. Update fixture JSON intentionally (no auto-regeneration in committed tests).
 2. Re-run replay harness and related tests.
 3. Include fixture diff context and reasoning in the PR.
-

--- a/packages/bench/src/ratatui-runner.ts
+++ b/packages/bench/src/ratatui-runner.ts
@@ -8,11 +8,12 @@
 
 import { execFileSync, execSync } from "node:child_process";
 import { existsSync } from "node:fs";
-import { resolve } from "node:path";
+import { dirname, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
 import { computeStats, takeMemory } from "./measure.js";
 import type { BenchMetrics, ScenarioConfig } from "./types.js";
 
-const BENCH_DIR = resolve(import.meta.dirname ?? ".", "..", "ratatui-bench");
+const BENCH_DIR = resolve(dirname(fileURLToPath(import.meta.url)), "..", "ratatui-bench");
 const BINARY = resolve(BENCH_DIR, "target", "release", "ratatui-bench");
 
 /** Check if we can build/run the ratatui benchmark. */

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -15,7 +15,7 @@
   "type": "module",
   "scripts": {
     "build": "tsc -p tsconfig.json --pretty false",
-    "test": "node --test --test-concurrency=1 $(find dist -type f -path '*/__tests__/*.test.js' | LC_ALL=C sort)"
+    "test": "CONCURRENCY=$(node -p \"parseInt(process.versions.node)>=19?'--test-concurrency=1':''\") && node --test $CONCURRENCY $(find dist -type f -path '*/__tests__/*.test.js' | LC_ALL=C sort)"
   },
   "types": "./dist/index.d.ts",
   "exports": {

--- a/scripts/run-e2e.mjs
+++ b/scripts/run-e2e.mjs
@@ -95,7 +95,8 @@ if (files.length === 0) {
 const relFiles = files.map((f) => relative(root, f));
 
 const cmd = process.execPath;
-const args = ["--test", "--test-concurrency=1", ...relFiles];
+const nodeMajor = Number.parseInt(process.versions.node.split(".")[0], 10);
+const args = ["--test", ...(nodeMajor >= 19 ? ["--test-concurrency=1"] : []), ...relFiles];
 
 const res = spawnSync(cmd, args, {
   cwd: root,

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -136,7 +136,8 @@ if (scope === "packages" && packageTests.length === 0) {
 const relFiles = files.map((f) => relative(root, f));
 
 const cmd = process.execPath;
-const args = ["--test", "--test-concurrency=1", ...relFiles];
+const nodeMajor = Number.parseInt(process.versions.node.split(".")[0], 10);
+const args = ["--test", ...(nodeMajor >= 19 ? ["--test-concurrency=1"] : []), ...relFiles];
 
 const res = spawnSync(cmd, args, {
   cwd: root,


### PR DESCRIPTION
## Summary
- Make `--test-concurrency=1` flag conditional on Node >= 19 (flag was added in Node 19, unavailable in Node 18)
- Replace `t.mock.timers` (Node 20.4+) with a portable `useFakeTimers()` utility in async validation tests
- Expand CI matrix to test Node 18, 20, and 22 (previously only tested Node 22 despite declaring `engines.node >= 18`)