### PR TITLE
fix(core): add max chord length and duplicate keybinding warnings

### DIFF
--- a/packages/core/src/keybindings/manager.ts
+++ b/packages/core/src/keybindings/manager.ts
@@ -8,6 +8,17 @@
  * @see docs/guide/input-and-focus.md
  */
 
+const NODE_ENV =
+  (globalThis as { process?: { env?: { NODE_ENV?: string } } }).process?.env?.NODE_ENV ??
+  "development";
+const DEV_MODE = NODE_ENV !== "production";
+
+function warnDev(message: string): void {
+  if (!DEV_MODE) return;
+  const c = (globalThis as { console?: { warn?: (msg: string) => void } }).console;
+  c?.warn?.(message);
+}
+
 import type { ZrevEvent } from "../events.js";
 import {
   CHORD_TIMEOUT_MS,
@@ -187,6 +198,11 @@ function mergeBindingsReplacingSequences<C>(
     for (let i = merged.length - 1; i >= 0; i--) {
       const current = merged[i];
       if (current && keySequencesEqual(current.sequence, next.sequence)) {
+        if (DEV_MODE) {
+          warnDev(
+            `[rezi] keybinding "${sequenceToString(next.sequence)}" registered multiple times, later definition wins`,
+          );
+        }
         merged.splice(i, 1);
       }
     }

--- a/packages/core/src/keybindings/parser.ts
+++ b/packages/core/src/keybindings/parser.ts
@@ -16,6 +16,8 @@
 import { EMPTY_MODS, KEY_NAME_TO_CODE, MODIFIER_NAMES, charToKeyCode } from "./keyCodes.js";
 import type { KeyParseError, KeySequence, Modifiers, ParseKeyResult, ParsedKey } from "./types.js";
 
+const MAX_CHORD_LENGTH = 8;
+
 /**
  * Parse a single key part (e.g., "ctrl+s" or just "a").
  *
@@ -225,6 +227,16 @@ export function parseKeySequence(input: string): ParseKeyResult {
     return {
       ok: false,
       error: { code: "EMPTY_SEQUENCE", detail: "no keys in sequence" },
+    };
+  }
+
+  if (keys.length > MAX_CHORD_LENGTH) {
+    return {
+      ok: false,
+      error: {
+        code: "INVALID_KEY",
+        detail: `chord sequence length ${String(keys.length)} exceeds maximum of ${String(MAX_CHORD_LENGTH)}`,
+      },
     };
   }
 


### PR DESCRIPTION
## Summary
- Reject key chord sequences longer than 8 keys (prevents unbounded trie memory and impossible-to-press combos)
- Warn in dev mode when keybinding sequences are registered multiple times and silently replaced

## Files changed
- `keybindings/parser.ts` — `MAX_CHORD_LENGTH = 8` enforcement
- `keybindings/manager.ts` — duplicate sequence warning in `mergeBindingsReplacingSequences()`