### PR TITLE
[codex] dispatch docs sync for api changes

### DIFF
--- a/.github/workflows/docs-dispatch.yml
+++ b/.github/workflows/docs-dispatch.yml
@@ -1,5 +1,6 @@
 # This workflow goes in the Rezi repo at .github/workflows/docs-dispatch.yml
-# It triggers the website repo to sync docs when docs/ changes
+# It triggers the website repo to sync docs and staged API reference output.
+# The website workflow pushes directly to its main branch, so no PR is opened.
 
 name: Dispatch Docs Update
 
@@ -9,6 +10,11 @@ on:
     paths:
       - 'docs/**'
       - 'mkdocs.yml'
+      - 'packages/**'
+      - 'typedoc.json'
+      - 'package.json'
+      - 'package-lock.json'
+      - 'scripts/docs.sh'
 
 jobs:
   dispatch:


### PR DESCRIPTION
## Summary
- broaden the docs-dispatch workflow triggers beyond `docs/**` and `mkdocs.yml`
- include package, TypeDoc, and docs-build script changes so the website API reference stays in sync automatically
- document that the website repo now syncs directly to `main` without opening a PR

## Why
The website sync now regenerates and publishes `public/api/reference` directly on `rezitui.dev`. Restricting dispatches to only docs content meant API-surface changes in `packages/**` or TypeDoc config changes would not trigger a website sync, leaving the hosted API reference stale.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated documentation workflow to trigger when package files, build configuration, and related scripts are modified, ensuring documentation stays synchronized with code and dependency changes.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->