### PR TITLE
fix(release): publish ink-compat and shim packages

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -208,6 +208,21 @@ jobs:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
         run: npm publish -w @rezi-ui/jsx --access public
 
+      - name: Publish @rezi-ui/ink-compat
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish -w @rezi-ui/ink-compat --access public
+
+      - name: Publish ink-gradient-shim
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish ./packages/ink-gradient-shim --access public
+
+      - name: Publish ink-spinner-shim
+        env:
+          NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
+        run: npm publish ./packages/ink-spinner-shim --access public
+
       - name: Publish create-rezi
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}

--- a/scripts/release-set-version.mjs
+++ b/scripts/release-set-version.mjs
@@ -4,6 +4,7 @@ import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = fileURLToPath(new URL("..", import.meta.url));
+const EXTRA_RELEASE_PACKAGE_DIRS = ["packages/ink-gradient-shim", "packages/ink-spinner-shim"];
 
 function die(msg) {
   process.stderr.write(`${msg}\n`);
@@ -63,6 +64,11 @@ function listWorkspaceDirs() {
   return out;
 }
 
+function listReleasePackageDirs() {
+  const dirs = [...listWorkspaceDirs(), ...EXTRA_RELEASE_PACKAGE_DIRS];
+  return [...new Set(dirs)].sort();
+}
+
 function updateInternalDeps(pkgJson, nextVersion) {
   const depFields = ["dependencies", "devDependencies", "optionalDependencies", "peerDependencies"];
   for (const field of depFields) {
@@ -76,10 +82,10 @@ function updateInternalDeps(pkgJson, nextVersion) {
   }
 }
 
-const workspaceDirs = listWorkspaceDirs();
-if (workspaceDirs.length === 0) die("release-set-version: no workspaces discovered");
+const releasePackageDirs = listReleasePackageDirs();
+if (releasePackageDirs.length === 0) die("release-set-version: no release packages discovered");
 
-for (const relDir of workspaceDirs) {
+for (const relDir of releasePackageDirs) {
   const pkgPath = join(ROOT, relDir, "package.json");
   if (!statSync(pkgPath, { throwIfNoEntry: false })) continue;
   const pkgJson = readJson(pkgPath);
@@ -92,5 +98,5 @@ for (const relDir of workspaceDirs) {
 }
 
 process.stdout.write(
-  `release-set-version: set version=${version} for ${workspaceDirs.length} workspace(s)\n`,
+  `release-set-version: set version=${version} for ${releasePackageDirs.length} package(s)\n`,
 );


### PR DESCRIPTION
## Summary
- publish `@rezi-ui/ink-compat` in release workflow
- publish `ink-gradient-shim` and `ink-spinner-shim` in release workflow
- include shim package directories in `release-set-version` so each release tag bumps their versions before publish

## Why
`v0.1.0-alpha.41` only published core/native/testkit/node/jsx/create-rezi. This wires missing packages into the same release pipeline so npm stays in sync.