### PR TITLE
docs: align runtime and release docs with current behavior

### DIFF
--- a/RELEASING.md
+++ b/RELEASING.md
@@ -22,11 +22,11 @@ That's it. The `release` workflow will:
 
 1. Create a GitHub Release with auto-generated notes
 2. Build native prebuilds for 6 platforms (linux-x64, linux-arm64, darwin-x64, darwin-arm64, win32-x64, win32-arm64)
-3. Run smoke tests on each platform
+3. Run smoke tests on the host lanes that currently support them
 4. Sync all `package.json` versions to match the tag (via `scripts/release-set-version.mjs`)
 5. Build TypeScript
 6. Assemble native binaries and verify pack contents
-7. Publish all 6 packages to npm in dependency order
+7. Publish all npm artifacts in dependency order
 
 ## Packages published
 
@@ -37,9 +37,17 @@ In order:
 3. `@rezi-ui/testkit` — no internal deps
 4. `@rezi-ui/node` — depends on core + native
 5. `@rezi-ui/jsx` — depends on core
-6. `create-rezi` — CLI scaffolding tool
+6. `@rezi-ui/ink-compat` — compatibility layer
+7. `ink-gradient-shim` — legacy shim package
+8. `ink-spinner-shim` — legacy shim package
+9. `@rezi-ui/ink-gradient-shim` — scoped shim package
+10. `@rezi-ui/ink-spinner-shim` — scoped shim package
+11. `create-rezi` — CLI scaffolding tool
 
 `@rezi-ui/bench` is private and never published.
+
+Documentation deployment is handled by the separate `docs` workflow on pushes to
+`main`.
 
 ## Version format
 

--- a/docs/backend/node.md
+++ b/docs/backend/node.md
@@ -41,8 +41,13 @@ Development hot reload:
 Execution mode details:
 
 - `auto` (default): select inline for low-fps workloads (`fpsCap <= 30`), worker otherwise.
-- `worker`: force worker-thread engine execution.
+- `worker`: force worker-thread engine execution. With the real native addon this
+  requires an interactive TTY; test harnesses can provide `nativeShimModule`
+  instead.
 - `inline`: run the engine inline on the main JS thread.
+
+For headless snapshots and unit tests, prefer `createTestRenderer()` /
+`@rezi-ui/testkit` over the real native backend.
 
 `NO_COLOR` support:
 

--- a/docs/backend/worker-model.md
+++ b/docs/backend/worker-model.md
@@ -6,6 +6,12 @@ Rezi supports three backend execution modes via `config.executionMode`:
 - `worker`: run native engine/polling on a worker thread
 - `inline`: run native engine inline on the main JS thread
 
+Notes:
+
+- Worker mode with the real native addon requires an interactive TTY.
+- Headless tests can use `nativeShimModule` or `@rezi-ui/testkit` /
+  `createTestRenderer()` instead of the real native backend.
+
 High-level goals:
 
 - worker offload when needed, inline fast path when appropriate

--- a/docs/dev/releasing.md
+++ b/docs/dev/releasing.md
@@ -6,7 +6,6 @@ Releases cover:
 
 - npm package publishing
 - GitHub Releases (notes + artifacts)
-- documentation deployment
 
 The native addon release includes prebuilt `.node` binaries for the supported platform matrix and packaging into `@rezi-ui/native`.
 
@@ -18,6 +17,13 @@ Rezi publishes:
 - `@rezi-ui/node`
 - `@rezi-ui/native`
 - `@rezi-ui/testkit`
+- `@rezi-ui/jsx`
+- `@rezi-ui/ink-compat`
+- `ink-gradient-shim`
+- `ink-spinner-shim`
+- `@rezi-ui/ink-gradient-shim`
+- `@rezi-ui/ink-spinner-shim`
+- `create-rezi`
 
 The repo uses a single version across these publishable packages.
 
@@ -65,6 +71,9 @@ node scripts/release-set-version.mjs 0.1.0-alpha.16
    - native prebuild matrix passes
    - npm publish steps pass
    - GitHub Release notes and assets are generated
