### PR TITLE
Update all docs links to point to rezitui.dev

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@
   <a href="https://github.com/RtlZeroMemory/Rezi/actions/workflows/ci.yml">
     <img src="https://github.com/RtlZeroMemory/Rezi/actions/workflows/ci.yml/badge.svg" alt="CI">
   </a>
-  <a href="https://rtlzeromemory.github.io/Rezi/">
+  <a href="https://rezitui.dev/docs">
     <img src="https://github.com/RtlZeroMemory/Rezi/actions/workflows/docs.yml/badge.svg" alt="docs">
   </a>
   <a href="LICENSE">
@@ -21,10 +21,11 @@
 </p>
 
 <p align="center">
-  <a href="https://rtlzeromemory.github.io/Rezi/">Docs</a> ·
-  <a href="https://rtlzeromemory.github.io/Rezi/getting-started/quickstart/">Quickstart</a> ·
-  <a href="https://rtlzeromemory.github.io/Rezi/widgets/">Widgets</a> ·
-  <a href="https://rtlzeromemory.github.io/Rezi/api/">API</a> ·
+  <a href="https://rezitui.dev">Website</a> ·
+  <a href="https://rezitui.dev/docs">Docs</a> ·
+  <a href="https://rezitui.dev/docs/getting-started/quickstart/">Quickstart</a> ·
+  <a href="https://rezitui.dev/docs/widgets/">Widgets</a> ·
+  <a href="https://rezitui.dev/docs/api/">API</a> ·
   <a href="BENCHMARKS.md">Benchmarks</a>
 </p>
 
@@ -347,12 +348,12 @@ build from a repository checkout with `npm run build:native`.
 
 | Resource | Link |
 |---|---|
