### PR TITLE
docs(animation): fully document PR #144 functionality across docs + skills

### DIFF
--- a/.claude/skills/rezi-create-screen/SKILL.md
+++ b/.claude/skills/rezi-create-screen/SKILL.md
@@ -19,8 +19,10 @@ Use this skill when:
 ## Source of truth
 
 - `packages/core/src/widgets/ui.ts` — all `ui.*` factory functions
+- `packages/core/src/widgets/composition.ts` — `defineWidget()` and animation hooks
 - `packages/core/src/router/` — router and route definitions
 - `packages/core/src/keybindings/` — keybinding system
+- `packages/create-rezi/templates/animation-lab/` — canonical animation screen pattern
 
 ## Steps
 
@@ -39,11 +41,30 @@ Use this skill when:
 
 2. **Use `ui.column()` or `ui.row()`** as the root container
 
-3. **If using router**, add a route definition (see `rezi-routing` skill)
+3. **If the screen needs motion**, prefer declarative hooks inside `defineWidget`:
+   ```typescript
+   import { defineWidget, ui, useSpring, useTransition } from "@rezi-ui/core";
 
-4. **Add keybindings** for screen-specific actions in the app's key handler
+   const AnimatedScreen = defineWidget<{ target: number }>((props, ctx) => {
+     const drift = useTransition(ctx, props.target, { duration: 180, easing: "easeOutCubic" });
+     const spring = useSpring(ctx, props.target, { stiffness: 190, damping: 22 });
 
-5. **Wire into main** via router or view switch:
+     return ui.box(
+       {
+         width: Math.round(20 + drift),
+         opacity: Math.max(0.35, Math.min(1, spring / 100)),
+         transition: { duration: 180, properties: ["size", "opacity"] },
+       },
+       [ui.text("Animated screen")],
+     );
+   });
+   ```
+
+4. **If using router**, add a route definition (see `rezi-routing` skill)
+
+5. **Add keybindings** for screen-specific actions in the app's key handler
+
+6. **Wire into main** via router or view switch:
    ```typescript
    view: (state) => {
      if (state.screen === "my-screen") return MyScreen(state);
@@ -56,3 +77,4 @@ Use this skill when:
 - Screen renders without errors
 - Navigation keybindings work
 - State types include any new fields
+- For animated screens: transitions retarget smoothly and no timer leaks occur on unmount

--- a/.claude/skills/rezi-debug-rendering/SKILL.md
+++ b/.claude/skills/rezi-debug-rendering/SKILL.md
@@ -20,9 +20,11 @@ Use this skill when:
 ## Source of truth
 
 - `packages/core/src/app/widgetRenderer.ts` — full render pipeline
+- `packages/core/src/app/__tests__/widgetRenderer.transition.test.ts` — transition behavior expectations
 - `packages/core/src/runtime/commit.ts` — VNode → RuntimeInstance tree
 - `packages/core/src/layout/` — layout engine
 - `packages/core/src/renderer/renderToDrawlist/` — draw operations
+- `packages/core/src/widgets/composition.ts` — animation hook implementations
 
 ## Debugging steps
 
@@ -52,6 +54,12 @@ Use this skill when:
 
 7. **Review layout props**: `width`, `height`, `flex`, `p`, `gap`, `align`
 
+8. **If animation is involved**, verify:
+   - `ui.box` uses `transition` with expected `properties` (`position`, `size`, `opacity`)
+   - `properties: []` is not accidentally disabling tracks
+   - `opacity` stays within `[0..1]`
+   - animation hooks are not conditionally called
+
 ## Common causes
 
 | Symptom | Likely cause |
@@ -60,4 +68,6 @@ Use this skill when:
 | Overlapping widgets | Wrong container type (use `column`/`row` not `box`) |
 | Content truncated | Fixed width too small, missing `flex` |
 | Flicker/full re-render | Missing `key` on list items |
+| Transition not animating | `transition` missing, wrong `properties`, or no actual value delta |
+| Opacity animation looks wrong | `opacity` outside `[0..1]` (clamped) or `properties` excludes `opacity` |
 | Crash on deep tree | Nesting depth > 500 |

--- a/.claude/skills/rezi-perf-profiling/SKILL.md
+++ b/.claude/skills/rezi-perf-profiling/SKILL.md
@@ -22,6 +22,7 @@ Use this skill when:
 - `packages/core/src/app/widgetRenderer.ts` — render pipeline with phase timing
 - `packages/core/src/runtime/commit.ts` — reconciliation (leaf/container reuse)
 - `packages/core/src/layout/` — layout engine (FNV-1a stability signatures)
+- `packages/core/src/widgets/composition.ts` — animation utility hooks
 - `packages/bench/src/` — profiling scripts
 
 ## Steps
@@ -47,6 +48,7 @@ Use this skill when:
    | Commit phase slow | Add `key` props on list items for stable reconciliation |
    | Layout phase slow | Reduce nesting depth; layout stability signatures skip relayout when tree is stable |
    | Render phase slow | Use `ui.virtualList()` for large datasets |
+   | Animation-heavy screen slow | Limit transition scope (`properties`), animate only visible rows, avoid per-frame object churn |
    | Overall slow | Flatten unnecessary wrapper nodes |
 
 5. **Depth guardrails**:
@@ -59,4 +61,6 @@ Use this skill when:
 - `ctx.useMemo(() => expensiveComputation, [deps])` — skip recomputation
 - `key` on every list item — enables O(1) reconciliation
 - `ui.virtualList()` — only renders visible rows
+- `useStagger(...)` + `ui.virtualList(...)` — stagger only the visible window
+- `ui.box({ transition: { properties: [...] } })` — animate only required dimensions
 - Avoid creating new closures/objects in render — use `ctx.useCallback(fn, [deps])`

--- a/.claude/skills/rezi-write-tests/SKILL.md
+++ b/.claude/skills/rezi-write-tests/SKILL.md
@@ -21,6 +21,8 @@ Use this skill when:
 
 - `packages/core/src/testing/` — test utilities (`createTestRenderer`, etc.)
 - `packages/core/src/widgets/__tests__/` — existing widget tests (use as examples)
+- `packages/core/src/widgets/__tests__/composition.animationHooks.test.ts` — animation hook test patterns
+- `packages/core/src/app/__tests__/widgetRenderer.transition.test.ts` — `ui.box` transition expectations
 - `scripts/run-tests.mjs` — test runner
 
 ## Steps
@@ -53,6 +55,12 @@ Use this skill when:
 
 5. **Use `result.findById()`** to locate specific nodes in the render tree
 
+6. **For animation features**, cover:
+   - mount value
+   - retarget while running
+   - cleanup on unmount (no timer leak)
+   - property filtering (`position` / `size` / `opacity`) for `ui.box` transitions
+
 ## Running tests
 
 ```bash
