### PR TITLE
feat(core): wire select and table recipes

### DIFF
--- a/packages/core/src/renderer/__tests__/selectRecipeRendering.test.ts
+++ b/packages/core/src/renderer/__tests__/selectRecipeRendering.test.ts
@@ -1,0 +1,85 @@
+import { assert, describe, test } from "@rezi-ui/testkit";
+import { defaultTheme } from "../../theme/defaultTheme.js";
+import { coerceToLegacyTheme } from "../../theme/interop.js";
+import { darkTheme } from "../../theme/presets.js";
+import { ui } from "../../widgets/ui.js";
+import { type DrawOp, renderOps } from "./recipeRendering.test-utils.js";
+
+const dsTheme = coerceToLegacyTheme(darkTheme);
+const options = [{ value: "a", label: "Alpha" }] as const;
+
+function firstDrawText(
+  ops: readonly DrawOp[],
+  match: (text: string) => boolean,
+): DrawOp | undefined {
+  return ops.find((op) => op.kind === "drawText" && match(op.text));
+}
+
+describe("select recipe rendering", () => {
+  test("uses recipe colors in default state with semantic-token themes", () => {
+    const ops = renderOps(
+      ui.row({ height: 3, items: "stretch" }, [ui.select({ id: "sel", value: "a", options })]),
+      { viewport: { cols: 40, rows: 5 }, theme: dsTheme },
+    );
+    const fill = ops.find((op) => op.kind === "fillRect");
+    assert.ok(fill !== undefined, "select should fill recipe background");
+    if (!fill || fill.kind !== "fillRect") return;
+    assert.deepEqual(fill.style?.bg, dsTheme.colors["bg.elevated"]);
+
+    const text = firstDrawText(ops, (s) => s.includes("Alpha"));
+    assert.ok(text && text.kind === "drawText");
+    if (!text || text.kind !== "drawText") return;
+    assert.deepEqual(text.style?.fg, dsTheme.colors["fg.primary"]);
+  });
+
+  test("uses focused recipe text styling when focused", () => {
+    const ops = renderOps(
+      ui.row({ height: 3, items: "stretch" }, [
+        ui.select({ id: "sel-focus", value: "a", options }),
+      ]),
+      { viewport: { cols: 40, rows: 5 }, theme: dsTheme, focusedId: "sel-focus" },
+    );
+    const text = firstDrawText(ops, (s) => s.includes("Alpha"));
+    assert.ok(text && text.kind === "drawText", "focused select should render selected text");
+    if (!text || text.kind !== "drawText") return;
+    assert.equal(text.style?.bold, true);
+    assert.equal(text.style?.underline, true);
+  });
+
+  test("uses disabled recipe text colors", () => {
+    const ops = renderOps(
+      ui.row({ height: 3, items: "stretch" }, [
+        ui.select({ id: "sel-disabled", value: "a", options, disabled: true }),
+      ]),
+      { viewport: { cols: 40, rows: 5 }, theme: dsTheme },
+    );
+    const text = firstDrawText(ops, (s) => s.includes("Alpha"));
+    assert.ok(text && text.kind === "drawText");
+    if (!text || text.kind !== "drawText") return;
+    assert.deepEqual(text.style?.fg, dsTheme.colors["disabled.fg"]);
+  });
+
+  test("keeps legacy fallback when semantic tokens are absent", () => {
+    const ops = renderOps(
+      ui.row({ height: 3, items: "stretch" }, [ui.select({ id: "legacy", value: "a", options })]),
+      { viewport: { cols: 40, rows: 5 }, theme: defaultTheme },
+    );
+    assert.equal(
+      ops.some((op) => op.kind === "fillRect"),
+      false,
+      "legacy select should not fill recipe background",
+    );
+    assert.equal(
+      ops.some((op) => op.kind === "drawText" && /[┌┐└┘]/.test(op.text)),
+      false,
+      "legacy select should not draw recipe border",
+    );
+    assert.equal(
+      ops.some(
+        (op) => op.kind === "drawText" && op.text.includes("Alpha") && op.text.includes("▼"),
+      ),
+      true,
+      "legacy select should render inline caret text",
+    );
+  });
+});