+
+Documentation deployment is handled separately by the docs workflow on pushes to
+`main`, not by the npm release workflow.
 
 ## Publishing requirements
 

--- a/docs/getting-started/install.md
+++ b/docs/getting-started/install.md
@@ -46,7 +46,8 @@ Or with other package managers:
 
 ## Prebuilt Binaries
 
-The `@rezi-ui/node` package includes prebuilt native binaries for common platforms:
+Installing `@rezi-ui/node` also installs `@rezi-ui/native`, which contains the
+prebuilt `.node` binaries for supported platforms:
 
 | Platform | Architecture | Status |
 |----------|--------------|--------|
@@ -55,15 +56,18 @@ The `@rezi-ui/node` package includes prebuilt native binaries for common platfor
 | macOS | x64 (Intel) | Included |
 | macOS | arm64 (Apple Silicon) | Included |
 | Windows | x64 | Included |
+| Windows | arm64 | Included |
 
-If a prebuilt binary is not available for your platform, the package will attempt to compile from source (requires a C toolchain).
+No install-time source build runs for unsupported targets. If a matching
+prebuilt binary is not available, build from a repository checkout with
+`npm run build:native`.
 
 ## Package Overview
 
 | Package | Description | Required |
 |---------|-------------|----------|
 | `@rezi-ui/core` | Widgets, layout, themes, forms, keybindings | Yes |
-| `@rezi-ui/node` | Node.js/Bun backend (worker/inline modes + native rendering) | Yes |
+| `@rezi-ui/node` | Node.js/Bun backend (worker/inline modes + depends on `@rezi-ui/native`) | Yes |
 | `@rezi-ui/testkit` | Testing utilities and fixtures | Optional |
 
 ## Optional packages

--- a/docs/overrides/main.html
+++ b/docs/overrides/main.html
@@ -2,6 +2,6 @@
 
 {% block announce %}
   <a href="https://github.com/RtlZeroMemory/Rezi/blob/main/CHANGELOG.md">
-    Rezi v0.1.0-alpha.13 released — 4 new navigation widgets, grid layout, expanded forms
+    See CHANGELOG.md for the latest release notes.
   </a>
 {% endblock %}

--- a/docs/protocol/abi.md
+++ b/docs/protocol/abi.md
@@ -1,7 +1,7 @@
 # ABI Pins
 
-The following constants are exported by `@rezi-ui/core` and must stay aligned
-with the engine.
+The following exported constants from `@rezi-ui/core` must stay aligned with the
+engine pins.
 
 ## Version Pins
 
@@ -11,7 +11,6 @@ with the engine.
 | `ZR_ENGINE_ABI_MINOR` | `2` | Engine ABI minor |
 | `ZR_ENGINE_ABI_PATCH` | `0` | Engine ABI patch |
 | `ZR_DRAWLIST_VERSION_V1` | `1` | ZRDL v1 |
-| `ZR_DRAWLIST_VERSION_V2` | `2` | ZRDL v2 (`BLIT_RECT`) |
 | `ZR_EVENT_BATCH_VERSION_V1` | `1` | ZREV v1 |
 | `ZR_UNICODE_VERSION_MAJOR` | `15` | Unicode major |
 | `ZR_UNICODE_VERSION_MINOR` | `1` | Unicode minor |
@@ -26,7 +25,8 @@ with the engine.
 
 ## Drawlist Version Rule
 
-Rezi currently emits drawlist v1. Engine-side validation accepts v1 and v2.
+Rezi currently exports and emits drawlist v1. The engine-side pins additionally
+accept `ZR_DRAWLIST_VERSION_V2` for native validation.
 
 ## Result Codes
 

--- a/docs/protocol/versioning.md
+++ b/docs/protocol/versioning.md
@@ -17,12 +17,12 @@ Pinned to match Zireael:
 
 ## Drawlist (ZRDL)
 
