### PR TITLE
refactor(core): remove dead percent guard paths from stack layout

### DIFF
--- a/packages/core/src/layout/engine/guards.ts
+++ b/packages/core/src/layout/engine/guards.ts
@@ -60,18 +60,6 @@ export function childHasFlexInMainAxis(vnode: unknown, axis: Axis): boolean {
   return typeof flex === "number" && Number.isFinite(flex) && flex > 0;
 }
 
-export function childHasPercentInMainAxis(vnode: unknown, axis: Axis): boolean {
-  void vnode;
-  void axis;
-  return false;
-}
-
-export function childHasPercentInCrossAxis(vnode: unknown, axis: Axis): boolean {
-  void vnode;
-  void axis;
-  return false;
-}
-
 export function childHasAbsolutePosition(vnode: unknown): boolean {
   if (!isVNode(vnode)) return false;
   const p = vnode.props as { position?: unknown };

--- a/packages/core/src/layout/kinds/stack.ts
+++ b/packages/core/src/layout/kinds/stack.ts
@@ -19,8 +19,6 @@ import {
 import {
   childHasAbsolutePosition,
   childHasFlexInMainAxis,
-  childHasPercentInCrossAxis,
-  childHasPercentInMainAxis,
   getConstraintProps,
 } from "../engine/guards.js";
 import { measureMaxContent, measureMinContent } from "../engine/intrinsic.js";
@@ -1284,19 +1282,10 @@ function measureStack(
   const hasFlexInMainAxis = vnode.children.some(
     (c) => !childHasAbsolutePosition(c) && childHasFlexInMainAxis(c, axis.axis),
   );
-  const hasPercentInMainAxis = vnode.children.some(
-    (c) => !childHasAbsolutePosition(c) && childHasPercentInMainAxis(c, axis.axis),
-  );
   const hasAdvancedFlexProps = vnode.children.some(
     (c) => !childHasAbsolutePosition(c) && childHasAdvancedFlexProps(c),
   );
-  const needsConstraintPass = hasFlexInMainAxis || hasPercentInMainAxis || hasAdvancedFlexProps;
-  const fillMain = forcedMain === null && hasPercentInMainAxis;
-  const fillCross =
-    forcedCross === null &&
-    vnode.children.some(
-      (c) => !childHasAbsolutePosition(c) && childHasPercentInCrossAxis(c, axis.axis),
-    );
+  const needsConstraintPass = hasFlexInMainAxis || hasAdvancedFlexProps;
   const childCount = countNonEmptyChildren(vnode.children);
 
   const outerWLimit = forcedW ?? maxWCap;
@@ -1307,10 +1296,8 @@ function measureStack(
   const crossLimit = crossFromWH(axis, cw, ch);
 
   const finalizeSize = (contentMain: number, contentCross: number): LayoutResult<Size> => {
-    const chosenMain =
-      forcedMain ?? (fillMain ? maxMainCap : Math.min(maxMainCap, padMain + contentMain));
-    const chosenCross =
-      forcedCross ?? (fillCross ? maxCrossCap : Math.min(maxCrossCap, padCross + contentCross));
+    const chosenMain = forcedMain ?? Math.min(maxMainCap, padMain + contentMain);
+    const chosenCross = forcedCross ?? Math.min(maxCrossCap, padCross + contentCross);
     const innerMain = clampWithin(chosenMain, minMain, maxMainCap);
     const innerCross = clampWithin(chosenCross, minCross, maxCrossCap);
     const { w: innerW, h: innerH } = toWH(axis, innerMain, innerCross);
@@ -1585,9 +1572,7 @@ function layoutStack(
   const needsConstraintPass = vnode.children.some(
     (c) =>
       !childHasAbsolutePosition(c) &&
-      (childHasFlexInMainAxis(c, axis.axis) ||
-        childHasPercentInMainAxis(c, axis.axis) ||
-        childHasAdvancedFlexProps(c)),
+      (childHasFlexInMainAxis(c, axis.axis) || childHasAdvancedFlexProps(c)),
   );
   const wrap = isWrapEnabled(vnode.props);
 


### PR DESCRIPTION
## Summary
- remove `childHasPercentInMainAxis` / `childHasPercentInCrossAxis` from layout guards
- remove corresponding dead callsites in stack measure/layout passes
- simplify stack auto-size finalize logic by dropping never-true percent fill branches

## Why
- percentage strings are intentionally rejected in current API (`expr(...)` is the replacement)
- percent guard helpers were hardcoded `false`, so these branches were dead code
- this reduces cognitive overhead without changing runtime behavior

## Behavior
- `%` strings remain rejected (unchanged)
- flex/advanced constraint passes remain intact

## Tests
- `npx tsx --test packages/core/src/layout/__tests__/layout.percentage.test.ts`
- `npx tsx --test packages/core/src/layout/__tests__/layout.auto-sizing.test.ts`
- `npx tsx --test packages/core/src/layout/__tests__/layout.edgecases.test.ts`
- `node scripts/run-tests.mjs --filter "layout\.(percentage|auto-sizing|edgecases)"`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Simplified layout constraint logic by removing percentage-based sizing calculations from the layout engine.
  * Streamlined sizing computations by removing percent-driven constraint planning.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->