### PR TITLE
fix(core): defer fatal handlers outside event dispatch

### DIFF
--- a/packages/core/src/app/__tests__/onEventHandlers.test.ts
+++ b/packages/core/src/app/__tests__/onEventHandlers.test.ts
@@ -104,6 +104,44 @@ test("onEvent handler failure aborts the current batch before later events commi
   assert.equal(backend.disposeCalls, 1);
 });
 
+test("onEvent handler failure faults before same-turn queued updates commit", async () => {
+  const backend = new StubBackend();
+  const app = createApp({ backend, initialState: 0 });
+
+  app.draw((g) => g.clear());
+
+  let updaterRan = false;
+  app.onEvent((ev) => {
+    if (ev.kind !== "engine" || ev.event.kind !== "text") return;
+    app.update((state) => {
+      updaterRan = true;
+      return state + 1;
+    });
+    throw new Error("boom");
+  });
+
+  const fatals: string[] = [];
+  app.onEvent((ev) => {
+    if (ev.kind === "fatal") fatals.push(ev.detail);
+  });
+
+  await app.start();
+  backend.pushBatch(
+    makeBackendBatch({
+      bytes: encodeZrevBatchV1({
+        events: [{ kind: "text", timeMs: 1, codepoint: 65 }],
+      }),
+    }),
+  );
+
+  await flushMicrotasks(20);
+
+  assert.equal(updaterRan, false);
+  assert.equal(fatals.length, 1);
+  assert.equal(backend.stopCalls, 1);
+  assert.equal(backend.disposeCalls, 1);
+});
+
 test("fatal handlers run after onEvent handler depth unwinds", async () => {
   const backend = new StubBackend();
   const app = createApp({ backend, initialState: 0 });

--- a/packages/core/src/app/createApp.ts
+++ b/packages/core/src/app/createApp.ts
@@ -719,6 +719,7 @@ export function createApp<S>(opts: CreateAppStateOptions<S> | CreateAppRoutesOnl
   let breadcrumbLastConsumptionPath: RuntimeBreadcrumbConsumptionPath | null = null;
   let breadcrumbLastAction: RuntimeBreadcrumbAction | null = null;
   let breadcrumbEventTracked = false;
+  let deferredInlineFatal: Readonly<{ code: ZrUiErrorCode; detail: string }> | null = null;
 
   function recomputeRuntimeBreadcrumbCollection(): void {
     const next =
@@ -881,9 +882,21 @@ export function createApp<S>(opts: CreateAppStateOptions<S> | CreateAppRoutesOnl
     scheduler.enqueue({ kind: "fatal", code, detail });
   }
 
+  function flushDeferredInlineFatal(): void {
+    if (deferredInlineFatal === null || inEventHandlerDepth !== 0) return;
+    const fatal = deferredInlineFatal;
+    deferredInlineFatal = null;
+    doFatal(fatal.code, fatal.detail);
+  }
+
   function fatalNowOrEnqueue(code: ZrUiErrorCode, detail: string): void {
-    const canFailFastInline =
-      scheduler.isExecuting && !inRender && !inCommit && inEventHandlerDepth === 0;
+    const canFailFastInline = scheduler.isExecuting && !inRender && !inCommit;
+    if (canFailFastInline && inEventHandlerDepth > 0) {
+      if (deferredInlineFatal === null) {
+        deferredInlineFatal = Object.freeze({ code, detail });
+      }
+      return;
+    }
     if (canFailFastInline) {
       doFatal(code, detail);
       return;
@@ -936,6 +949,7 @@ export function createApp<S>(opts: CreateAppStateOptions<S> | CreateAppRoutesOnl
       }
     } finally {
       inEventHandlerDepth--;
+      flushDeferredInlineFatal();
     }
     return true;
   }


### PR DESCRIPTION
## Summary
- defer inline fatal dispatch until app user-code depth unwinds
- add a regression test proving fatal handlers can call \ after an \ handler throw

## Why
CodeRabbit flagged a real runtime hole in merged PR #265: fatal handlers could run while \, causing app API calls from fatal handlers to trip re-entrancy guards and get swallowed.

## Validation
- npm run lint
- npm run build
- node scripts/run-tests.mjs --filter "onEventHandlers|fatal|eventPump"

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Deferred fatal conditions during event handling are now processed after the event stack unwinds, ensuring fatal handlers run reliably and disposal can occur without error.

* **Tests**
  * Added tests verifying that failures inside event handlers prevent same-turn updates and that fatal handlers run after the handler stack unwinds.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->