### PR TITLE
perf(core): reduce routing commit overhead

### DIFF
--- a/packages/core/src/app/widgetRenderer.ts
+++ b/packages/core/src/app/widgetRenderer.ts
@@ -4888,7 +4888,7 @@ export class WidgetRenderer<S> {
         }
 
         // Garbage collect local state for virtual lists that were removed.
-        for (const virtualListId of this.virtualListStore.keys?.() ?? []) {
+        for (const virtualListId of this.virtualListStore.keys()) {
           if (!this.virtualListById.has(virtualListId)) this.virtualListStore.delete(virtualListId);
         }
         if (this.pressedVirtualList && !this.virtualListById.has(this.pressedVirtualList.id)) {
@@ -4896,7 +4896,7 @@ export class WidgetRenderer<S> {
         }
 
         // Garbage collect local state for tables that were removed.
-        for (const tableId of this.tableStore.keys?.() ?? []) {
+        for (const tableId of this.tableStore.keys()) {
           if (!this.tableById.has(tableId)) this.tableStore.delete(tableId);
         }
 
@@ -4912,7 +4912,7 @@ export class WidgetRenderer<S> {
         }
 
         // Garbage collect treeStore entries for tree-like widgets that were removed.
-        for (const treeLikeId of this.treeStore.keys?.() ?? []) {
+        for (const treeLikeId of this.treeStore.keys()) {
           if (
             !this.treeById.has(treeLikeId) &&
             !this.filePickerById.has(treeLikeId) &&

--- a/packages/core/src/runtime/localState.ts
+++ b/packages/core/src/runtime/localState.ts
@@ -140,7 +140,7 @@ export type VirtualListStateStore = Readonly<{
   get: (id: string) => VirtualListLocalState;
   set: (id: string, patch: VirtualListLocalStatePatch) => VirtualListLocalState;
   delete: (id: string) => void;
-  keys?: () => IterableIterator<string>;
+  keys: () => IterableIterator<string>;
 }>;
 
 /** Create a new virtual list state store instance. */
@@ -224,7 +224,7 @@ export type TableStateStore = Readonly<{
   get: (id: string) => TableLocalState;
   set: (id: string, patch: TableLocalStatePatch) => TableLocalState;
   delete: (id: string) => void;
-  keys?: () => IterableIterator<string>;
+  keys: () => IterableIterator<string>;
 }>;
 
 /** Create a new table state store instance. */
@@ -335,7 +335,7 @@ export type TreeStateStore = Readonly<{
   get: (id: string) => TreeLocalState;
   set: (id: string, patch: TreeLocalStatePatch) => TreeLocalState;
   delete: (id: string) => void;
-  keys?: () => IterableIterator<string>;
+  keys: () => IterableIterator<string>;
   /** Add a key to the loading set. */
   startLoading: (id: string, nodeKey: string) => TreeLocalState;
   /** Remove a key from the loading set. */


### PR DESCRIPTION
## Summary
- skip full routing rebuild work when commits do not touch routing-affecting state
- reduce routing GC snapshot overhead in `WidgetRenderer` by trimming per-commit snapshot work
- avoid freezing transient routing arrays created in hot commit paths

## Why
Routing maintenance was adding avoidable overhead on render commits where route/focus candidates did not materially change. This PR narrows and cheapens that path while preserving behavior.

## Scope
- `packages/core/src/app/widgetRenderer.ts`
- `packages/core/src/runtime/localState.ts`

## Validation
- `node scripts/run-tests.mjs --filter "router|routing|widgetRenderer|createApp"`
  - pass: 97
  - fail: 0
- manual PTY regression and benchmark passes were executed during the optimization wave before acceptance of these commits.

## Commits
- `58ca7c9` perf(core): skip full routing rebuild on non-routing commits
- `be86dc9` perf(core): trim routing GC snapshot overhead
- `acbbaed` perf(core): avoid freezing transient routing arrays


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Chores**
  * Optimized state cleanup and garbage collection paths for widget rendering to reduce stale state and streamline per-commit cleanup.
* **Enhancements**
  * Added enumerable keys to list, table, and tree state stores for easier iteration.
  * Improved routing/shortcut stability by avoiding unnecessary full rebuilds when routing-related changes are absent.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->