### PR TITLE
fix(release): publish ink-compat by path

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -211,7 +211,7 @@ jobs:
       - name: Publish @rezi-ui/ink-compat
         env:
           NODE_AUTH_TOKEN: ${{ secrets.NPM_TOKEN }}
-        run: npm publish -w @rezi-ui/ink-compat --access public
+        run: npm publish ./packages/ink-compat --access public
 
       - name: Publish ink-gradient-shim
         env:

--- a/scripts/release-set-version.mjs
+++ b/scripts/release-set-version.mjs
@@ -4,7 +4,11 @@ import { join, resolve } from "node:path";
 import { fileURLToPath } from "node:url";
 
 const ROOT = fileURLToPath(new URL("..", import.meta.url));
-const EXTRA_RELEASE_PACKAGE_DIRS = ["packages/ink-gradient-shim", "packages/ink-spinner-shim"];
+const EXTRA_RELEASE_PACKAGE_DIRS = [
+  "packages/ink-compat",
+  "packages/ink-gradient-shim",
+  "packages/ink-spinner-shim",
+];
 
 function die(msg) {
   process.stderr.write(`${msg}\n`);


### PR DESCRIPTION
## Summary
- publish `@rezi-ui/ink-compat` via package path (`./packages/ink-compat`) instead of workspace selector
- include `packages/ink-compat` in release version sync extras

## Why
`v0.1.0-alpha.43` failed in publish because root workspaces still omit ink-compat, so `npm publish -w @rezi-ui/ink-compat` cannot resolve. This keeps release working without changing workspace topology.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated release workflow to properly include the ink-compat package in the publishing and versioning process.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->