### PR TITLE
fix(native): make ZR_ARRAYLEN MSVC-compatible

### DIFF
--- a/packages/native/vendor/zireael/src/util/zr_macros.h
+++ b/packages/native/vendor/zireael/src/util/zr_macros.h
@@ -11,11 +11,18 @@
 /*
   Number of elements in a fixed-size array.
 
-  Rejects pointer arguments at compile time.
+  On GCC/Clang: rejects pointer arguments at compile time via
+  __builtin_types_compatible_p.
+  On MSVC (non-clang-cl): no pointer-decay guard is available in C mode,
+  so callers must ensure a true array is passed.
 */
+#if defined(_MSC_VER) && !defined(__clang__)
+#define ZR_ARRAYLEN(arr) (sizeof(arr) / sizeof((arr)[0]))
+#else
 #define ZR_ARRAYLEN(arr)                                                                                               \
   ((sizeof(arr) / sizeof((arr)[0])) +                                                                                  \
    0u * sizeof(char[1 - 2 * !!__builtin_types_compatible_p(__typeof__(arr), __typeof__(&(arr)[0]))]))
+#endif
 
 /*
   Generic min/max helpers.


### PR DESCRIPTION
## Summary
- add MSVC/non-clang fallback for `ZR_ARRAYLEN` in vendored Zireael macros
- keep GCC/Clang pointer-decay guard path unchanged

## Why
`v0.1.0-alpha.42` release failed in Windows prebuild jobs due to GCC-only builtins in `ZR_ARRAYLEN`.
This unblocks release prebuild matrix so npm publish can run.