### PR TITLE
test(core): add input recipe rendering coverage

### DIFF
--- a/packages/core/src/renderer/__tests__/inputRecipeRendering.test.ts
+++ b/packages/core/src/renderer/__tests__/inputRecipeRendering.test.ts
@@ -1,0 +1,102 @@
+import { assert, describe, test } from "@rezi-ui/testkit";
+import { defaultTheme } from "../../theme/defaultTheme.js";
+import { coerceToLegacyTheme } from "../../theme/interop.js";
+import { darkTheme } from "../../theme/presets.js";
+import { ui } from "../../widgets/ui.js";
+import { type DrawOp, renderOps } from "./recipeRendering.test-utils.js";
+
+const dsTheme = coerceToLegacyTheme(darkTheme);
+
+function firstDrawText(
+  ops: readonly DrawOp[],
+  match: (text: string) => boolean,
+): DrawOp | undefined {
+  return ops.find((op) => op.kind === "drawText" && match(op.text));
+}
+
+describe("input recipe rendering", () => {
+  test("uses recipe colors with semantic-token themes", () => {
+    const ops = renderOps(
+      ui.row({ height: 3, items: "stretch" }, [ui.input("name", "", { placeholder: "Name" })]),
+      { viewport: { cols: 40, rows: 5 }, theme: dsTheme },
+    );
+    const fill = ops.find((op) => op.kind === "fillRect");
+    assert.ok(fill !== undefined, "input should fill recipe background");
+    if (!fill || fill.kind !== "fillRect") return;
+    assert.deepEqual(fill.style?.bg, dsTheme.colors["bg.elevated"]);
+
+    const border = firstDrawText(ops, (text) => text.includes("┌"));
+    assert.ok(border !== undefined, "input should render recipe border");
+    if (!border || border.kind !== "drawText") return;
+    assert.deepEqual(border.style?.fg, dsTheme.colors["border.default"]);
+  });
+
+  test("keeps legacy fallback path for non-semantic themes", () => {
+    const ops = renderOps(
+      ui.row({ height: 3, items: "stretch" }, [ui.input("legacy", "", { placeholder: "Name" })]),
+      { viewport: { cols: 40, rows: 5 }, theme: defaultTheme },
+    );
+    assert.equal(
+      ops.some((op) => op.kind === "fillRect"),
+      false,
+      "legacy input should not fill recipe background",
+    );
+    assert.equal(
+      ops.some((op) => op.kind === "drawText" && /[┌┐└┘]/.test(op.text)),
+      false,
+      "legacy input should not render recipe border",
+    );
+  });
+
+  test("increases left padding when dsSize is lg", () => {
+    const mdOps = renderOps(
+      ui.column({ width: 20, items: "stretch" }, [ui.input("i-md", "", { placeholder: "Name" })]),
+      { viewport: { cols: 40, rows: 5 }, theme: dsTheme },
+    );
+    const lgOps = renderOps(
+      ui.column({ width: 20, items: "stretch" }, [
+        ui.input({ id: "i-lg", value: "", placeholder: "Name", dsSize: "lg" }),
+      ]),
+      { viewport: { cols: 40, rows: 5 }, theme: dsTheme },
+    );
+    const mdText = firstDrawText(mdOps, (text) => text.includes("Name"));
+    const lgText = firstDrawText(lgOps, (text) => text.includes("Name"));
+    assert.ok(mdText && mdText.kind === "drawText");
+    assert.ok(lgText && lgText.kind === "drawText");
+    if (!mdText || mdText.kind !== "drawText" || !lgText || lgText.kind !== "drawText") return;
+    assert.ok(lgText.x > mdText.x, "lg input should indent text more than md");
+  });
+
+  test("uses disabled recipe colors", () => {
+    const ops = renderOps(
+      ui.row({ height: 3, items: "stretch" }, [
+        ui.input({ id: "disabled", value: "hello", disabled: true }),
+      ]),
+      { viewport: { cols: 40, rows: 5 }, theme: dsTheme },
+    );
+    const fill = ops.find((op) => op.kind === "fillRect");
+    assert.ok(fill !== undefined);
+    if (!fill || fill.kind !== "fillRect") return;
+    assert.deepEqual(fill.style?.bg, dsTheme.colors["disabled.bg"]);
+
+    const text = firstDrawText(ops, (s) => s.includes("hello"));
+    assert.ok(text && text.kind === "drawText");
+    if (!text || text.kind !== "drawText") return;
+    assert.deepEqual(text.style?.fg, dsTheme.colors["disabled.fg"]);
+  });
+
+  test("uses focused recipe border color", () => {
+    const ops = renderOps(
+      ui.row({ height: 3, items: "stretch" }, [ui.input("focus-input", "hello")]),
+      { viewport: { cols: 40, rows: 5 }, theme: dsTheme, focusedId: "focus-input" },
+    );
+    const focusBorder = firstDrawText(ops, (text) => text.includes("┏"));
+    assert.ok(
+      focusBorder && focusBorder.kind === "drawText",
+      "focused input should use heavy border",
+    );
+    if (!focusBorder || focusBorder.kind !== "drawText") return;
+    assert.deepEqual(focusBorder.style?.fg, dsTheme.colors["accent.primary"]);
+    assert.equal(focusBorder.style?.bold, true);
+  });
+});

