### PR TITLE
fix(runtime): replace hardcoded kind lists in enabled-map with protocol registry lookups

### DIFF
--- a/packages/core/src/runtime/__tests__/widgetMeta.test.ts
+++ b/packages/core/src/runtime/__tests__/widgetMeta.test.ts
@@ -125,6 +125,79 @@ test("widgetMeta: slider participates in focusable/enabled metadata", () => {
   assert.equal(enabled.get("s3"), true);
 });
 
+test("widgetMeta: link disabled state is tracked in both enabled collectors", () => {
+  const vnode = ui.column({}, [
+    ui.link({
+      id: "l1",
+      url: "https://example.com/disabled",
+      label: "Disabled",
+      disabled: true,
+      onPress: () => {},
+    }),
+    ui.link({
+      id: "l2",
+      url: "https://example.com/enabled",
+      label: "Enabled",
+      onPress: () => {},
+    }),
+  ]);
+
+  const committed = commitTree(vnode);
+
+  const enabled = collectEnabledMap(committed);
+  assert.equal(enabled.get("l1"), false);
+  assert.equal(enabled.get("l2"), true);
+
+  const allMeta = collectAllWidgetMetadata(committed);
+  assert.equal(allMeta.enabledById.get("l1"), false);
+  assert.equal(allMeta.enabledById.get("l2"), true);
+});
+
+test("widgetMeta: all disableable kinds honor disabled in both enabled collectors", () => {
+  const vnode = ui.column({}, [
+    ui.button({ id: "btn", label: "Button", disabled: true }),
+    ui.link({
+      id: "lnk",
+      url: "https://example.com",
+      label: "Link",
+      disabled: true,
+      onPress: () => {},
+    }),
+    ui.input({ id: "inp", value: "value", disabled: true }),
+    ui.slider({ id: "sld", value: 5, min: 0, max: 10, disabled: true }),
+    ui.select({
+      id: "sel",
+      value: "a",
+      options: [{ value: "a", label: "A" }],
+      disabled: true,
+    }),
+    ui.checkbox({ id: "chk", checked: true, disabled: true }),
+    ui.radioGroup({
+      id: "rad",
+      value: "x",
+      options: [{ value: "x", label: "X" }],
+      disabled: true,
+    }),
+  ]);
+
+  const committed = commitTree(vnode);
+  const expectedDisabledIds = ["btn", "lnk", "inp", "sld", "sel", "chk", "rad"] as const;
+
+  const enabled = collectEnabledMap(committed);
+  for (const id of expectedDisabledIds) {
+    assert.equal(enabled.get(id), false, `collectEnabledMap expected "${id}" disabled`);
+  }
+
+  const allMeta = collectAllWidgetMetadata(committed);
+  for (const id of expectedDisabledIds) {
+    assert.equal(
+      allMeta.enabledById.get(id),
+      false,
+      `collectAllWidgetMetadata expected "${id}" disabled`,
+    );
+  }
+});
+
 test("widgetMeta: collectAllWidgetMetadata produces same results as individual collectors", () => {
   // Complex tree with buttons, inputs, zones, and traps
   const vnode = ui.column({}, [

--- a/packages/core/src/runtime/widgetMeta.ts
+++ b/packages/core/src/runtime/widgetMeta.ts
@@ -43,22 +43,13 @@ function isEnabledInteractive(v: RuntimeInstance["vnode"]): string | null {
   const id = readInteractiveId(v);
   if (id === null) return null;
 
-  // Disabled applies only to a subset of interactive widgets.
-  if (
-    v.kind === "button" ||
-    v.kind === "link" ||
-    v.kind === "input" ||
-    v.kind === "slider" ||
-    v.kind === "select" ||
-    v.kind === "checkbox" ||
-    v.kind === "radioGroup"
-  ) {
+  const proto = getWidgetProtocol(v.kind);
+  if (proto.disableable) {
     const disabled = (v.props as { disabled?: unknown }).disabled;
     if (disabled === true) return null;
   }
 
-  // For advanced widgets, check the 'open' prop for modal widgets
-  if (v.kind === "commandPalette" || v.kind === "toolApprovalDialog") {
+  if (proto.openGated) {
     const open = (v.props as { open?: unknown }).open;
     if (open !== true) return null;
   }
@@ -110,19 +101,12 @@ export function collectEnabledMap(tree: RuntimeInstance): ReadonlyMap<string, bo
     const id = readInteractiveId(node.vnode);
     if (id !== null && !m.has(id)) {
       let enabled = true;
-      if (
-        node.vnode.kind === "button" ||
-        node.vnode.kind === "input" ||
-        node.vnode.kind === "slider" ||
-        node.vnode.kind === "select" ||
-        node.vnode.kind === "checkbox" ||
-        node.vnode.kind === "radioGroup"
-      ) {
+      const proto = getWidgetProtocol(node.vnode.kind);
+      if (proto.disableable) {
         const disabled = (node.vnode.props as { disabled?: unknown }).disabled;
         enabled = disabled !== true;
       }
-      // For modal widgets, enabled depends on 'open' prop
-      if (node.vnode.kind === "commandPalette" || node.vnode.kind === "toolApprovalDialog") {
+      if (proto.openGated) {
         const open = (node.vnode.props as { open?: unknown }).open;
         enabled = open === true;
       }
@@ -838,19 +822,12 @@ export class WidgetMetadataCollector {
       const interactiveId = readInteractiveId(vnode);
       if (interactiveId !== null && !this._enabledById.has(interactiveId)) {
         let enabled = true;
-        if (
-          vnode.kind === "button" ||
-          vnode.kind === "link" ||
-          vnode.kind === "input" ||
-          vnode.kind === "slider" ||
-          vnode.kind === "select" ||
-          vnode.kind === "checkbox" ||
-          vnode.kind === "radioGroup"
-        ) {
+        const proto = getWidgetProtocol(vnode.kind);
+        if (proto.disableable) {
           const disabled = (vnode.props as { disabled?: unknown }).disabled;
           enabled = disabled !== true;
         }
-        if (vnode.kind === "commandPalette" || vnode.kind === "toolApprovalDialog") {
+        if (proto.openGated) {
           const open = (vnode.props as { open?: unknown }).open;
           enabled = open === true;
         }


### PR DESCRIPTION
## Summary
- replace hardcoded enabled/disabled kind checks in `widgetMeta.ts` with `getWidgetProtocol(kind)` lookups in all three collection paths
- keep open-gated and disableable handling aligned with protocol metadata
- add regression tests for disabled/enabled links and all disableable widget kinds across both metadata collection paths

## Test Plan
- npm run build
- node scripts/run-tests.mjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Added comprehensive tests to verify disabled state tracking consistency across all widget types.

* **Refactor**
  * Improved widget enablement and gating logic through a more generalized approach, enhancing code maintainability.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->