### PR TITLE
docs(ink-compat): move benchmark block out of root README

### DIFF
--- a/README.md
+++ b/README.md
@@ -133,44 +133,6 @@ See [BENCHMARKS.md](BENCHMARKS.md) for full results, all scenarios, scenario def
 
 ---
 
-## Ink-Compat Bench (Ink vs Ink-Compat)
-
-This repo includes a fairness-focused benchmark + profiling suite that runs the **same TUI app code** against:
-
-- `real-ink`: `@jrichman/ink`
-- `ink-compat`: `@rezi-ui/ink-compat`
-
-Key commands:
-
-```bash
-# build bench packages
-npm run prebench
-
-# (optional) set up module resolution for bench-app explicitly
-npm run prepare:real-ink
-npm run prepare:ink-compat
-
-# run a scenario (3 replicates)
-npm run -s bench -- --scenario streaming-chat --renderer real-ink --runs 3 --out results/
-npm run -s bench -- --scenario streaming-chat --renderer ink-compat --runs 3 --out results/
-
-# CPU profiling (writes .cpuprofile under results/.../run_XX/cpu-prof/)
-npm run -s bench -- --scenario dashboard-grid --renderer ink-compat --runs 1 --cpu-prof --out results/
-
-# final-screen equivalence gate
-npm run -s verify -- --scenario streaming-chat --compare real-ink,ink-compat --out results/
-```
-
-Docs + reports:
-
-- Methodology + metric definitions: `BENCHMARK_VALIDITY.md`
-- Latest report: `results/report_2026-02-27.md`
-- Bottlenecks + fixes: `results/bottlenecks.md`
-- Porting and architecture docs:
-  - `docs/migration/ink-to-ink-compat.md`
-  - `docs/architecture/ink-compat.md`
-  - `docs/dev/ink-compat-debugging.md`
-
 ## Quick Start
 
 Get running in under a minute:

--- a/docs/architecture/ink-compat.md
+++ b/docs/architecture/ink-compat.md
@@ -103,6 +103,43 @@ node -e "const fs=require('node:fs'); const path=require('node:path'); const pkg
 
 4. For rendering/layout/theme parity checks, run a live PTY with `REZI_FRAME_AUDIT=1` and generate evidence with `node scripts/frame-audit-report.mjs`.
 
+## Ink-Compat Bench (Ink vs Ink-Compat)
+
+This repo includes a fairness-focused benchmark + profiling suite that runs the **same TUI app code** against:
+
+- `real-ink`: `@jrichman/ink`
+- `ink-compat`: `@rezi-ui/ink-compat`
+
+Key commands:
+
+```bash
+# build bench packages
+npm run prebench
+
+# (optional) set up module resolution for bench-app explicitly
+npm run prepare:real-ink
+npm run prepare:ink-compat
+
+# run a scenario (3 replicates)
+npm run -s bench -- --scenario streaming-chat --renderer real-ink --runs 3 --out results/
+npm run -s bench -- --scenario streaming-chat --renderer ink-compat --runs 3 --out results/
+
+# CPU profiling (writes .cpuprofile under results/.../run_XX/cpu-prof/)
+npm run -s bench -- --scenario dashboard-grid --renderer ink-compat --runs 1 --cpu-prof --out results/
+
+# final-screen equivalence gate
+npm run -s verify -- --scenario streaming-chat --compare real-ink,ink-compat --out results/
+```
+
+Docs + reports:
+
+- Methodology + metric definitions: `BENCHMARK_VALIDITY.md`
+- Latest report: `results/report_2026-02-27.md`
+- Bottlenecks + fixes: `results/bottlenecks.md`
+- Porting and architecture docs:
+  - `../migration/ink-to-ink-compat.md`
+  - `../dev/ink-compat-debugging.md`
+
 ## Public compatibility surface
 
 ### Components


### PR DESCRIPTION
## Summary
- remove the `Ink-Compat Bench (Ink vs Ink-Compat)` section from root README
- move the same benchmark/profiling commands and report links into `docs/architecture/ink-compat.md`
- keep root README focused on project-level overview and quick start

## Validation
- docs-only change; no runtime or package code touched