--- a/packages/core/src/renderer/__tests__/tableRecipeRendering.test.ts
+++ b/packages/core/src/renderer/__tests__/tableRecipeRendering.test.ts
@@ -1,0 +1,119 @@
+import { assert, describe, test } from "@rezi-ui/testkit";
+import { defaultTheme } from "../../theme/defaultTheme.js";
+import { coerceToLegacyTheme } from "../../theme/interop.js";
+import { darkTheme } from "../../theme/presets.js";
+import { ui } from "../../widgets/ui.js";
+import { type DrawOp, renderOps } from "./recipeRendering.test-utils.js";
+
+const dsTheme = coerceToLegacyTheme(darkTheme);
+
+type Row = Readonly<{ id: string; name: string }>;
+
+const columns = [{ key: "name", header: "Name", sortable: true }] as const;
+const data: readonly Row[] = [
+  { id: "r0", name: "Alpha" },
+  { id: "r1", name: "Beta" },
+];
+
+function rgbEquals(
+  actual: unknown,
+  expected: Readonly<{ r: number; g: number; b: number }> | undefined,
+): boolean {
+  if (!expected || typeof actual !== "object" || actual === null) return false;
+  const a = actual as { r?: unknown; g?: unknown; b?: unknown };
+  return a.r === expected.r && a.g === expected.g && a.b === expected.b;
+}
+
+function firstDrawText(
+  ops: readonly DrawOp[],
+  match: (text: string) => boolean,
+): DrawOp | undefined {
+  return ops.find((op) => op.kind === "drawText" && match(op.text));
+}
+
+describe("table recipe rendering", () => {
+  test("uses table recipe colors for header, selected rows, and stripes", () => {
+    const ops = renderOps(
+      ui.table<Row>({
+        id: "tbl",
+        columns,
+        data,
+        getRowKey: (row) => row.id,
+        selection: ["r0"],
+        selectionMode: "single",
+        stripedRows: true,
+        border: "none",
+      }),
+      { viewport: { cols: 40, rows: 6 }, theme: dsTheme },
+    );
+
+    const header = firstDrawText(ops, (text) => text.includes("Name"));
+    const selectedRow = firstDrawText(ops, (text) => text.includes("Alpha"));
+    assert.ok(header && header.kind === "drawText");
+    assert.ok(selectedRow && selectedRow.kind === "drawText");
+    if (!header || header.kind !== "drawText" || !selectedRow || selectedRow.kind !== "drawText")
+      return;
+    assert.deepEqual(header.style?.fg, dsTheme.colors["fg.secondary"]);
+    assert.equal(header.style?.bold, true);
+    assert.deepEqual(selectedRow.style?.fg, dsTheme.colors["selected.fg"]);
+    assert.equal(selectedRow.style?.bold, true);
+
+    assert.equal(
+      ops.some(
+        (op) => op.kind === "fillRect" && rgbEquals(op.style?.bg, dsTheme.colors["bg.subtle"]),
+      ),
+      true,
+      "striped rows should use recipe subtle background",
+    );
+  });
+
+  test("uses focused-row recipe colors when table is focused", () => {
+    const ops = renderOps(
+      ui.table<Row>({
+        id: "tbl-focus",
+        columns,
+        data,
+        getRowKey: (row) => row.id,
+        selectionMode: "single",
+        border: "none",
+      }),
+      { viewport: { cols: 40, rows: 6 }, theme: dsTheme, focusedId: "tbl-focus" },
+    );
+    assert.equal(
+      ops.some(
+        (op) => op.kind === "fillRect" && rgbEquals(op.style?.bg, dsTheme.colors["focus.bg"]),
+      ),
+      true,
+      "focused row should use recipe focus background",
+    );
+  });
+
+  test("keeps legacy table fallback when semantic tokens are absent", () => {
+    const ops = renderOps(
+      ui.table<Row>({
+        id: "legacy-table",
+        columns,
+        data,
+        getRowKey: (row) => row.id,
+        stripedRows: true,
+        sortColumn: "name",
+        sortDirection: "asc",
+        border: "none",
+      }),
+      { viewport: { cols: 40, rows: 6 }, theme: defaultTheme },
+    );
+
+    const sortedHeader = firstDrawText(ops, (text) => text.includes("▲"));
+    assert.ok(sortedHeader && sortedHeader.kind === "drawText");
+    if (!sortedHeader || sortedHeader.kind !== "drawText") return;
+    assert.deepEqual(sortedHeader.style?.fg, defaultTheme.colors.info);
+
+    assert.equal(
+      ops.some(
+        (op) => op.kind === "fillRect" && rgbEquals(op.style?.bg, defaultTheme.colors.border),
+      ),
+      true,
+      "legacy striped rows should still use theme.colors.border",
+    );
+  });
+});