@@ -67,4 +75,4 @@ node --test path/to/test.ts
 
 - All new tests pass
 - No existing tests broken
-- Tests are deterministic (no timers, no randomness)
+- Tests are deterministic (bounded timers/explicit waits, no randomness)

--- a/.codex/skills/rezi-create-screen/SKILL.md
+++ b/.codex/skills/rezi-create-screen/SKILL.md
@@ -14,8 +14,10 @@ Use this skill when:
 ## Source of truth
 
 - `packages/core/src/widgets/ui.ts` — all `ui.*` factory functions
+- `packages/core/src/widgets/composition.ts` — `defineWidget()` and animation hooks
 - `packages/core/src/router/` — router and route definitions
 - `packages/core/src/keybindings/` — keybinding system
+- `packages/create-rezi/templates/animation-lab/` — canonical animation screen pattern
 
 ## Steps
 
@@ -34,11 +36,30 @@ Use this skill when:
 
 2. **Use `ui.column()` or `ui.row()`** as the root container
 
-3. **If using router**, add a route definition (see `rezi-routing` skill)
+3. **If the screen needs motion**, prefer declarative hooks inside `defineWidget`:
+   ```typescript
+   import { defineWidget, ui, useSpring, useTransition } from "@rezi-ui/core";
 
-4. **Add keybindings** for screen-specific actions in the app's key handler
+   const AnimatedScreen = defineWidget<{ target: number }>((props, ctx) => {
+     const drift = useTransition(ctx, props.target, { duration: 180, easing: "easeOutCubic" });
+     const spring = useSpring(ctx, props.target, { stiffness: 190, damping: 22 });
 
-5. **Wire into main** via router or view switch:
+     return ui.box(
+       {
+         width: Math.round(20 + drift),
+         opacity: Math.max(0.35, Math.min(1, spring / 100)),
+         transition: { duration: 180, properties: ["size", "opacity"] },
+       },
+       [ui.text("Animated screen")],
+     );
+   });
+   ```
+
+4. **If using router**, add a route definition (see `rezi-routing` skill)
+
+5. **Add keybindings** for screen-specific actions in the app's key handler
+
+6. **Wire into main** via router or view switch:
    ```typescript
    view: (state) => {
      if (state.screen === "my-screen") return MyScreen(state);
@@ -51,3 +72,4 @@ Use this skill when:
 - Screen renders without errors
 - Navigation keybindings work
 - State types include any new fields
+- For animated screens: transitions retarget smoothly and no timer leaks occur on unmount

--- a/.codex/skills/rezi-debug-rendering/SKILL.md
+++ b/.codex/skills/rezi-debug-rendering/SKILL.md
@@ -15,9 +15,11 @@ Use this skill when:
 ## Source of truth
 
 - `packages/core/src/app/widgetRenderer.ts` — full render pipeline
+- `packages/core/src/app/__tests__/widgetRenderer.transition.test.ts` — transition behavior expectations
 - `packages/core/src/runtime/commit.ts` — VNode → RuntimeInstance tree
 - `packages/core/src/layout/` — layout engine
 - `packages/core/src/renderer/renderToDrawlist/` — draw operations
+- `packages/core/src/widgets/composition.ts` — animation hook implementations
 
 ## Debugging steps
 
@@ -47,6 +49,12 @@ Use this skill when:
 
 7. **Review layout props**: `width`, `height`, `flex`, `p`, `gap`, `align`
 
+8. **If animation is involved**, verify:
+   - `ui.box` uses `transition` with expected `properties` (`position`, `size`, `opacity`)
+   - `properties: []` is not accidentally disabling tracks
+   - `opacity` stays within `[0..1]`
+   - animation hooks are not conditionally called
+
 ## Common causes
 
 | Symptom | Likely cause |
@@ -55,4 +63,6 @@ Use this skill when:
 | Overlapping widgets | Wrong container type (use `column`/`row` not `box`) |
 | Content truncated | Fixed width too small, missing `flex` |
 | Flicker/full re-render | Missing `key` on list items |
+| Transition not animating | `transition` missing, wrong `properties`, or no actual value delta |
+| Opacity animation looks wrong | `opacity` outside `[0..1]` (clamped) or `properties` excludes `opacity` |
 | Crash on deep tree | Nesting depth > 500 |

--- a/.codex/skills/rezi-perf-profiling/SKILL.md
+++ b/.codex/skills/rezi-perf-profiling/SKILL.md
@@ -17,6 +17,7 @@ Use this skill when:
 - `packages/core/src/app/widgetRenderer.ts` — render pipeline with phase timing
 - `packages/core/src/runtime/commit.ts` — reconciliation (leaf/container reuse)
 - `packages/core/src/layout/` — layout engine (FNV-1a stability signatures)
+- `packages/core/src/widgets/composition.ts` — animation utility hooks
 - `packages/bench/src/` — profiling scripts
 
 ## Steps
@@ -42,6 +43,7 @@ Use this skill when:
    | Commit phase slow | Add `key` props on list items for stable reconciliation |
    | Layout phase slow | Reduce nesting depth; layout stability signatures skip relayout when tree is stable |
    | Render phase slow | Use `ui.virtualList()` for large datasets |
+   | Animation-heavy screen slow | Limit transition scope (`properties`), animate only visible rows, avoid per-frame object churn |
    | Overall slow | Flatten unnecessary wrapper nodes |
 
 5. **Depth guardrails**:
@@ -54,4 +56,6 @@ Use this skill when:
 - `ctx.useMemo(() => expensiveComputation, [deps])` — skip recomputation
 - `key` on every list item — enables O(1) reconciliation
 - `ui.virtualList()` — only renders visible rows
+- `useStagger(...)` + `ui.virtualList(...)` — stagger only the visible window
+- `ui.box({ transition: { properties: [...] } })` — animate only required dimensions
 - Avoid creating new closures/objects in render — use `ctx.useCallback(fn, [deps])`

--- a/.codex/skills/rezi-write-tests/SKILL.md
+++ b/.codex/skills/rezi-write-tests/SKILL.md
@@ -16,6 +16,8 @@ Use this skill when:
 
 - `packages/core/src/testing/` — test utilities (`createTestRenderer`, etc.)
 - `packages/core/src/widgets/__tests__/` — existing widget tests (use as examples)
+- `packages/core/src/widgets/__tests__/composition.animationHooks.test.ts` — animation hook test patterns
+- `packages/core/src/app/__tests__/widgetRenderer.transition.test.ts` — `ui.box` transition expectations
 - `scripts/run-tests.mjs` — test runner
 
 ## Steps
@@ -48,6 +50,12 @@ Use this skill when:
 
 5. **Use `result.findById()`** to locate specific nodes in the render tree
 
+6. **For animation features**, cover:
+   - mount value
+   - retarget while running
+   - cleanup on unmount (no timer leak)
+   - property filtering (`position` / `size` / `opacity`) for `ui.box` transitions
+
 ## Running tests
 
 ```bash
