### PR TITLE
fix(protocol): align ABI mouse-kind mapping across docs, types, and runtime

### DIFF
--- a/docs/protocol/abi.md
+++ b/docs/protocol/abi.md
@@ -153,10 +153,10 @@ Mouse kinds:
 | Mouse kind | Value |
 |---|---:|
 | `move` | `1` |
-| `press` | `2` |
-| `release` | `3` |
-| `drag` | `4` |
-| `scroll` | `5` |
+| `drag` | `2` |
+| `down` | `3` |
+| `up` | `4` |
+| `wheel` | `5` |
 
 ## Related
 

--- a/packages/core/src/protocol/__tests__/mouseKinds.test.ts
+++ b/packages/core/src/protocol/__tests__/mouseKinds.test.ts
@@ -1,0 +1,19 @@
+import assert from "node:assert/strict";
+import { describe, test } from "node:test";
+import {
+  ZR_MOUSE_DOWN,
+  ZR_MOUSE_DRAG,
+  ZR_MOUSE_MOVE,
+  ZR_MOUSE_UP,
+  ZR_MOUSE_WHEEL,
+} from "../mouseKinds.js";
+
+describe("mouseKinds ABI mapping", () => {
+  test("matches zr_event.h values", () => {
+    assert.equal(ZR_MOUSE_MOVE, 1);
+    assert.equal(ZR_MOUSE_DRAG, 2);
+    assert.equal(ZR_MOUSE_DOWN, 3);
+    assert.equal(ZR_MOUSE_UP, 4);
+    assert.equal(ZR_MOUSE_WHEEL, 5);
+  });
+});

--- a/packages/core/src/protocol/mouseKinds.ts
+++ b/packages/core/src/protocol/mouseKinds.ts
@@ -1,0 +1,5 @@
+export const ZR_MOUSE_MOVE = 1 as const;
+export const ZR_MOUSE_DRAG = 2 as const;
+export const ZR_MOUSE_DOWN = 3 as const;
+export const ZR_MOUSE_UP = 4 as const;
+export const ZR_MOUSE_WHEEL = 5 as const;

--- a/packages/core/src/protocol/types.ts
+++ b/packages/core/src/protocol/types.ts
@@ -39,7 +39,7 @@ export type ZrevKeyAction = "down" | "up" | "repeat";
 
 /**
  * Mouse event kind enumeration (matches ZREV binary values).
- *   1 = move, 2 = press, 3 = release, 4 = drag, 5 = scroll
+ *   1 = move, 2 = drag, 3 = down, 4 = up, 5 = wheel
  */
 export type ZrevMouseKind = 1 | 2 | 3 | 4 | 5;
 

--- a/packages/core/src/runtime/router/mouse.ts
+++ b/packages/core/src/runtime/router/mouse.ts
@@ -1,9 +1,6 @@
 import type { ZrevEvent } from "../../events.js";
+import { ZR_MOUSE_DOWN, ZR_MOUSE_UP } from "../../protocol/mouseKinds.js";
 import type { EnabledById, MouseRoutingCtx, RoutedAction, RoutingResult } from "./types.js";
-
-/* Mouse kind values (locked by ABI) */
-const ZR_MOUSE_KIND_DOWN = 3;
-const ZR_MOUSE_KIND_UP = 4;
 
 function isEnabled(enabledById: EnabledById, id: string): boolean {
   return enabledById.get(id) === true;
@@ -19,7 +16,7 @@ export function routeMouse(event: ZrevEvent, ctx: MouseRoutingCtx): RoutingResul
 
   const targetId = ctx.hitTestTargetId;
 
-  if (event.mouseKind === ZR_MOUSE_KIND_DOWN) {
+  if (event.mouseKind === ZR_MOUSE_DOWN) {
     if (targetId !== null && isEnabled(ctx.enabledById, targetId)) {
       const pressable = ctx.pressableIds ? ctx.pressableIds.has(targetId) : true;
       return Object.freeze({ nextFocusedId: targetId, nextPressedId: pressable ? targetId : null });
@@ -27,7 +24,7 @@ export function routeMouse(event: ZrevEvent, ctx: MouseRoutingCtx): RoutingResul
     return Object.freeze({ nextPressedId: null });
   }
 
-  if (event.mouseKind === ZR_MOUSE_KIND_UP) {
+  if (event.mouseKind === ZR_MOUSE_UP) {
     const pressedId = ctx.pressedId;
     if (
       pressedId !== null &&

--- a/packages/core/src/testing/events.ts
+++ b/packages/core/src/testing/events.ts
@@ -11,6 +11,7 @@
 import { ZREV_MAGIC, ZR_EVENT_BATCH_VERSION_V1 } from "../abi.js";
 import type { BackendEventBatch } from "../backend.js";
 import { KEY_NAME_TO_CODE, charToKeyCode } from "../keybindings/keyCodes.js";
+import { ZR_MOUSE_DOWN, ZR_MOUSE_UP, ZR_MOUSE_WHEEL } from "../protocol/mouseKinds.js";
 import type { ZrevKeyAction, ZrevMouseKind } from "../protocol/types.js";
 
 const BATCH_HEADER_SIZE = 24;
@@ -24,9 +25,9 @@ const MOUSE_RECORD_SIZE = 48;
 const RESIZE_RECORD_SIZE = 32;
 const TICK_RECORD_SIZE = 32;
 
-export const TEST_MOUSE_KIND_DOWN: ZrevMouseKind = 3;
-export const TEST_MOUSE_KIND_UP: ZrevMouseKind = 4;
-export const TEST_MOUSE_KIND_SCROLL: ZrevMouseKind = 5;
+export const TEST_MOUSE_KIND_DOWN: ZrevMouseKind = ZR_MOUSE_DOWN;
+export const TEST_MOUSE_KIND_UP: ZrevMouseKind = ZR_MOUSE_UP;
+export const TEST_MOUSE_KIND_SCROLL: ZrevMouseKind = ZR_MOUSE_WHEEL;
 
 export type TestZrevEvent =
   | Readonly<{


### PR DESCRIPTION
Fixes drift between C engine header (zr_event.h), protocol docs, and TS type comments for mouse kind numeric values.
Introduces canonical mouseKinds.ts constants module as single source of truth.