### PR TITLE
feat(core): wire checkbox and radioGroup recipes

### DIFF
--- a/packages/core/src/renderer/__tests__/checkboxRecipeRendering.test.ts
+++ b/packages/core/src/renderer/__tests__/checkboxRecipeRendering.test.ts
@@ -1,0 +1,78 @@
+import { assert, describe, test } from "@rezi-ui/testkit";
+import { coerceToLegacyTheme } from "../../theme/interop.js";
+import { darkTheme } from "../../theme/presets.js";
+import { ui } from "../../widgets/ui.js";
+import { type DrawOp, renderOps } from "./recipeRendering.test-utils.js";
+
+const dsTheme = coerceToLegacyTheme(darkTheme);
+
+function findTextOp(ops: readonly DrawOp[], text: string): DrawOp | undefined {
+  return ops.find((op) => op.kind === "drawText" && op.text === text);
+}
+
+describe("checkbox recipe rendering", () => {
+  test("uses recipe colors with semantic-token themes", () => {
+    const ops = renderOps(ui.checkbox({ id: "cb", checked: false, label: "Option" }), {
+      viewport: { cols: 40, rows: 3 },
+      theme: dsTheme,
+    });
+    const indicator = findTextOp(ops, "[ ]");
+    const label = findTextOp(ops, "Option");
+    assert.ok(indicator && indicator.kind === "drawText");
+    assert.ok(label && label.kind === "drawText");
+    if (!indicator || indicator.kind !== "drawText" || !label || label.kind !== "drawText") return;
+    assert.deepEqual(indicator.style?.fg, dsTheme.colors["fg.secondary"]);
+    assert.deepEqual(label.style?.fg, dsTheme.colors["fg.primary"]);
+  });
+
+  test("renders checked indicator with selected recipe style", () => {
+    const uncheckedOps = renderOps(ui.checkbox({ id: "u", checked: false, label: "U" }), {
+      viewport: { cols: 30, rows: 2 },
+      theme: dsTheme,
+    });
+    const checkedOps = renderOps(ui.checkbox({ id: "c", checked: true, label: "C" }), {
+      viewport: { cols: 30, rows: 2 },
+      theme: dsTheme,
+    });
+    const unchecked = findTextOp(uncheckedOps, "[ ]");
+    const checked = findTextOp(checkedOps, "[x]");
+    assert.ok(unchecked && unchecked.kind === "drawText");
+    assert.ok(checked && checked.kind === "drawText");
+    if (!unchecked || unchecked.kind !== "drawText" || !checked || checked.kind !== "drawText")
+      return;
+    assert.notDeepEqual(checked.style?.fg, unchecked.style?.fg);
+    assert.deepEqual(checked.style?.fg, dsTheme.colors["accent.primary"]);
+  });
+
+  test("uses disabled recipe colors", () => {
+    const ops = renderOps(
+      ui.checkbox({ id: "d", checked: true, label: "Disabled", disabled: true }),
+      {
+        viewport: { cols: 40, rows: 2 },
+        theme: dsTheme,
+      },
+    );
+    const indicator = findTextOp(ops, "[x]");
+    const label = findTextOp(ops, "Disabled");
+    assert.ok(indicator && indicator.kind === "drawText");
+    assert.ok(label && label.kind === "drawText");
+    if (!indicator || indicator.kind !== "drawText" || !label || label.kind !== "drawText") return;
+    assert.deepEqual(indicator.style?.fg, dsTheme.colors["disabled.fg"]);
+    assert.deepEqual(label.style?.fg, dsTheme.colors["disabled.fg"]);
+  });
+
+  test("uses focus recipe styling when focused", () => {
+    const ops = renderOps(ui.checkbox({ id: "f", checked: false, label: "Focus me" }), {
+      viewport: { cols: 40, rows: 2 },
+      theme: dsTheme,
+      focusedId: "f",
+    });
+    const indicator = findTextOp(ops, "[ ]");
+    const label = findTextOp(ops, "Focus me");
+    assert.ok(indicator && indicator.kind === "drawText");
+    assert.ok(label && label.kind === "drawText");
+    if (!indicator || indicator.kind !== "drawText" || !label || label.kind !== "drawText") return;
+    assert.equal(indicator.style?.bold, true);
+    assert.equal(label.style?.bold, true);
+  });
+});

--- a/packages/core/src/ui/recipes.ts
+++ b/packages/core/src/ui/recipes.ts
@@ -513,6 +513,8 @@ export function dividerRecipe(colors: ColorTokens): DividerRecipeResult {
 export type CheckboxRecipeParams = Readonly<{
   state?: WidgetState;
   checked?: boolean;
+  tone?: WidgetTone;
+  size?: WidgetSize;
 }>;
 
 export type CheckboxRecipeResult = Readonly<{
@@ -528,6 +530,10 @@ export function checkboxRecipe(
 ): CheckboxRecipeResult {
   const state = params.state ?? "default";
   const checked = params.checked ?? false;
+  const tone = params.tone ?? "default";
+  const large = params.size === "lg";
+  const selected = checked || state === "selected";
+  const selectedColor = resolveToneColor(colors, tone);
 
   if (state === "disabled") {
     return {
@@ -539,12 +545,12 @@ export function checkboxRecipe(
   const isFocused = state === "focus";
   return {
     indicator: {
-      fg: checked ? colors.accent.primary : colors.fg.secondary,
-      bold: isFocused,
+      fg: selected ? selectedColor : colors.fg.secondary,
+      bold: isFocused || large,
     },
     label: {
       fg: colors.fg.primary,
-      bold: isFocused,
+      bold: isFocused || large,
     },
   };
 }

--- a/packages/core/src/widgets/types.ts
+++ b/packages/core/src/widgets/types.ts
@@ -1398,6 +1398,10 @@ export type CheckboxProps = Readonly<{
   onChange?: (checked: boolean) => void;
   /** Whether the checkbox is disabled. */
   disabled?: boolean;
+  /** Design system: tone for checked/focus rendering. */
+  dsTone?: WidgetTone;
+  /** Design system: size preset. */
+  dsSize?: WidgetSize;
 }>;
 
 /** Props for radio group widget. */
@@ -1418,6 +1422,10 @@ export type RadioGroupProps = Readonly<{
   direction?: "horizontal" | "vertical";
   /** Whether the radio group is disabled. */
   disabled?: boolean;
+  /** Design system: tone for selected/focus rendering. */
+  dsTone?: WidgetTone;
+  /** Design system: size preset. */
+  dsSize?: WidgetSize;
 }>;
 
 /* ========== Navigation Widgets ========== */


### PR DESCRIPTION
## Summary
- wire recipe-based DS rendering for `checkbox` and `radioGroup` when semantic tokens are available
- keep legacy fallback rendering for non-semantic themes
- add `dsTone` and `dsSize` props for checkbox/radioGroup
- extend checkbox recipe params to support tone/size and selected-state styling
- add checkbox recipe renderer tests (default/checked/disabled/focused)

## Testing
- `node scripts/run-tests.mjs`