@@ -62,4 +70,4 @@ node --test path/to/test.ts
 
 - All new tests pass
 - No existing tests broken
-- Tests are deterministic (no timers, no randomness)
+- Tests are deterministic (bounded timers/explicit waits, no randomness)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -19,6 +19,8 @@ The format is based on Keep a Changelog and the project follows Semantic Version
 - `ui.textarea(...)` multi-line text input widget with wrapping and line-aware editing
 - OSC 52 clipboard copy/cut for Input/CodeEditor selections (`Ctrl+C`, `Ctrl+X`)
 - Keybinding metadata/introspection: optional `description` in binding definitions, `app.getBindings(mode?)`, `app.pendingChord`, and `ui.keybindingHelp(...)` for auto-generated shortcut overlays
+- Declarative animation hooks: `useTransition`, `useSpring`, `useSequence`, and `useStagger`
+- `ui.box` transition API with property-scoped animation (`position`, `size`, `opacity`) plus surface `opacity`
 - `create-rezi` `animation-lab` template with declarative animation hooks, responsive reactor canvas scene, and scaffolded tests/docs
 - `ui.virtualList(...)` estimate mode via `estimateItemHeight` with measured-height correction/cache and optional `measureItemHeight` override for variable-height rows
 

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -74,6 +74,7 @@ packages/create-rezi/templates/
   cli-tool/                   # Multi-screen app with routing
   dashboard/                  # Real-time dashboard with charts
   stress-test/                # Stress/performance testing template
+  animation-lab/              # Declarative animation + responsive reactor lab
   (each template follows: main.ts, types.ts, theme.ts, helpers/, screens/)
 ```
 
@@ -121,12 +122,13 @@ const Counter = defineWidget<{ initial: number; key?: string }>((props, ctx) => 
 });
 ```
 
-Available hooks: `ctx.useState()`, `ctx.useEffect()`, `ctx.useRef()`, `ctx.useMemo()`, `ctx.useCallback()`, `ctx.id()`.
+Available hooks: `ctx.useState()`, `ctx.useEffect()`, `ctx.useRef()`, `ctx.useMemo()`, `ctx.useCallback()`, `ctx.useAppState()`, `ctx.useViewport()`, `ctx.id()`.
+Animation utility hooks: `useTransition()`, `useSpring()`, `useSequence()`, `useStagger()`.
 
-### Layer 3 — Domain Hooks (for complex state)
+### Layer 3 — Domain Hooks (for complex state and motion)
 
 ```typescript
-import { useTable, useModalStack, useForm } from "@rezi-ui/core";
+import { useTransition, useSpring, useSequence, useStagger, useTable, useModalStack, useForm } from "@rezi-ui/core";
 ```
 
 ### Layer 4 — Raw VNodes (avoid unless necessary)
@@ -154,6 +156,7 @@ each(items, (item) => ui.text(item.name), { key: (item) => item.id });
 
 - All interactive widgets MUST have a unique `id` prop.
 - Hooks must be called in consistent order (no conditional hooks, no hooks in loops).