-| Docs home | [rtlzeromemory.github.io/Rezi](https://rtlzeromemory.github.io/Rezi/) |
-| Getting started | [Install](https://rtlzeromemory.github.io/Rezi/getting-started/install/) · [Quickstart](https://rtlzeromemory.github.io/Rezi/getting-started/quickstart/) · [JSX](https://rtlzeromemory.github.io/Rezi/getting-started/jsx/) |
-| Guides | [Concepts](https://rtlzeromemory.github.io/Rezi/guide/concepts/) · [Layout](https://rtlzeromemory.github.io/Rezi/guide/layout/) · [Input & Focus](https://rtlzeromemory.github.io/Rezi/guide/input-and-focus/) · [Styling](https://rtlzeromemory.github.io/Rezi/guide/styling/) |
-| Widget catalog | [56 widgets](https://rtlzeromemory.github.io/Rezi/widgets/) |
-| API reference | [TypeDoc](https://rtlzeromemory.github.io/Rezi/api/) |
-| Architecture | [Overview](https://rtlzeromemory.github.io/Rezi/architecture/) · [Protocol](https://rtlzeromemory.github.io/Rezi/protocol/) |
+| Website & Docs | [rezitui.dev](https://rezitui.dev) |
+| Getting started | [Install](https://rezitui.dev/docs/getting-started/install/) · [Quickstart](https://rezitui.dev/docs/getting-started/quickstart/) · [JSX](https://rezitui.dev/docs/getting-started/jsx/) |
+| Guides | [Concepts](https://rezitui.dev/docs/guide/concepts/) · [Layout](https://rezitui.dev/docs/guide/layout/) · [Input & Focus](https://rezitui.dev/docs/guide/input-and-focus/) · [Styling](https://rezitui.dev/docs/guide/styling/) |
+| Widget catalog | [56 widgets](https://rezitui.dev/docs/widgets/) |
+| API reference | [TypeDoc](https://rezitui.dev/docs/api/) |
+| Architecture | [Overview](https://rezitui.dev/docs/architecture/) · [Protocol](https://rezitui.dev/docs/protocol/) |
 
 ## Contributing
 

--- a/docs/dev/docs.md
+++ b/docs/dev/docs.md
@@ -153,7 +153,7 @@ Deployment is triggered on every push to `main`, every pull request, and manual
 `workflow_dispatch`. The workflow does not use path filters.
 
 The live site is available at:
-[https://rtlzeromemory.github.io/Rezi/](https://rtlzeromemory.github.io/Rezi/)
+[rezitui.dev](https://rezitui.dev)
 
 ## See Also
 

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -1,6 +1,6 @@
 site_name: Rezi
 site_description: A high-performance, code-first terminal UI framework for Node.js built on the Zireael engine.
-site_url: https://rtlzeromemory.github.io/Rezi/
+site_url: https://rezitui.dev/
 repo_url: https://github.com/RtlZeroMemory/Rezi
 repo_name: RtlZeroMemory/Rezi
 edit_uri: edit/main/docs/

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -8,5 +8,5 @@ Runtime-agnostic TypeScript core for Rezi:
 
 Most applications should use the Node backend package (`@rezi-ui/node`), which depends on this package.
 
-Docs: `https://rtlzeromemory.github.io/Rezi/`
+Docs: `https://rezitui.dev/docs`
 

--- a/packages/core/package.json
+++ b/packages/core/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0-alpha.17",
   "description": "Runtime-agnostic TypeScript core for Rezi (widgets, layout, routing, drawlists, event parsing).",
   "license": "Apache-2.0",
-  "homepage": "https://rtlzeromemory.github.io/Rezi/",
+  "homepage": "https://rezitui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/RtlZeroMemory/Rezi.git",

--- a/packages/create-rezi/README.md
+++ b/packages/create-rezi/README.md
@@ -61,4 +61,4 @@ Scaffolded templates now follow the same baseline structure:
 - `src/__tests__/`
 
 For template descriptions and highlights, see:
-https://rtlzeromemory.github.io/Rezi/getting-started/create-rezi/
+https://rezitui.dev/docs/getting-started/create-rezi/

--- a/packages/create-rezi/package.json
+++ b/packages/create-rezi/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0-alpha.17",
   "description": "Scaffold a Rezi terminal UI app.",
   "license": "Apache-2.0",
-  "homepage": "https://rtlzeromemory.github.io/Rezi/",
+  "homepage": "https://rezitui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/RtlZeroMemory/Rezi.git",

--- a/packages/jsx/package.json
+++ b/packages/jsx/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0-alpha.17",
   "description": "JSX runtime for Rezi TUI framework.",
   "license": "Apache-2.0",
-  "homepage": "https://rtlzeromemory.github.io/Rezi/",
+  "homepage": "https://rezitui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/RtlZeroMemory/Rezi.git",

--- a/packages/native/package.json
+++ b/packages/native/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0-alpha.17",
   "description": "Native addon for Rezi (napi-rs + Zireael engine).",
   "license": "Apache-2.0",
-  "homepage": "https://rtlzeromemory.github.io/Rezi/",
+  "homepage": "https://rezitui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/RtlZeroMemory/Rezi.git",

--- a/packages/node/README.md
+++ b/packages/node/README.md
@@ -28,4 +28,4 @@ npm i @rezi-ui/node
 bun add @rezi-ui/node
 ```
 
-Docs: `https://rtlzeromemory.github.io/Rezi/`
+Docs: `https://rezitui.dev/docs`

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0-alpha.17",
   "description": "Node.js/Bun backend for Rezi (worker-thread engine ownership, scheduling, IO).",
   "license": "Apache-2.0",
-  "homepage": "https://rtlzeromemory.github.io/Rezi/",
+  "homepage": "https://rezitui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/RtlZeroMemory/Rezi.git",

--- a/packages/testkit/README.md
+++ b/packages/testkit/README.md
@@ -4,5 +4,5 @@ Test utilities and golden fixtures for Rezi.
 
 Most applications do not need this package directly.
 
-Docs: `https://rtlzeromemory.github.io/Rezi/`
+Docs: `https://rezitui.dev/docs`
 

--- a/packages/testkit/package.json
+++ b/packages/testkit/package.json
@@ -3,7 +3,7 @@
   "version": "0.1.0-alpha.17",
   "description": "Test utilities and fixtures for Rezi.",
   "license": "Apache-2.0",
-  "homepage": "https://rtlzeromemory.github.io/Rezi/",
+  "homepage": "https://rezitui.dev",
   "repository": {
     "type": "git",
     "url": "git+https://github.com/RtlZeroMemory/Rezi.git",


### PR DESCRIPTION
Replace rtlzeromemory.github.io/Rezi references with rezitui.dev across the repo:

- README.md: add Website link to header nav, update all doc links
- 6 package.json homepage fields → https://rezitui.dev
- 4 package READMEs → rezitui.dev/docs
- mkdocs.yml site_url → rezitui.dev
- docs/dev/docs.md → rezitui.dev
 