-Pinned drawlist version:
+Exported drawlist version pin:
 
 - `ZR_DRAWLIST_VERSION_V1 = 1`
-- `ZR_DRAWLIST_VERSION_V2 = 2`
 
-Rezi currently emits ZRDL v1, and the engine accepts v1/v2.
+Rezi currently emits ZRDL v1. The engine accepts v1/v2, with `ZR_DRAWLIST_VERSION_V2 = 2`
+defined in Zireael's public headers.
 ZRDL v2 adds opcode `14` (`BLIT_RECT`).
 Style link reference fields (`linkUriRef`, `linkIdRef`) are stable across v1/v2:
 `0` means unset and positive values are 1-based string resource IDs.

--- a/docs/widgets/index.md
+++ b/docs/widgets/index.md
@@ -508,7 +508,7 @@ Widget stability tiers and guarantees are documented in [Widget Stability](stabi
 
 | Tier | Meaning |
 |------|---------|
-| `stable` | Semver-protected behavior contract with deterministic regression tests. No breaking changes in minor/patch releases. |
+| `stable` | Strongest contract-hardened tier inside the current pre-alpha line. Deterministic regression tests exist, but repo-wide pre-alpha status still applies. |
 | `beta` | Core invariants tested; contract may evolve in minor releases. |
 | `experimental` | No compatibility guarantees; APIs can change at any time. |
 

--- a/docs/widgets/stability.md
+++ b/docs/widgets/stability.md
@@ -4,7 +4,7 @@ Rezi uses stability tiers so teams can choose widgets with clear behavior guaran
 
 ## Tiers
 
-- `stable`: behavior contract and deterministic tests exist; semver guarantees apply to the documented stable surface.
+- `stable`: strongest widget tier inside the current pre-alpha line; documented behavior contracts and deterministic tests exist, and maintainers aim to avoid unnecessary breaking changes.
 - `beta`: usable and tested for core invariants, but parts of the contract can still evolve.
 - `experimental`: no compatibility guarantees; behavior and APIs can change quickly.
 
@@ -14,8 +14,8 @@ When a widget is marked `stable`, Rezi guarantees:
 
 - deterministic behavior for documented keyboard, pointer, and editing contracts
 - deterministic regression tests that pin those contracts in `packages/core/src/**/__tests__`
-- no breaking changes to documented stable behavior in minor or patch releases
-- any required stable-surface behavior change is treated as semver-major
+- clear changelog callouts when documented stable behavior changes
+- stronger compatibility expectations than `beta` / `experimental`, while the repo-wide pre-alpha status still applies to the package line as a whole
 
 ## Daily Driver Status
 

--- a/examples/gallery/src/index.ts
+++ b/examples/gallery/src/index.ts
@@ -96,8 +96,6 @@ const app = createNodeApp<State>({
     activeScene: 0,
     themeName: "dark",
   },
-  // Inline mode avoids worker/native crash during live theme switches in demo flow.
-  config: { executionMode: "inline" },
 });
 
 function resolveSceneTabWindow(

--- a/examples/regression-dashboard/src/main.ts
+++ b/examples/regression-dashboard/src/main.ts
@@ -235,7 +235,6 @@ const app = createNodeApp({
   config: {
     fpsCap: UI_FPS_CAP,
     emojiWidthPolicy: "auto",
-    executionMode: "inline",
   },
   initialState,
   theme: themeSpec(initialState.themeName).theme,


### PR DESCRIPTION
## Summary
- remove stale inline-for-crash forcing from examples
- align install, backend, stability, protocol, and release docs with current runtime behavior
- replace the stale docs-site version announcement

## Verification
- npm run build
- npm run docs:build

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Updated installation guidance and package descriptions.
  * Clarified widget stability tier expectations within pre-alpha status.
  * Added testing guidance for worker mode and TTY requirements.
  * Updated release notes pointer in announcement section.

* **Chores**
  * Revised published package list and release workflow documentation.
  * Updated example configurations to use default execution modes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->