### PR TITLE
fix: reduce CodeQL noise from tests and harden scan findings

### DIFF
--- a/.github/codeql/codeql-config.yml
+++ b/.github/codeql/codeql-config.yml
@@ -1,0 +1,9 @@
+name: rezi-codeql
+paths-ignore:
+  - "**/__tests__/**"
+  - "**/*.test.js"
+  - "**/*.test.jsx"
+  - "**/*.test.mjs"
+  - "**/*.test.ts"
+  - "**/*.test.tsx"
+  - "**/tests.rs"

--- a/.github/workflows/codeql.yml
+++ b/.github/workflows/codeql.yml
@@ -30,6 +30,7 @@ jobs:
         with:
           languages: javascript-typescript
           build-mode: none
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3
@@ -47,6 +48,7 @@ jobs:
         with:
           languages: rust
           build-mode: none
+          config-file: ./.github/codeql/codeql-config.yml
 
       - name: Perform CodeQL Analysis
         uses: github/codeql-action/analyze@v3

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -157,6 +157,9 @@ Quick scoped run:
 node scripts/run-tests.mjs --filter "codeEditor.syntax"
 ```
 
+`--filter` performs a literal substring match against discovered relative test
+file paths. It does not interpret the value as a raw regular expression.
+
 ### Manual HSR + GIF Workflow
 
 Use the built-in demos under `scripts/hsr/`:

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -28,6 +28,9 @@ Filter to a subset:
 node scripts/run-tests.mjs --filter "layout"
 ```
 
+`--filter` matches a literal substring in the discovered relative test file
+paths.
+
 ## What to test
 
 - Unit behavior for pure helpers and validators.

--- a/packages/core/src/constraints/helpers.ts
+++ b/packages/core/src/constraints/helpers.ts
@@ -102,7 +102,7 @@ function formatDslNumber(fn: string, value: number): string {
   }
 
   if (out.includes(".")) {
-    out = out.replace(/0+$/, "").replace(/\.$/, "");
+    out = trimTrailingZerosAfterDecimal(out);
   }
   if (out.length > 64) {
     throw invalidArg(
@@ -111,6 +111,17 @@ function formatDslNumber(fn: string, value: number): string {
     );
   }
   return `${sign}${out}`;
+}
+
+function trimTrailingZerosAfterDecimal(value: string): string {
+  let end = value.length;
+  while (end > 0 && value.charCodeAt(end - 1) === 48) {
+    end--;
+  }
+  if (end > 0 && value.charCodeAt(end - 1) === 46) {
+    end--;
+  }
+  return end === value.length ? value : value.slice(0, end);
 }
 
 function metricToRefProp(metric: WidgetMetric): RefProp {

--- a/packages/core/src/widgets/__tests__/compositionWidgets.test.ts
+++ b/packages/core/src/widgets/__tests__/compositionWidgets.test.ts
@@ -71,6 +71,16 @@ describe("composition widgets", () => {
     assert.equal(sidebarBox.props.width, railWidth);
   });
 
+  test("constraint helpers format exponent inputs as trimmed decimal literals", () => {
+    const width = widthConstraints.clampedPercentOfParent({
+      ratio: 1e-7,
+      min: 2.5e-7,
+      max: 1e-6,
+    });
+
+    assert.equal(width.source, "clamp(0.00000025, parent.w * 0.0000001, 0.000001)");
+  });
+
   test("ui.card title overload includes title and body", () => {
     const renderer = createTestRenderer({ viewport: { cols: 60, rows: 10 } });
     const result = renderer.render(ui.card("Title", [ui.text("body")]));

--- a/scripts/run-tests.mjs
+++ b/scripts/run-tests.mjs
@@ -71,6 +71,10 @@ function collectPackageTests(root) {
   return out;
 }
 
+function escapeRegExpLiteral(value) {
+  return value.replace(/[\\^$.*+?()[\]{}|]/g, "\\$&");
+}
+
 function parseArgs(argv) {
   let scope = "all";
   let filter = null;
@@ -146,15 +150,7 @@ if (scope === "packages" && packageTests.length === 0) {
 let relFiles = files.map((f) => relative(root, f));
 
 if (typeof filter === "string") {
-  let rx;
-  try {
-    rx = new RegExp(filter);
-  } catch (err) {
-    const msg = err instanceof Error ? err.message : String(err);
-    process.stderr.write(`run-tests: invalid --filter regex: ${msg}\n`);
-    process.exit(1);
-  }
-
+  const rx = new RegExp(escapeRegExpLiteral(filter));
   relFiles = relFiles.filter((p) => rx.test(p));
   if (relFiles.length === 0) {
     process.stderr.write(`run-tests: --filter matched 0 test files (${filter})\n`);


### PR DESCRIPTION
## Summary
- exclude test-only paths from CodeQL analysis for JS/TS and Rust
- harden `scripts/run-tests.mjs --filter` to use literal substring matching instead of raw regex input
- replace the trailing-zero cleanup regex in constraint helpers with a linear trim path and add a regression test

## Validation
- `npm run lint`
- `npm run typecheck`
- `npm run build`
- `node scripts/run-tests.mjs --scope packages --filter "compositionWidgets"`
- `node scripts/run-tests.mjs --scope scripts --filter "check-core-portability"`

## Notes
- the current open alerts on `main` were concentrated in test paths, but there were also two non-test alerts in `scripts/run-tests.mjs` and `packages/core/src/constraints/helpers.ts`; this PR addresses both.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Clarified `--filter` flag behavior to match literal substrings in test file paths rather than regex patterns
  * Expanded testing guidance with examples covering integration, regression, snapshot/visual stability, and responsive behavior across viewports

* **Tests**
  * Added test coverage for numeric constraint formatting with exponent inputs

<!-- end of auto-generated comment: release notes by coderabbit.ai -->