### PR TITLE
test(core): lock modal action order and click mapping

### DIFF
--- a/packages/core/src/app/__tests__/widgetRenderer.integration.test.ts
+++ b/packages/core/src/app/__tests__/widgetRenderer.integration.test.ts
@@ -10,7 +10,7 @@ import type { DrawlistBuilder } from "../../drawlist/index.js";
 import type { ZrevEvent } from "../../events.js";
 import { type VNode, defineWidget, ui } from "../../index.js";
 import { DEFAULT_TERMINAL_CAPS } from "../../terminalCaps.js";
-import { createTestRenderer } from "../../testing/renderer.js";
+import { createTestRenderer } from "../../testing/index.js";
 import { defaultTheme } from "../../theme/defaultTheme.js";
 import { TOAST_HEIGHT, getToastActionFocusId } from "../../widgets/toast.js";
 import { createApp } from "../createApp.js";


### PR DESCRIPTION
## Summary
- validated modal action rendering/routing behavior from issue #222 on current `main`
- added `WidgetRenderer` integration regression coverage to assert:
  - modal action buttons keep declared left-to-right order
  - click targets trigger the matching callbacks in the same order

## Validation
- `npm -w @rezi-ui/core run build`
- `node --test --test-concurrency=1 packages/core/dist/app/__tests__/widgetRenderer.integration.test.js`

Fixes #222


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests to verify modal action buttons render left-to-right, respond to clicks in order, and invoke callbacks in the expected sequence. Includes rendering/snapshot-style checks to guard visual consistency of the modal actions.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->