### PR TITLE
perf(runtime): use Set for focus-zone membership and complete breadcrumb event kinds

### DIFF
--- a/packages/core/src/app/__tests__/runtimeBreadcrumbs.test.ts
+++ b/packages/core/src/app/__tests__/runtimeBreadcrumbs.test.ts
@@ -7,6 +7,7 @@ import { DEFAULT_TERMINAL_CAPS } from "../../terminalCaps.js";
 import { defaultTheme } from "../../theme/defaultTheme.js";
 import { createApp } from "../createApp.js";
 import type { RuntimeBreadcrumbSnapshot } from "../runtimeBreadcrumbs.js";
+import { isRuntimeBreadcrumbEventKind } from "../runtimeBreadcrumbs.js";
 import { WidgetRenderer } from "../widgetRenderer.js";
 import { encodeZrevBatchV1, flushMicrotasks, makeBackendBatch } from "./helpers.js";
 import { StubBackend } from "./stubBackend.js";
@@ -143,8 +144,8 @@ test("runtime breadcrumbs capture event path/action/focus/cursor deterministical
   assert.equal(renderSnapshots.length, 2);
   const second = renderSnapshots[1];
   assert.ok(second);
-  assert.equal(second.event.kind, "text");
-  assert.equal(second.event.path, "keybindings");
+  assert.equal(second.event.kind, "tick");
+  assert.equal(second.event.path, null);
   assert.equal(second.focus.focusedId, "name");
   assert.equal(second.focus.activeZoneId, null);
   assert.equal(second.focus.activeTrapId, "trap");
@@ -177,8 +178,8 @@ test("runtime breadcrumbs capture event path/action/focus/cursor deterministical
   const fourth = renderSnapshots[3];
   assert.ok(fourth);
   assert.deepEqual(fourth.lastAction, { id: "save", action: "press" });
-  assert.equal(fourth.event.kind, "key");
-  assert.equal(fourth.event.path, "widgetRouting");
+  assert.equal(fourth.event.kind, "tick");
+  assert.equal(fourth.event.path, null);
 
   await settleNextFrame(backend);
 });
@@ -293,4 +294,10 @@ test("enabling breadcrumb capture does not change widget routing outcomes", () =
 
   assert.equal(rendererWithout.getRuntimeBreadcrumbSnapshot(), null);
   assert.notEqual(rendererWith.getRuntimeBreadcrumbSnapshot(), null);
+});
+
+test("runtime breadcrumb event kind guard includes tick and user", () => {
+  assert.equal(isRuntimeBreadcrumbEventKind("tick"), true);
+  assert.equal(isRuntimeBreadcrumbEventKind("user"), true);
+  assert.equal(isRuntimeBreadcrumbEventKind("custom"), false);
 });

--- a/packages/core/src/app/runtimeBreadcrumbs.ts
+++ b/packages/core/src/app/runtimeBreadcrumbs.ts
@@ -9,7 +9,14 @@ import type { CursorShape } from "../abi.js";
 import type { RoutedAction } from "../runtime/router.js";
 
 /** Engine event kinds tracked by runtime breadcrumbs. */
-export type RuntimeBreadcrumbEventKind = "key" | "text" | "paste" | "mouse" | "resize";
+export type RuntimeBreadcrumbEventKind =
+  | "key"
+  | "text"
+  | "paste"
+  | "mouse"
+  | "resize"
+  | "tick"
+  | "user";
 
 /** Which routing path handled the last tracked engine event. */
 export type RuntimeBreadcrumbConsumptionPath = "keybindings" | "widgetRouting";
@@ -121,7 +128,13 @@ export function toRuntimeBreadcrumbAction(action: RoutedAction): RuntimeBreadcru
 /** Narrow runtime event kinds that breadcrumbs track. */
 export function isRuntimeBreadcrumbEventKind(kind: string): kind is RuntimeBreadcrumbEventKind {
   return (
-    kind === "key" || kind === "text" || kind === "paste" || kind === "mouse" || kind === "resize"
+    kind === "key" ||
+    kind === "text" ||
+    kind === "paste" ||
+    kind === "mouse" ||
+    kind === "resize" ||
+    kind === "tick" ||
+    kind === "user"
   );
 }
 


### PR DESCRIPTION
## Summary
- replace repeated zone/trap array membership scans in finalizeFocusWithPreCollectedMetadata with precomputed set lookups
- keep behavior unchanged while reducing hot-path includes usage across active-zone and remembered-zone handling
- extend runtime breadcrumb event kinds to include tick and user
- update runtime breadcrumb tests to validate tick tracking behavior and kind-guard coverage

## Testing
- npm run build
- node scripts/run-tests.mjs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

# Release Notes

* **New Features**
  * Extended runtime breadcrumb event tracking to include new "tick" and "user" event types for more comprehensive event monitoring.

* **Performance**
  * Optimized focus trap and zone management with more efficient membership lookup operations.

* **Tests**
  * Added comprehensive validation tests for breadcrumb event type support.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->