--- a/packages/core/src/renderer/renderToDrawlist/widgets/basic.ts
+++ b/packages/core/src/renderer/renderToDrawlist/widgets/basic.ts
@@ -1369,6 +1369,8 @@ export function renderBasicWidget(
         placeholder?: unknown;
         disabled?: unknown;
         focusConfig?: unknown;
+        dsVariant?: unknown;
+        dsTone?: unknown;
         dsSize?: unknown;
       };
       const focusConfig = readFocusConfig(props.focusConfig);

--- a/packages/core/src/ui/recipes.ts
+++ b/packages/core/src/ui/recipes.ts
@@ -346,6 +346,8 @@ export function selectRecipe(
 
 export type TableRecipeParams = Readonly<{
   state?: "header" | "row" | "selectedRow" | "focusedRow" | "stripe";
+  size?: WidgetSize;
+  tone?: WidgetTone;
   density?: Density;
 }>;
 

--- a/packages/core/src/widgets/types.ts
+++ b/packages/core/src/widgets/types.ts
@@ -1297,6 +1297,10 @@ export type TableProps<T = unknown> = Readonly<{
   borderStyle?: TableBorderStyle;
   /** Optional focus appearance configuration. */
   focusConfig?: FocusConfig;
+  /** Design system: size preset. */
+  dsSize?: WidgetSize;
+  /** Design system: tone (reserved for future table recipe variants). */
+  dsTone?: WidgetTone;
 }>;
 
 /* ========== Form Widgets (GitHub issue #119) ========== */
@@ -1346,6 +1350,10 @@ export type SelectProps = Readonly<{
   placeholder?: string;
   /** Optional focus appearance configuration. */
   focusConfig?: FocusConfig;
+  /** Design system: visual variant (reserved for future select recipes). */
+  dsVariant?: WidgetVariant;
+  /** Design system: tone (reserved for future select recipes). */
+  dsTone?: WidgetTone;
   /** Design system: size preset. */
   dsSize?: WidgetSize;
 }>;


### PR DESCRIPTION
## Summary
- wire table renderer to `tableRecipe()` when semantic tokens are available
- preserve legacy table styling path for non-semantic themes
- add DS prop surface for select/table (`dsVariant`/`dsTone`/`dsSize` as applicable)
- add select and table recipe rendering tests for DS and legacy paths

## Testing
- `node scripts/run-tests.mjs`
- `npm run lint`
- `npm run build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Enhanced design system theming for select and table components with new styling options: variant, tone, and size presets.
  * Improved semantic token-based rendering for table headers, rows, and selection states with fallback support for legacy themes.

* **Tests**
  * Added comprehensive test coverage for recipe-driven rendering of select and table components across multiple states and theming scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->