+- `ui.box` transition properties default to animating `position`, `size`, and `opacity`; constrain with explicit `properties` when needed.
 - Use `key` prop for list items to enable stable reconciliation.
 - State updates during render are forbidden (throws `ZRUI_UPDATE_DURING_RENDER`).
 - Duplicate interactive widget IDs are fatal (throws `ZRUI_DUPLICATE_ID`).
@@ -169,8 +172,9 @@ each(items, (item) => ui.text(item.name), { key: (item) => item.id });
 - Use `each()` / `eachInline()` for list rendering with keys.
 - Use `show()` / `when()` / `maybe()` / `match()` for conditional rendering.
 - Use `defineWidget()` for reusable stateful components.
+- Use `useTransition()` / `useSpring()` / `useSequence()` / `useStagger()` for declarative numeric motion.
 - Use `useTable()` for table state, `useModalStack()` for modal state.
-- Follow template structure: separate `screens/`, `helpers/state.ts`, `helpers/keybindings.ts`, `theme.ts`, `types.ts`.
+- Follow template structure: separate `screens/`, `helpers/state.ts`, `helpers/keybindings.ts`, `theme.ts`, `types.ts` (see `animation-lab` for motion-heavy screens).
 - Test with `createTestRenderer()` from the testing module.
 
 ### DON'T

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -55,6 +55,7 @@ npm run test:native:smoke
 - Binary parsing/building must follow the safety rules in the docs (bounded reads, alignment checks, deterministic failure).
 - Public APIs should be documented and stable within a release line.
 - Streaming hooks in `packages/core` must use runtime adapters/factories for environment-specific sources (`EventSource`, `WebSocket`, file tailing) and include cleanup + stale-update guards.
+- Animation hooks (`useTransition`, `useSpring`, `useSequence`, `useStagger`) and `ui.box` transition behavior must remain deterministic and be documented in docs + templates when user-visible behavior changes.
 
 ## Pull requests
 
@@ -76,6 +77,7 @@ PRs may be rejected if they:
 - TypeScript: strict mode (`npm run typecheck`)
 - Tests: `npm test` (keep tests deterministic and fast)
 - Hook changes: add/adjust hook docs (`docs/guide/hooks-reference.md`) and include race/cleanup tests.
+- Animation changes: update `docs/guide/animation.md` and `docs/widgets/box.md`, and add/adjust transition/hook tests.
 
 ## Interaction guidelines
 

--- a/README.md
+++ b/README.md
@@ -48,6 +48,7 @@ Rezi is a high-performance terminal UI framework for TypeScript. You write decla
 - **JSX without React** — optional `@rezi-ui/jsx` maps JSX directly to Rezi VNodes with zero React runtime overhead
 - **Deterministic rendering** — same state + same events = same frames; versioned binary protocol, pinned Unicode tables
 - **6 built-in themes** — dark, light, dimmed, high-contrast, nord, dracula; switch at runtime with one call
+- **Declarative animation APIs** — numeric hooks (`useTransition`, `useSpring`, `useSequence`, `useStagger`) and `ui.box` transition props for position/size/opacity motion
 - **Record & replay** — capture input sessions as deterministic bundles for debugging and automated testing
 
 ---
@@ -138,7 +139,7 @@ cd my-app
 bun start
 ```
 
-Starter templates: **EdgeOps control-plane dashboard** and **Visual benchmark stress test**.
+Starter templates: **dashboard**, **stress-test**, **cli-tool**, **animation-lab**, and **minimal**.
 
 ---
 

--- a/docs/api.md
+++ b/docs/api.md
@@ -33,5 +33,6 @@ The API reference is included at `out/site/api/reference/index.html`.
 For the most common APIs, see:
 
 - [Widget Catalog](widgets/index.md) - All widget types and props
+- [Animation Guide](guide/animation.md) - Declarative animation hooks and box transitions
 - [@rezi-ui/core](packages/core.md) - Core package exports
 - [@rezi-ui/node](packages/node.md) - Node.js/Bun backend

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -28,6 +28,7 @@ npm run docs:build
 ## Hook/API changes
 
 - For public hook changes, update `docs/guide/hooks-reference.md` and `docs/guide/composition.md` in the same PR.
+- For animation hook changes (`useTransition`, `useSpring`, `useSequence`, `useStagger`) or `ui.box` transition behavior, also update `docs/guide/animation.md` and `docs/widgets/box.md`.
 - Add deterministic lifecycle tests (mount, dependency change, unmount cleanup, stale async result guards).
 - If the hook depends on runtime capabilities, keep adapters in runtime packages (`@rezi-ui/node`, etc.), not in `@rezi-ui/core`.
 

--- a/docs/dev/repo-layout.md
+++ b/docs/dev/repo-layout.md
@@ -93,7 +93,7 @@ terminal.
 
 CLI scaffolding tool. Running `npm create rezi` generates a new Rezi project
 from built-in templates with proper `package.json`, `tsconfig.json`, and example
-code.
+code. Current templates: `dashboard`, `stress-test`, `cli-tool`, `animation-lab`, `minimal`.
 
 ### bench -- `@rezi-ui/bench` (private)
 

--- a/docs/dev/style-guide.md
+++ b/docs/dev/style-guide.md
@@ -150,6 +150,17 @@ When adding or using streaming hooks (`useStream`, `useEventSource`, `useWebSock
 - Ensure parser callbacks are total and defensive (`unknown` input, explicit narrowing, deterministic fallback behavior).
 - Test stale-update races (dependency changes/unmount before async completion) for every new streaming hook.
 
