### PR TITLE
fix(core): skip virtual-list mouse-up render when no selection callback runs

### DIFF
--- a/packages/core/src/app/__tests__/widgetRenderer.integration.test.ts
+++ b/packages/core/src/app/__tests__/widgetRenderer.integration.test.ts
@@ -1078,6 +1078,40 @@ describe("WidgetRenderer integration battery", () => {
     assert.deepEqual(selected, ["b:1"]);
   });
 
+  test("virtualList mouse-up does not request render when no select callback runs", () => {
+    const backend = createNoopBackend();
+    const renderer = new WidgetRenderer<void>({
+      backend,
+      requestRender: () => {},
+    });
+
+    const vnode = ui.virtualList({
+      id: "v",
+      items: ["a"],
+      itemHeight: 1,
+      renderItem: (item) => ui.text(item),
+    });
+
+    const res = renderer.submitFrame(
+      () => vnode,
+      undefined,
+      { cols: 20, rows: 3 },
+      defaultTheme,
+      noRenderHooks(),
+    );
+    assert.ok(res.ok);
+
+    const down1 = renderer.routeEngineEvent(mouseEvent(0, 0, 3, { timeMs: 1, buttons: 1 }));
+    const up1 = renderer.routeEngineEvent(mouseEvent(0, 0, 4, { timeMs: 2, buttons: 0 }));
+    const down2 = renderer.routeEngineEvent(mouseEvent(0, 0, 3, { timeMs: 3, buttons: 1 }));
+    const up2 = renderer.routeEngineEvent(mouseEvent(0, 0, 4, { timeMs: 4, buttons: 0 }));
+
+    assert.equal(down1.needsRender, true);
+    assert.equal(up1.needsRender, false);
+    assert.equal(down2.needsRender, false);
+    assert.equal(up2.needsRender, false);
+  });
+
   test("virtualList onScroll fires for wheel and key-driven scroll", () => {
     const backend = createNoopBackend();
     const renderer = new WidgetRenderer<void>({

--- a/packages/core/src/app/widgetRenderer/mouseRouting.ts
+++ b/packages/core/src/app/widgetRenderer/mouseRouting.ts
@@ -767,8 +767,10 @@ export function routeVirtualListMouseClick(
           const idx = Math.max(0, Math.min(vlist.items.length - 1, idx0));
           if (idx === pressed.index) {
             const item = vlist.items[idx];
-            if (item !== undefined) invokeCallbackSafely(vlist.onSelect, item, idx);
-            localNeedsRender = true;
+            if (item !== undefined && typeof vlist.onSelect === "function") {
+              invokeCallbackSafely(vlist.onSelect, item, idx);
+              localNeedsRender = true;
+            }
           }
         }
       }


### PR DESCRIPTION
Supersedes #176 due cross-repo push permission limits (unable to push to contributor fork branch).

This branch contains the refactor-compatible version of the same fix.

## What changed
- Virtual-list mouse-up now requests render only when `onSelect` actually runs with a defined item.
- Added regression test covering no-op mouse-up when no selection callback runs.

## Why
- The redundant virtual-list mouse-up render path still exists on latest `main`.
- I intentionally excluded the original `pressedId` render-gating part because current renderer uses `pressedId` for pressed visuals.

## Validation
- `npm -w @rezi-ui/core run build`
- `node --test packages/core/dist/app/__tests__/widgetRenderer.integration.test.js`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Fixed potential runtime errors when interacting with virtual lists that lack a selection callback.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->