### PR TITLE
docs(dev): add Rezi code standards and enforcement references

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,14 @@ Rezi is a runtime-agnostic TypeScript TUI framework. Monorepo with `npm` workspa
 | `create-rezi` | `packages/create-rezi/` | Project scaffolding CLI |
 | `@rezi-ui/bench` | `packages/bench/` | Benchmark suite |
 
+## Mandatory Code Standards
+
+All code changes MUST comply with `docs/dev/code-standards.md`.
+Treat it as a required merge checklist for:
+- TypeScript strictness and API modeling
+- Rezi runtime/layout/reconciliation invariants
+- Error handling, callback safety, and async cancellation guards
+
 ## Exploration Protocol
 
 When investigating Rezi code, follow this order:
@@ -68,9 +76,10 @@ When modifying layout code/docs, assume these features are part of the current c
 
 ### Before changing code
 
-1. Read the target file fully.
-2. Check existing tests for the module (`__tests__/` directory adjacent to or near the file).
-3. Understand where the target sits in the render pipeline.
+1. Read `docs/dev/code-standards.md` and apply the relevant MUST rules.
+2. Read the target file fully.
+3. Check existing tests for the module (`__tests__/` directory adjacent to or near the file).
+4. Understand where the target sits in the render pipeline.
 
 ### Safe modification zones
 
@@ -280,6 +289,7 @@ Before finalizing any TUI implementation, verify:
 ## PR and Commit Protocol
 
 - Run full test suite before commits: `node scripts/run-tests.mjs`
+- Verify `docs/dev/code-standards.md` checklist before opening/merging a PR.
 - Commit message format: `feat(scope):`, `fix(scope):`, `docs(scope):`, `refactor(scope):`, `test(scope):`
 - Keep commits atomic — one logical change per commit.
 - Update `CHANGELOG.md` for user-facing changes.

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -15,6 +15,12 @@ npx tsx packages/bench/src/...       # Run benchmarks (bypasses tsc)
 REZI_PERF=1 REZI_PERF_DETAIL=1      # Enable profiling (env vars, prefix any command)
 ```
 
+## Mandatory Code Standards
+
+All code changes MUST follow `docs/dev/code-standards.md`.
+Use it as the merge gate for TypeScript rigor, Rezi-specific invariants, and
+error-handling patterns.
+
 ## Project Map
 
 ```
@@ -282,6 +288,7 @@ each(items, (item) => ui.text(item.name), { key: (item) => item.id });
 
 ## Code Standards and Guardrails
 
+- Canonical standards document: `docs/dev/code-standards.md` (MUST follow).
 - All interactive widgets MUST have a unique `id` prop.
 - Hooks must be called in consistent order (no conditional hooks, no hooks in loops).
 - Container transition properties (`ui.box`/`ui.row`/`ui.column`/`ui.grid`) default to animating `position`, `size`, and `opacity`; constrain with explicit `properties` when needed.

