### PR TITLE
fix(core): harden router guard error handling and param validation

### DIFF
--- a/packages/core/src/router/integration.ts
+++ b/packages/core/src/router/integration.ts
@@ -157,15 +157,23 @@ export function createRouterIntegration<S>(
         const guard = ancestryRoute.guard;
         if (!guard) continue;
 
-        const guardResult = guard(
-          resolvedParams,
-          opts.getState(),
-          Object.freeze({
-            from,
-            to,
-            action,
-          }),
-        );
+        let guardResult: boolean | { redirect: string; params?: RouteParams };
+        try {
+          guardResult = guard(
+            resolvedParams,
+            opts.getState(),
+            Object.freeze({
+              from,
+              to,
+              action,
+            }),
+          );
+        } catch (e) {
+          throw new ZrUiError(
+            "ZRUI_USER_CODE_THROW",
+            `route guard for "${ancestryRouteId}" threw: ${e instanceof Error ? `${e.name}: ${e.message}` : String(e)}`,
+          );
+        }
 
         if (guardResult === true) {
           continue;


### PR DESCRIPTION
## Summary
- Wrap route guard invocations in try-catch, converting exceptions to `ZRUI_USER_CODE_THROW` with the originating route ID
- Warn in dev mode when route params contain non-string values that get silently coerced
- Warn in dev mode when route IDs contain non-identifier characters

## Files changed
- `router/integration.ts` — guard error wrapping
- `router/router.ts` — param type warnings, route ID character validation