### PR TITLE
Fix Ctrl+text keybinding routing from terminal control chars

### DIFF
--- a/packages/core/src/app/createApp.ts
+++ b/packages/core/src/app/createApp.ts
@@ -512,6 +512,9 @@ function codepointToKeyCode(codepoint: number): number | null {
  * because they have dedicated key semantics in the engine.
  */
 function codepointToCtrlKeyCode(codepoint: number): number | null {
+  if (codepoint === 9 || codepoint === 13) {
+    return null;
+  }
   if (codepoint >= 1 && codepoint <= 26) {
     return codepoint + 64;
   }
@@ -1203,9 +1206,12 @@ export function createApp<S>(opts: CreateAppStateOptions<S> | CreateAppRoutesOnl
             if (ev.kind === "text") {
               const ctrlKeyCode = codepointToCtrlKeyCode(ev.codepoint);
               const shouldRouteCtrlText = ctrlKeyCode !== null;
-              const shouldRoutePrintableText = !shouldRouteCtrlText && !widgetRenderer.hasActiveOverlay();
+              const shouldRoutePrintableText =
+                !shouldRouteCtrlText && !widgetRenderer.hasActiveOverlay();
               if (shouldRouteCtrlText || shouldRoutePrintableText) {
-                const keyCode = shouldRouteCtrlText ? ctrlKeyCode : codepointToKeyCode(ev.codepoint);
+                const keyCode = shouldRouteCtrlText
+                  ? ctrlKeyCode
+                  : codepointToKeyCode(ev.codepoint);
                 const mods = shouldRouteCtrlText ? ZR_MOD_CTRL : 0;
                 if (keyCode !== null) {
                   // Create a synthetic key event for keybinding matching


### PR DESCRIPTION
## Problem
Some terminals emit `Ctrl+<letter>` as text control characters (`0x01..0x1A`) instead of key events. In that path, Rezi only routed printable text through keybinding matching, so bindings like `ctrl+p` were missed.

## Fix
- Added `codepointToCtrlKeyCode()` in `createApp.ts` to map text control characters to key codes for `Ctrl+A..Z` and `Ctrl+\\..Ctrl+_`.
- Updated text-event routing to synthesize keybinding events with `mods: ZR_MOD_CTRL` for control-char text input.
- Preserved overlay guard behavior for printable text routing, while allowing ctrl control-char routing even when an overlay is active.

## Tests
Added regression coverage in `shortcutEnforcement.test.ts`:
- `ctrl+letter keybindings are matched from text control characters`
- `ctrl control-char text bindings still route while an overlay is active`

Validation run:
- `npm -C packages/core run build`
- `npm -C packages/core test`
- Result: `4673` passing, `0` failing.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved keyboard shortcut routing so Ctrl+key combos are recognized consistently, including when overlays or dropdowns are active.
  * Prevents Tab and Enter text events from incorrectly triggering Ctrl-bound shortcuts.

* **Tests**
  * Added tests validating shortcut handling for text control characters, overlay visibility, and that Tab/Enter do not synthesize Ctrl keybindings.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->