### PR TITLE
fix(core): remove stale textarea entry from widget protocol registry

### DIFF
--- a/packages/core/src/widgets/protocol.ts
+++ b/packages/core/src/widgets/protocol.ts
@@ -174,7 +174,6 @@ export const WIDGET_PROTOCOL: Readonly<Partial<Record<string, WidgetProtocol>>> 
   focusTrap: CONTAINER,
   breadcrumb: CONTAINER,
   resizablePanel: CONTAINER,
-  textarea: CONTAINER,
 });
 
 /** Get the protocol for a widget kind. Returns DISPLAY_ONLY for unknown kinds. */


### PR DESCRIPTION
## Summary
- remove `textarea` from `WIDGET_PROTOCOL` in `packages/core/src/widgets/protocol.ts`
- aligns protocol registry with runtime widget kinds and textarea factory behavior (textarea maps to input)

## Validation
- `npm run lint`
- `npm run build`
- `node --test packages/core/dist/widgets/tests/protocol.test.js`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Updated textarea widget to use default display behavior for consistent protocol handling across the application.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->