--- a/packages/core/src/renderer/__tests__/recipeRendering.test-utils.ts
+++ b/packages/core/src/renderer/__tests__/recipeRendering.test-utils.ts
@@ -1,0 +1,105 @@
+import { assert } from "@rezi-ui/testkit";
+import type { DrawlistTextRunSegment } from "../../drawlist/types.js";
+import type {
+  DrawlistBuildResult,
+  DrawlistBuilderV1,
+  TextStyle,
+  Theme,
+  VNode,
+} from "../../index.js";
+import { layout } from "../../layout/layout.js";
+import type { Axis } from "../../layout/types.js";
+import { commitVNodeTree } from "../../runtime/commit.js";
+import { createInstanceIdAllocator } from "../../runtime/instance.js";
+import { renderToDrawlist } from "../renderToDrawlist.js";
+
+export type DrawOp =
+  | Readonly<{ kind: "clear" }>
+  | Readonly<{ kind: "clearTo"; cols: number; rows: number; style?: TextStyle }>
+  | Readonly<{ kind: "fillRect"; x: number; y: number; w: number; h: number; style?: TextStyle }>
+  | Readonly<{ kind: "drawText"; x: number; y: number; text: string; style?: TextStyle }>
+  | Readonly<{ kind: "pushClip"; x: number; y: number; w: number; h: number }>
+  | Readonly<{ kind: "popClip" }>;
+
+class RecordingBuilder implements DrawlistBuilderV1 {
+  readonly ops: DrawOp[] = [];
+
+  clear(): void {
+    this.ops.push({ kind: "clear" });
+  }
+
+  clearTo(cols: number, rows: number, style?: TextStyle): void {
+    this.ops.push(style ? { kind: "clearTo", cols, rows, style } : { kind: "clearTo", cols, rows });
+  }
+
+  fillRect(x: number, y: number, w: number, h: number, style?: TextStyle): void {
+    this.ops.push(
+      style ? { kind: "fillRect", x, y, w, h, style } : { kind: "fillRect", x, y, w, h },
+    );
+  }
+
+  drawText(x: number, y: number, text: string, style?: TextStyle): void {
+    this.ops.push(
+      style ? { kind: "drawText", x, y, text, style } : { kind: "drawText", x, y, text },
+    );
+  }
+
+  pushClip(x: number, y: number, w: number, h: number): void {
+    this.ops.push({ kind: "pushClip", x, y, w, h });
+  }
+
+  popClip(): void {
+    this.ops.push({ kind: "popClip" });
+  }
+
+  addBlob(_bytes: Uint8Array): number | null {
+    return null;
+  }
+
+  addTextRunBlob(_segments: readonly DrawlistTextRunSegment[]): number | null {
+    // Force deterministic drawText commands for style assertions.
+    return null;
+  }
+
+  drawTextRun(_x: number, _y: number, _blobIndex: number): void {}
+
+  build(): DrawlistBuildResult {
+    return { ok: true, bytes: new Uint8Array() };
+  }
+
+  reset(): void {
+    this.ops.length = 0;
+  }
+}
+
+export type RenderOpsOptions = Readonly<{
+  viewport?: Readonly<{ cols: number; rows: number }>;
+  axis?: Axis;
+  focusedId?: string | null;
+  pressedId?: string | null;
+  theme?: Theme;
+}>;
+
+export function renderOps(vnode: VNode, options: RenderOpsOptions = {}): readonly DrawOp[] {
+  const viewport = options.viewport ?? { cols: 80, rows: 24 };
+  const axis = options.axis ?? "column";
+  const committed = commitVNodeTree(null, vnode, { allocator: createInstanceIdAllocator(1) });
+  assert.equal(committed.ok, true, "commit should succeed");
+  if (!committed.ok) return Object.freeze([]);
+
+  const laidOut = layout(committed.value.root.vnode, 0, 0, viewport.cols, viewport.rows, axis);
+  assert.equal(laidOut.ok, true, "layout should succeed");
+  if (!laidOut.ok) return Object.freeze([]);
+
+  const builder = new RecordingBuilder();
+  renderToDrawlist({
+    tree: committed.value.root,
+    layout: laidOut.value,
+    viewport,
+    focusState: Object.freeze({ focusedId: options.focusedId ?? null }),
+    pressedId: options.pressedId ?? null,
+    ...(options.theme ? { theme: options.theme } : {}),
+    builder,
+  });
+  return Object.freeze(builder.ops.slice());
+}


### PR DESCRIPTION
## Summary
- add deterministic renderer test utilities for recipe-style assertions
- add input recipe rendering coverage for semantic-token themes and legacy fallback
- verify focused, disabled, and `dsSize: lg` input behaviors

## Testing
- `node scripts/run-tests.mjs`