--- a/docs/dev/code-standards.md
+++ b/docs/dev/code-standards.md
@@ -1,0 +1,152 @@
+# Code Standards
+
+This document defines mandatory code standards for Rezi contributors and AI agents.
+Treat this as a normative checklist for code review and PR readiness.
+
+See also:
+- [Style Guide](style-guide.md)
+- [Contributing](contributing.md)
+
+## Enforcement Levels
+
+- `MUST`: required for merge.
+- `SHOULD`: expected unless there is a clear, documented reason not to.
+
+## 1) Baseline Checks (MUST)
+
+For any code change:
+
+```bash
+npm run lint
+npm run typecheck
+```
+
+For runtime/layout/renderer/reconcile changes, also run:
+
+```bash
+node scripts/run-tests.mjs
+```
+
+For drawlist protocol or command layout changes, also run:
+
+```bash
+npm run codegen
+npm run codegen:check
+```
+
+## 2) TypeScript Standards
+
+### Type safety
+
+- `MUST` preserve strict typing (`strict`, `noImplicitAny`, `useUnknownInCatchVariables`).
+- `MUST NOT` introduce `any` unless there is no safe alternative.
+- `MUST` narrow `unknown` before property access.
+- `MUST` prefer `import type { ... }` for type-only imports.
+
+### Public API and domain modeling
+
+- `MUST` model variants with discriminated unions (tagged unions), not class hierarchies.
+- `MUST` keep exported API shapes explicit and stable.
+- `SHOULD` use explicit return types on exported functions.
+
+### Nullability and indexing
+
+- `MUST` handle `undefined` from array/index lookups explicitly (`noUncheckedIndexedAccess`).
+- `MUST NOT` use non-null assertion (`!`) unless the invariant is proven in the same scope.
+
+### Immutability and determinism
+
+- `SHOULD` prefer readonly shapes (`Readonly`, readonly arrays) for shared data.
+- `MUST` avoid hidden mutation of shared objects in render/layout paths.
+
+## 3) Rezi-Specific Architecture Standards
+
+### Runtime boundaries
+
+- `MUST NOT` import runtime-specific APIs into `@rezi-ui/core`.
+- `MUST` keep module boundaries intact:
+  - `core` -> no imports from `node`/`jsx`/`native`
+  - `node`/`jsx` -> may import from `core`
+
+### Widget and reconciliation rules
+
+- `MUST` use stable `id` for interactive widgets.
+- `MUST` use stable `key` values for list reconciliation.
+- `MUST` keep hook invocation order stable (no conditional hooks).
+- `MUST` preserve deterministic behavior for the same input state.
+
+### API layering
+
+- `SHOULD` prefer `ui.*` factories over raw vnode construction.
+- `MUST` keep JSX parity when changing core widget APIs (`ui.ts`, JSX components/types/tests/docs together).
+
+### Generated code and protocol
+
+- `MUST NOT` hand-edit generated drawlist writers.
+- `MUST` update source spec + regenerate writers + update protocol docs when command bytes/layout changes.
+
+## 4) Error Handling Standards (Critical)
+
+### Choose the right failure contract
+
+- `MUST` use typed result unions for parse/validation-style flows where callers should recover.
+- `MUST` throw for unrecoverable programmer/configuration errors.
+- `MUST` keep error contracts consistent within each module.
+
+### Catch blocks and thrown values
+
+- `MUST` treat caught values as `unknown`.
+- `MUST` use safe thrown-value formatting in logs/warnings.
+- `MUST NOT` call `String(error)` directly in safety-critical catch blocks without a nested guard.
+
+Recommended pattern:
+
+```ts
+function describeThrown(value: unknown): string {
+  if (value instanceof Error) return `${value.name}: ${value.message}`;
+  try {
+    return String(value);
+  } catch {
+    return "[unstringifiable thrown value]";
+  }
+}
+```
+
+### Callback boundaries
+
+- `MUST` isolate user callback failures so they do not destabilize routing/render loops.
+- `MUST` keep callback wrappers deterministic and side-effect safe.
+- `SHOULD` emit dev warnings (`warnDev`) instead of throwing for user callback exceptions in routing/event handlers.
+
+### Async cancellation and stale results
+
+- `MUST` guard async completion paths against cancellation/stale-token updates.
+- `MUST` ensure canceled validations/effects cannot mutate state after cleanup/unmount.
+
+### Error wrapping
+
+- `SHOULD` preserve original errors via `cause` when wrapping.
+- `MUST` keep wrapped messages actionable and specific.
+
+## 5) Performance and Hot-Path Standards
+
+- `MUST` avoid unnecessary allocations in per-frame render/layout paths.
+- `SHOULD` use simple loops in hot paths instead of allocation-heavy array pipelines.
+- `MUST` preserve existing deterministic ordering and stable signatures where applicable.
+
+## 6) Documentation and Parity Standards
+
+- `MUST` update docs in the same PR when changing public behavior.
+- `MUST` update examples/templates when recommended patterns change.
+- `MUST` keep `CLAUDE.md` and `AGENTS.md` aligned with these standards.
+
+## 7) PR Checklist
+
+Before merging, verify:
+
+- [ ] `lint` and `typecheck` are green.
+- [ ] Required tests for touched areas are green.
+- [ ] Error paths and cancellation/stale guards are covered where relevant.
+- [ ] Module boundaries and JSX parity are preserved.
+- [ ] Public API/documentation updates are included.
+

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -2,6 +2,9 @@
 
 Rezi welcomes issues and pull requests. This page summarizes the local workflow; see the linked guides for details.
 
+Before starting implementation, review the mandatory
+[Code Standards](code-standards.md) checklist.
+
 ## Prerequisites
 
 - Node.js 18+ (18.18+ recommended)
@@ -62,4 +65,5 @@ If your change touches code-editor syntax behavior (`syntaxLanguage`, tokenizer 
 - [Build](build.md)
 - [Testing](testing.md)
 - [Docs](docs.md)
+- [Code Standards](code-standards.md)
 - [Style guide](style-guide.md)

--- a/docs/dev/style-guide.md
+++ b/docs/dev/style-guide.md
@@ -3,6 +3,10 @@
 This page documents the coding conventions and tooling standards used across the
 Rezi codebase.
 
+For mandatory merge-gate rules, start with
+[Code Standards](code-standards.md). This page provides supporting details and
+examples.
+
 ## Formatting and Linting
 
 Rezi uses [Biome](https://biomejs.dev/) (v1.9.4) for both formatting and

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -249,6 +249,7 @@ nav:
       - Repo Layout: dev/repo-layout.md
       - Build: dev/build.md
       - Testing: dev/testing.md
+      - Code Standards: dev/code-standards.md
       - Perf Regressions: dev/perf-regressions.md
       - Repro Replay: dev/repro-replay.md
       - Releasing: dev/releasing.md


### PR DESCRIPTION
## Summary
- add `docs/dev/code-standards.md` as a normative TypeScript + Rezi engineering standard
- include explicit error-handling standards (safe thrown-value formatting, callback isolation, async cancellation guards, error wrapping)
- wire standards into developer docs used by AI agents and contributors (`AGENTS.md`, `CLAUDE.md`, `docs/dev/contributing.md`, `docs/dev/style-guide.md`)
- add docs nav entry under Developer

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `npm run docs:build`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Introduced comprehensive code standards documentation for developers and contributors, including mandatory requirements for code quality, TypeScript practices, architecture patterns, error handling, and performance guidelines.
  * Updated developer guides to reference the new code standards as a required checklist before implementation and PR submission.
  * Added code standards navigation to the developer documentation site.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->