+## Animation Hook Conventions
+
+When adding or changing animation hooks (`useTransition`, `useSpring`, `useSequence`, `useStagger`) or `ui.box` transition behavior:
+
+- Keep interpolation deterministic for identical state + frame-time inputs.
+- Normalize durations/configs defensively (finite, non-negative, integer-ms where applicable).
+- Retarget from current animated state (avoid reset jumps on mid-flight updates).
+- Clamp bounded values (for example, `opacity` in `[0..1]`).
+- Ensure timers/subscriptions are cleaned up on dependency change and unmount.
+- Cover mount/update/retarget/unmount behavior in dedicated unit tests.
+
 ## Allocation Constraints in Hot Paths
 
 The rendering pipeline runs every frame (up to 60 fps by default). Allocations

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -177,6 +177,16 @@ Tests designed to exercise the system under extreme conditions:
 Stress tests verify that the runtime does not crash, exceed memory bounds, or
 exhibit non-linear performance degradation.
 
+## Animation Regression Suites
+
+Animation behavior has dedicated deterministic suites and should be run for any motion-related change:
+
+- `node --test packages/core/src/widgets/__tests__/composition.animationHooks.test.ts`
+- `node --test packages/core/src/app/__tests__/widgetRenderer.transition.test.ts`
+- `node --test packages/core/src/runtime/__tests__/commit.fastReuse.regression.test.ts`
+
+These suites cover hook retargeting/timer cleanup, `ui.box` transition property filters (`position`/`size`/`opacity`), and reconciliation fast-reuse correctness with transition props.
+
 ## Reconciliation Hardening Matrix
 
 Reconciliation edge-cases are covered by dedicated runtime suites:

--- a/docs/getting-started/create-rezi.md
+++ b/docs/getting-started/create-rezi.md
@@ -89,3 +89,4 @@ For package-level CLI reference (invocation forms and options), see [packages/cr
 
 - [Quickstart](quickstart.md) for manual setup.
 - [Examples](examples.md) for runnable repository examples.
+- [Animation Guide](../guide/animation.md) for transition/spring/sequence/stagger usage patterns.

--- a/docs/getting-started/examples.md
+++ b/docs/getting-started/examples.md
@@ -42,5 +42,6 @@ Use `create-rezi` templates (`dashboard`, `stress-test`, `cli-tool`, `animation-
 ## Next Steps
 
 - [Quickstart](quickstart.md) - Build your first app
+- [Animation Guide](../guide/animation.md) - Learn the declarative motion APIs used by `animation-lab`
 - [Widget Catalog](../widgets/index.md) - Browse available widgets
 - [Keybindings](../guide/input-and-focus.md) - Advanced input handling

--- a/docs/getting-started/quickstart.md
+++ b/docs/getting-started/quickstart.md
@@ -241,5 +241,6 @@ Key takeaways:
 - [Using JSX](jsx.md) - Prefer JSX syntax? Use `@rezi-ui/jsx` for a JSX-based widget API
 - [Widget Catalog](../widgets/index.md) - Browse all available widgets
 - [Layout Guide](../guide/layout.md) - Learn about spacing and alignment
+- [Animation Guide](../guide/animation.md) - Declarative motion with hooks and box transitions
 - [Styling Guide](../guide/styling.md) - Customize colors and themes
 - [Examples](examples.md) - More example applications

--- a/docs/guide/animation.md
+++ b/docs/guide/animation.md
@@ -1,0 +1,104 @@
+# Animation
+
+Rezi supports declarative motion in two layers:
+
+- **Hook-driven numeric animation** for custom widget behavior (`useTransition`, `useSpring`, `useSequence`, `useStagger`).
+- **Container transitions** for layout/surface animation on `ui.box(...)` via the `transition` prop.
+
+All animation APIs are deterministic for the same state/input sequence.
+
+## Choose the right API
+
+- Use `useTransition(...)` for direct time-based interpolation between numeric targets.
+- Use `useSpring(...)` for natural motion that eases based on spring physics.
+- Use `useSequence(...)` for keyframe timelines.
+- Use `useStagger(...)` for list/rail entry timing offsets.
+- Use `ui.box({ transition: ... })` when you want runtime-managed position/size/opacity transitions without writing hook logic.
+
+## Hook example
+
+```typescript
+import { defineWidget, ui, useSequence, useSpring, useStagger, useTransition } from "@rezi-ui/core";
+
+type ReactorProps = {
+  driftTarget: number;
+  fluxTarget: number;
+  modules: readonly string[];
+  key?: string;
+};
+
+export const ReactorRow = defineWidget<ReactorProps>((props, ctx) => {
+  const drift = useTransition(ctx, props.driftTarget, { duration: 180, easing: "easeOutCubic" });
+  const flux = useSpring(ctx, props.fluxTarget, { stiffness: 190, damping: 22 });
+  const pulse = useSequence(ctx, [0.25, 1, 0.4, 0.9], { duration: 120, loop: true });
+  const stagger = useStagger(ctx, props.modules, { delay: 40, duration: 180, easing: "easeOutCubic" });
+
+  return ui.column({ gap: 1 }, [
+    ui.text(`drift=${drift.toFixed(2)} flux=${flux.toFixed(2)} pulse=${pulse.toFixed(2)}`),
+    ui.row(
+      { gap: 1 },
+      props.modules.map((label, i) =>
+        ui.box(
+          {
+            key: label,
+            border: "rounded",
+            p: 1,
+            opacity: 0.3 + 0.7 * (stagger[i] ?? 0),
+          },
+          [ui.text(label)],
+        ),
+      ),
+    ),
+  ]);
+});
+```
+
+## Box transition props
+
+`ui.box(...)` supports declarative render-time transitions:
+
+```typescript
+ui.box(
+  {
+    id: "panel",
+    width: state.expanded ? 48 : 28,
+    opacity: state.focused ? 1 : 0.7,
+    transition: {
+      duration: 220,
+      easing: "easeInOutCubic",
+      properties: ["size", "opacity"],
+    },
+  },
+  [ui.text("Animated panel")],
+);
+```
+
+Behavior:
+
+- `properties` defaults to `"all"` when omitted (`position`, `size`, and `opacity`).
+- `properties: []` disables all animated tracks.
+- `opacity` is clamped to `[0..1]`.
+- Container transitions are currently supported on `box`.
+
+## Defaults and safety
+
+- Hook durations are normalized to safe non-negative integer milliseconds.
+- `useTransition` default duration: `160ms`.
+- `useSequence` default per-segment duration: `160ms`.
+- `useStagger` defaults: `delay=40ms`, `duration=180ms`.
+- `ui.box` transition default duration: `180ms`.
+- Non-finite numeric targets snap safely instead of producing unstable interpolation.
+
+## Performance guidance
+
+- Drive animation from state targets; avoid ad-hoc timer loops in app/view code.
+- Keep animated values numeric and local; derive display strings lazily in render.
+- For large animated collections, combine `useStagger(...)` with windowing (`ui.virtualList(...)`) to cap visible work.
+
+## Related
+
+- [Hooks Reference](hooks-reference.md)
+- [Composition](composition.md)
+- [Box](../widgets/box.md)
+- [Performance](performance.md)
+- [Create Rezi templates](../getting-started/create-rezi.md)

--- a/docs/guide/composition.md
+++ b/docs/guide/composition.md
@@ -56,6 +56,11 @@ const onSubmit = ctx.useCallback(() => save(filteredRows), [save, filteredRows])
 
 Rezi ships a small utility-hook layer for common composition patterns:
 
+- Animation hooks for numeric motion and sequencing:
+  - `useTransition(ctx, value, config?)` interpolates toward a numeric target over duration/easing.
+  - `useSpring(ctx, target, config?)` animates toward a target with spring physics.
+  - `useSequence(ctx, keyframes, config?)` runs keyframe timelines (optional loop).
+  - `useStagger(ctx, items, config?)` returns per-item eased progress for staggered entrances.
 - `useDebounce(ctx, value, delayMs)` returns a debounced value.
 - `useAsync(ctx, task, deps)` runs async tasks with loading/error state and stale-result protection.
 - `usePrevious(ctx, value)` returns the previous render value.
@@ -71,6 +76,10 @@ import {
   ui,
   useAsync,
   useDebounce,
+  useSequence,
+  useSpring,
+  useStagger,
+  useTransition,
   usePrevious,
   useStream,
 } from "@rezi-ui/core";
@@ -96,6 +105,17 @@ const SearchResults = defineWidget<SearchProps>((props, ctx) => {
   ]);
 });
 
+const AnimatedValue = defineWidget<{ value: number; key?: string }>((props, ctx) => {
+  const eased = useTransition(ctx, props.value, { duration: 160, easing: "easeOutCubic" });
+  const spring = useSpring(ctx, props.value, { stiffness: 180, damping: 22 });
+  const pulse = useSequence(ctx, [0.2, 1, 0.4, 1], { duration: 120, loop: true });
+  const stagger = useStagger(ctx, [0, 1, 2], { delay: 30, duration: 140 });
+
+  return ui.text(
+    `eased=${eased.toFixed(1)} spring=${spring.toFixed(1)} pulse=${pulse.toFixed(2)} stagger0=${(stagger[0] ?? 0).toFixed(2)}`,
+  );
+});
+
 async function fetchResults(query: string): Promise<string[]> {
   return query.length > 0 ? [query] : [];
 }
@@ -117,6 +137,7 @@ const LiveMetric = defineWidget<{ key?: string }>((props, ctx) => {
 ## Related
 
 - [Concepts](concepts.md)
+- [Animation](animation.md)
 - [Lifecycle & updates](lifecycle-and-updates.md)
 - [Widget catalog](../widgets/index.md)
 - [API reference](../api/reference/index.html)

--- a/docs/guide/index.md
+++ b/docs/guide/index.md
@@ -4,6 +4,7 @@ Core Rezi guides:
 
 - [Concepts](concepts.md)
 - [Composition](composition.md)
+- [Animation](animation.md)
 - [Runtime & Layout](runtime-and-layout.md)
 - [Lifecycle & Updates](lifecycle-and-updates.md)
 - [Routing](routing.md)
@@ -15,3 +16,4 @@ Core Rezi guides:
 - [Performance](performance.md)
 - [Debugging](debugging.md)
 - [Record & Replay](record-replay.md)
+- [Hooks Reference](hooks-reference.md)

--- a/docs/guide/performance.md
+++ b/docs/guide/performance.md
@@ -31,8 +31,8 @@ Patterns:
 - Precompute derived data in state updates instead of inside `view`.
 - Keep large static arrays/constants outside the view closure.
 - Prefer event handlers that call `app.update(...)` without doing heavy work in render.
-- For animation, prefer tick-driven widget updates over ad-hoc timer loops; Rezi
-  bounds animation cadence to keep render and input responsive.
+- For animation, prefer declarative hooks (`useTransition`, `useSpring`, `useSequence`, `useStagger`) and `ui.box` transition props over ad-hoc timer loops in app/view code.
+- Rezi bounds animation cadence to keep render and input responsive.
 
 ## Virtual lists
 

--- a/docs/index.md
+++ b/docs/index.md
@@ -46,6 +46,9 @@ await app.start();
 **Theming**
 : Six built-in themes (dark, light, dimmed, high-contrast, nord, dracula) with semantic color tokens.
 
+**Declarative Animation**
+: Built-in animation hooks (`useTransition`, `useSpring`, `useSequence`, `useStagger`) plus container transition props on `ui.box(...)`.
+
 **Keybindings**
 : First-class support for modal keybindings with chord sequences (Vim-style `g g`, Emacs-style `C-x C-s`).
 
@@ -217,6 +220,7 @@ User feedback: `spinner`, `skeleton`, `callout`, `errorDisplay`, `empty`
 - [Layout](guide/layout.md) - Spacing, alignment, and constraints
 - [Input & Focus](guide/input-and-focus.md) - Keyboard navigation and focus management
 - [Mouse Support](guide/mouse-support.md) - Click, scroll, and drag interactions
+- [Animation](guide/animation.md) - Declarative motion hooks and box transitions
 - [Styling](guide/styling.md) - Colors, themes, and visual customization
 - [Graphics](guide/graphics.md) - Capability-aware rendering and progressive enhancement
 - [Performance](guide/performance.md) - Optimization techniques

--- a/docs/packages/core.md
+++ b/docs/packages/core.md
@@ -54,6 +54,30 @@ app.setTheme(nordTheme);
 
 Create custom themes with `createThemeDefinition()`.
 
+### Animation Primitives
+
+Declarative animation hooks and container transitions:
+
+```typescript
+import { defineWidget, ui, useSpring, useTransition } from "@rezi-ui/core";
+
+const AnimatedMeter = defineWidget<{ target: number; key?: string }>((props, ctx) => {
+  const eased = useTransition(ctx, props.target, { duration: 160, easing: "easeOutCubic" });
+  const spring = useSpring(ctx, props.target, { stiffness: 180, damping: 22 });
+
+  return ui.box(
+    {
+      width: Math.round(16 + eased),
+      opacity: Math.max(0.35, Math.min(1, spring / 100)),
+      transition: { duration: 180, properties: ["size", "opacity"] },
+    },
+    [ui.text(`Target: ${props.target}`)],
+  );
+});
+```
+
+Hooks: `useTransition`, `useSpring`, `useSequence`, `useStagger`.
+
 ### Form Management
 
 Form state management with validation:
@@ -214,6 +238,16 @@ await debug.enable({
 | `form.bind(...)`, `form.field(...)` | One-line input/field wiring helpers on `useForm` return |
 | `bind`, `bindChecked`, `bindSelect` | Standalone binding helpers for plain state objects |
 | `FormState`, `UseFormReturn` | Form types |
+
+### Animation
+
+| Export | Description |
+|--------|-------------|
+| `useTransition`, `UseTransitionConfig` | Time-based numeric interpolation hook + config type |
+| `useSpring`, `UseSpringConfig` | Spring-physics numeric animation hook + config type |
+| `useSequence`, `UseSequenceConfig` | Keyframe timeline hook + config type |
+| `useStagger`, `UseStaggerConfig` | Staggered per-item progress hook + config type |
+| `TransitionSpec`, `TransitionProperty` | `ui.box` transition prop type + allowed properties |
 
 ### Testing
 

--- a/docs/packages/create-rezi.md
+++ b/docs/packages/create-rezi.md
@@ -30,6 +30,8 @@ Canonical template names:
 - `animation-lab` (aliases: `animation`, `anim`, `lab`, `motion`)
 - `minimal` (aliases: `mini`, `basic`, `utility`)
 
+`animation-lab` is the canonical reference for Rezi's declarative motion APIs (`useTransition`, `useSpring`, `useSequence`, `useStagger`) plus `ui.box` transition props.
+
 Use a specific template:
 
 ```bash

--- a/docs/packages/index.md
+++ b/docs/packages/index.md
@@ -41,6 +41,7 @@ The core package defines Rezi's runtime-agnostic API and contains:
 - All widget constructors (`ui.text`, `ui.button`, `ui.table`, etc.)
 - Layout engine with flexbox-like semantics
 - Theme system with six built-in presets
+- Declarative animation hooks and `ui.box` transition props
 - Form management and validation
 - Keybinding parser with chord support
 - Focus management utilities

--- a/docs/styling/style-props.md
+++ b/docs/styling/style-props.md
@@ -102,7 +102,31 @@ ui.box({ p: "md", border: "rounded" }, [
 ]);
 ```
 
+## Container opacity and transitions
+
+`ui.box(...)` also supports surface opacity and declarative transitions:
+
+```typescript
+import { ui } from "@rezi-ui/core";
+
+ui.box(
+  {
+    width: state.open ? 40 : 24,
+    opacity: state.open ? 1 : 0.6,
+    transition: { duration: 180, easing: "easeOutCubic", properties: ["size", "opacity"] },
+  },
+  [ui.text("Panel")],
+);
+```
+
+Notes:
+
+- `opacity` is clamped to `[0..1]`.
+- `transition.properties` defaults to `"all"` (`position`, `size`, `opacity`) when omitted.
+- Use `properties: []` to disable animated tracks explicitly.
+
 ## Related
 
 - [Theme](theme.md) - Theme structure and presets
 - [Styling overview](index.md) - How themes and style props work together
+- [Animation guide](../guide/animation.md) - Hook and transition patterns

--- a/docs/widgets/box.md
+++ b/docs/widgets/box.md
@@ -23,6 +23,8 @@ ui.box({ title: "Settings", border: "rounded", p: 1 }, [
 | `border` | `"none" \| "single" \| "double" \| "rounded" \| "heavy" \| "dashed" \| "heavy-dashed"` | `"single"` | Border style |
 | `shadow` | `boolean \| { offsetX?: number; offsetY?: number; density?: \"light\" \| \"medium\" \| \"dense\" }` | - | Shadow effect for depth |
 | `style` | `TextStyle` | - | Style applied to the box surface (bg fills the rect) |
+| `opacity` | `number` | `1` | Surface opacity in `[0..1]` (values are clamped) |
+| `transition` | `TransitionSpec` | - | Declarative render-time transition for `position`, `size`, and/or `opacity` |
 | `p`, `px`, `py`, `pt`, `pr`, `pb`, `pl` | `SpacingValue` | - | Padding props |
 | `m`, `mx`, `my` | `SpacingValue` | - | Margin props |
 | `width`, `height` | `number \| \"auto\" \| \"${number}%\"` | - | Size constraints |
@@ -58,12 +60,37 @@ ui.row({ gap: 1 }, [
 ]);
 ```
 
+### 3) Declarative transition (size + opacity)
+
+```typescript
+import { ui } from "@rezi-ui/core";
+
+ui.box(
+  {
+    id: "details-panel",
+    width: state.expanded ? 48 : 28,
+    opacity: state.expanded ? 1 : 0.65,
+    border: "rounded",
+    p: 1,
+    transition: {
+      duration: 220,
+      easing: "easeInOutCubic",
+      properties: ["size", "opacity"],
+    },
+  },
+  [ui.text("Animated container")],
+);
+```
+
 ## Notes
 
 - Borders consume 1 cell on each edge (unless `border: "none"`).
 - Padding is applied inside the border and reduces child content area.
+- `transition.properties` defaults to `"all"` when omitted (`position`, `size`, `opacity`).
+- `transition.properties: []` disables animation tracks for that box.
 
 ## Related
 
 - [Layout](../guide/layout.md) - Borders, padding, nesting
+- [Animation](../guide/animation.md) - Motion hooks and transition props
 - [Row / Column](stack.md) - Stack layouts

--- a/docs/widgets/catalog.json
+++ b/docs/widgets/catalog.json
@@ -11,7 +11,7 @@
     {
       "name": "box",
       "requiredProps": [],
-      "commonProps": ["border", "p", "style", "children"],
+      "commonProps": ["border", "p", "style", "opacity", "transition", "children"],
       "example": "ui.box({ border: 'rounded', p: 1 }, [ui.text('Body')])"
     },
     {

--- a/docs/widgets/index.md
+++ b/docs/widgets/index.md
@@ -33,7 +33,7 @@ Container and spacing primitives for arranging widgets.
 
 | Factory | Description | Focusable | Stability |
 |---------|-------------|-----------|-----------|
-| [`ui.box(props, children)`](box.md) | Container with border, padding, title | No | `stable` |
+| [`ui.box(props, children)`](box.md) | Container with border, padding, title, and optional transition/opacity props | No | `stable` |
 | [`ui.row(props, children)`](stack.md) | Horizontal stack layout | No | `stable` |
 | [`ui.column(props, children)`](stack.md) | Vertical stack layout | No | `stable` |
 | [`ui.hstack(...)`](stack.md) | Shorthand horizontal stack (accepts gap number, props, or just children) | No | `stable` |

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -110,6 +110,7 @@ nav:
       - Index: guide/index.md
       - Concepts: guide/concepts.md
       - Composition: guide/composition.md
+      - Animation: guide/animation.md
       - Runtime & Layout: guide/runtime-and-layout.md
       - Lifecycle & Updates: guide/lifecycle-and-updates.md
       - Routing: guide/routing.md

--- a/packages/core/README.md
+++ b/packages/core/README.md
@@ -3,10 +3,11 @@
 Runtime-agnostic TypeScript core for Rezi:
 
 - widget constructors (`ui.*`)
+- declarative animation hooks (`useTransition`, `useSpring`, `useSequence`, `useStagger`)
+- box transition props (`transition`, `opacity`)
 - reconciliation + layout + focus + routing
 - drawlist building (ZRDL) and event batch parsing (ZREV)
 
 Most applications should use the Node backend package (`@rezi-ui/node`), which depends on this package.
 
 Docs: `https://rezitui.dev/docs`
-


### PR DESCRIPTION
## Summary
This PR comprehensively documents the functionality introduced in #144 across public docs, internal guidelines, and AI skills.

### Public documentation
- Added a dedicated animation guide covering `useTransition`, `useSpring`, `useSequence`, `useStagger`, and `ui.box` transition props
- Expanded hooks reference with signatures, behavior notes, and examples for all four animation hooks
- Updated `ui.box` docs and style-props docs for `opacity` + `transition` behavior
- Updated package and getting-started docs to surface animation APIs and the `animation-lab` template
- Wired the new guide into MkDocs nav and guide indexes

### Internal docs and contributor guidance
- Updated `AGENTS.md`, `CLAUDE.md`, and contribution/style/testing guidance to include animation APIs, template inventory, and animation-specific test expectations

### Claude/Codex skills
- Updated relevant skills in both `.claude/skills/*` and `.codex/skills/*` (`rezi-create-screen`, `rezi-debug-rendering`, `rezi-perf-profiling`, `rezi-write-tests`) to include animation-aware workflows

## Validation
- `npm run build`
- `npm run check:docs`