### PR TITLE
feat: distinguish shifted letter keybindings

### DIFF
--- a/packages/core/src/app/__tests__/shortcutEnforcement.test.ts
+++ b/packages/core/src/app/__tests__/shortcutEnforcement.test.ts
@@ -2,7 +2,7 @@ import { assert, describe, test } from "@rezi-ui/testkit";
 import type { RuntimeBackend } from "../../backend.js";
 import type { ZrevEvent } from "../../events.js";
 import { ui } from "../../index.js";
-import { ZR_MOD_CTRL } from "../../keybindings/keyCodes.js";
+import { ZR_MOD_CTRL, ZR_MOD_SHIFT } from "../../keybindings/keyCodes.js";
 import { DEFAULT_TERMINAL_CAPS } from "../../terminalCaps.js";
 import { defaultTheme } from "../../theme/defaultTheme.js";
 import type { CommandItem, CommandSource } from "../../widgets/types.js";
@@ -566,6 +566,118 @@ describe("widget shortcut enforcement contracts", () => {
 
       await pushEvents(backend, [{ kind: "text", timeMs: 2, codepoint: 120 }]);
       assert.equal(keybindingHits, 0);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  test("uppercase text bindings are distinct from lowercase text bindings", async () => {
+    const backend = new StubBackend();
+    const hits: string[] = [];
+    const app = createApp({ backend, initialState: 0 });
+
+    app.keys({
+      j: () => {
+        hits.push("lower");
+      },
+      J: () => {
+        hits.push("upper");
+      },
+    });
+    app.view(() => ui.text("ready"));
+
+    await app.start();
+    try {
+      await pushEvents(backend, [{ kind: "resize", timeMs: 1, cols: 40, rows: 12 }]);
+      await settleNextFrame(backend);
+
+      await pushEvents(backend, [
+        { kind: "text", timeMs: 2, codepoint: 106 },
+        { kind: "text", timeMs: 3, codepoint: 74 },
+      ]);
+      assert.deepEqual(hits, ["lower", "upper"]);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  test("paired shift key and text only fire uppercase keybindings once", async () => {
+    const backend = new StubBackend();
+    const inputValues: Array<readonly [string, number]> = [];
+    let uppercaseHits = 0;
+    const app = createApp({ backend, initialState: "" });
+
+    app.keys({
+      J: () => {
+        uppercaseHits++;
+      },
+    });
+    app.view((value) =>
+      ui.input({
+        id: "name",
+        value,
+        onInput: (next, cursor) => {
+          inputValues.push([next, cursor]);
+          app.update(() => next);
+        },
+      }),
+    );
+
+    await app.start();
+    try {
+      await pushEvents(backend, [{ kind: "resize", timeMs: 1, cols: 40, rows: 12 }]);
+      await settleNextFrame(backend);
+
+      await pushEvents(backend, [{ kind: "key", timeMs: 2, key: 3, mods: 0, action: "down" }]);
+      await settleNextFrame(backend);
+      await pushEvents(backend, [
+        { kind: "key", timeMs: 3, key: 74, mods: ZR_MOD_SHIFT, action: "down" },
+        { kind: "text", timeMs: 3, codepoint: 74 },
+      ]);
+
+      assert.equal(uppercaseHits, 1);
+      assert.equal(inputValues.length, 0);
+    } finally {
+      await app.stop();
+    }
+  });
+
+  test("paired shift key still routes text when no uppercase binding consumes it", async () => {
+    const backend = new StubBackend();
+    const inputValues: Array<readonly [string, number]> = [];
+    let lowercaseHits = 0;
+    const app = createApp({ backend, initialState: "" });
+
+    app.keys({
+      j: () => {
+        lowercaseHits++;
+      },
+    });
+    app.view((value) =>
+      ui.input({
+        id: "name",
+        value,
+        onInput: (next, cursor) => {
+          inputValues.push([next, cursor]);
+          app.update(() => next);
+        },
+      }),
+    );
+
+    await app.start();
+    try {
+      await pushEvents(backend, [{ kind: "resize", timeMs: 1, cols: 40, rows: 12 }]);
+      await settleNextFrame(backend);
+
+      await pushEvents(backend, [{ kind: "key", timeMs: 2, key: 3, mods: 0, action: "down" }]);
+      await settleNextFrame(backend);
+      await pushEvents(backend, [
+        { kind: "key", timeMs: 3, key: 74, mods: ZR_MOD_SHIFT, action: "down" },
+        { kind: "text", timeMs: 3, codepoint: 74 },
+      ]);
+
+      assert.equal(lowercaseHits, 0);
+      assert.deepEqual(inputValues[inputValues.length - 1], ["J", 1]);
     } finally {
       await app.stop();
     }

--- a/packages/core/src/app/__tests__/shortcutEnforcement.test.ts
+++ b/packages/core/src/app/__tests__/shortcutEnforcement.test.ts
@@ -642,6 +642,47 @@ describe("widget shortcut enforcement contracts", () => {
     }
   });
 
+  test("split shift key and text batches still only fire uppercase keybindings once", async () => {
+    const backend = new StubBackend();
+    const inputValues: Array<readonly [string, number]> = [];
+    let uppercaseHits = 0;
+    const app = createApp({ backend, initialState: "" });
+
+    app.keys({
+      J: () => {
+        uppercaseHits++;
+      },
+    });
+    app.view((value) =>
+      ui.input({
+        id: "name",
+        value,
+        onInput: (next, cursor) => {
+          inputValues.push([next, cursor]);
+          app.update(() => next);
+        },
+      }),
+    );
+
+    await app.start();
+    try {
+      await pushEvents(backend, [{ kind: "resize", timeMs: 1, cols: 40, rows: 12 }]);
+      await settleNextFrame(backend);
+
+      await pushEvents(backend, [{ kind: "key", timeMs: 2, key: 3, mods: 0, action: "down" }]);
+      await settleNextFrame(backend);
+      await pushEvents(backend, [
+        { kind: "key", timeMs: 3, key: 74, mods: ZR_MOD_SHIFT, action: "down" },
+      ]);
+      await pushEvents(backend, [{ kind: "text", timeMs: 3, codepoint: 74 }]);
+
+      assert.equal(uppercaseHits, 1);
+      assert.equal(inputValues.length, 0);
+    } finally {
+      await app.stop();
+    }
+  });
+
   test("paired shift key still routes text when no uppercase binding consumes it", async () => {
     const backend = new StubBackend();
     const inputValues: Array<readonly [string, number]> = [];

--- a/packages/core/src/app/createApp/eventLoop.ts
+++ b/packages/core/src/app/createApp/eventLoop.ts
@@ -4,7 +4,7 @@ import { describeThrown } from "../../debug/describeThrown.js";
 import type { UiEvent } from "../../events.js";
 import type { KeyContext, KeybindingManagerState } from "../../keybindings/index.js";
 import { resetChordState, routeKeyEvent } from "../../keybindings/index.js";
-import { ZR_MOD_CTRL } from "../../keybindings/keyCodes.js";
+import { ZR_MOD_CTRL, ZR_MOD_SHIFT } from "../../keybindings/keyCodes.js";
 import { perfMarkEnd, perfMarkStart, perfNow } from "../../perf/perf.js";
 import type { EventTimeUnwrapState } from "../../protocol/types.js";
 import { parseEventBatchV1 } from "../../protocol/zrev_v1.js";
@@ -15,6 +15,7 @@ import type { ResolvedAppConfig } from "./config.js";
 import { DIRTY_LAYOUT, DIRTY_RENDER, DIRTY_VIEW } from "./dirtyPlan.js";
 import {
   type AppKeybindingHelpers,
+  codepointToImplicitTextMods,
   codepointToCtrlKeyCode,
   codepointToKeyCode,
 } from "./keybindings.js";
@@ -166,12 +167,25 @@ export function createEventLoop<S>(options: CreateEventLoopOptions<S>): AppEvent
     const droppedBatches = batch.droppedBatches;
 
     try {
+      let pendingShiftTextPair:
+        | Readonly<{ codepoint: number; keybindingConsumed: boolean; timeMs: number }>
+        | null = null;
+
       if (engineTruncated || droppedBatches > 0) {
         if (!options.emit({ kind: "overrun", engineTruncated, droppedBatches })) return;
         if (options.getRuntimeState() !== "Running") return;
       }
 
       for (const ev of parsed.value.events) {
+        const pairedShiftText =
+          pendingShiftTextPair !== null &&
+          ev.kind === "text" &&
+          ev.timeMs === pendingShiftTextPair.timeMs &&
+          ev.codepoint === pendingShiftTextPair.codepoint
+            ? pendingShiftTextPair
+            : null;
+        pendingShiftTextPair = null;
+
         if (ev.kind === "key" || ev.kind === "text" || ev.kind === "paste" || ev.kind === "mouse") {
           options.setInteractiveBudget(2);
         }
@@ -251,6 +265,8 @@ export function createEventLoop<S>(options: CreateEventLoopOptions<S>): AppEvent
             }
 
             if (ev.kind === "key") {
+              const shouldPairShiftText =
+                ev.action === "down" && ev.mods === ZR_MOD_SHIFT && ev.key >= 65 && ev.key <= 90;
               const bypass = options.widgetRenderer.shouldBypassKeybindings(ev);
               if (!bypass) {
                 const keyCtx: KeyContext<S> = Object.freeze({
@@ -272,9 +288,23 @@ export function createEventLoop<S>(options: CreateEventLoopOptions<S>): AppEvent
                   return;
                 }
                 if (keyResult.consumed) {
+                  if (shouldPairShiftText) {
+                    pendingShiftTextPair = Object.freeze({
+                      codepoint: ev.key,
+                      keybindingConsumed: true,
+                      timeMs: ev.timeMs,
+                    });
+                  }
                   options.noteBreadcrumbConsumptionPath("keybindings");
                   continue;
                 }
+              }
+              if (shouldPairShiftText) {
+                pendingShiftTextPair = Object.freeze({
+                  codepoint: ev.key,
+                  keybindingConsumed: false,
+                  timeMs: ev.timeMs,
+                });
               }
             }
 
@@ -283,11 +313,12 @@ export function createEventLoop<S>(options: CreateEventLoopOptions<S>): AppEvent
               const shouldRouteCtrlText = ctrlKeyCode !== null;
               const shouldRoutePrintableText =
                 !shouldRouteCtrlText && !options.widgetRenderer.hasActiveOverlay();
-              if (shouldRouteCtrlText || shouldRoutePrintableText) {
+              if (pairedShiftText === null && (shouldRouteCtrlText || shouldRoutePrintableText)) {
                 const keyCode = shouldRouteCtrlText
                   ? ctrlKeyCode
                   : codepointToKeyCode(ev.codepoint);
-                const mods = shouldRouteCtrlText ? ZR_MOD_CTRL : 0;
+                const mods =
+                  (shouldRouteCtrlText ? ZR_MOD_CTRL : 0) | codepointToImplicitTextMods(ev.codepoint);
                 if (keyCode !== null) {
                   const syntheticKeyEvent = {
                     kind: "key" as const,
@@ -319,6 +350,10 @@ export function createEventLoop<S>(options: CreateEventLoopOptions<S>): AppEvent
                     continue;
                   }
                 }
+              }
+              if (pairedShiftText?.keybindingConsumed === true) {
+                options.noteBreadcrumbConsumptionPath("keybindings");
+                continue;
               }
             }
           }

--- a/packages/core/src/app/createApp/eventLoop.ts
+++ b/packages/core/src/app/createApp/eventLoop.ts
@@ -94,9 +94,11 @@ export type AppEventLoop = Readonly<{
   processTurn: (items: readonly WorkItem[]) => void;
 }>;
 
-type PendingShiftTextPair =
-  | Readonly<{ codepoint: number; keybindingConsumed: boolean; timeMs: number }>
-  | null;
+type PendingShiftTextPair = Readonly<{
+  codepoint: number;
+  keybindingConsumed: boolean;
+  timeMs: number;
+}> | null;
 
 export function createEventLoop<S>(options: CreateEventLoopOptions<S>): AppEventLoop {
   let pendingShiftTextPair: PendingShiftTextPair = null;
@@ -318,8 +320,9 @@ export function createEventLoop<S>(options: CreateEventLoopOptions<S>): AppEvent
                 const keyCode = shouldRouteCtrlText
                   ? ctrlKeyCode
                   : codepointToKeyCode(ev.codepoint);
-                const mods = (shouldRouteCtrlText ? ZR_MOD_CTRL : 0)
-                  | codepointToImplicitTextMods(ev.codepoint);
+                const mods =
+                  (shouldRouteCtrlText ? ZR_MOD_CTRL : 0) |
+                  codepointToImplicitTextMods(ev.codepoint);
                 if (keyCode !== null) {
                   const syntheticKeyEvent = {
                     kind: "key" as const,

--- a/packages/core/src/app/createApp/eventLoop.ts
+++ b/packages/core/src/app/createApp/eventLoop.ts
@@ -15,8 +15,8 @@ import type { ResolvedAppConfig } from "./config.js";
 import { DIRTY_LAYOUT, DIRTY_RENDER, DIRTY_VIEW } from "./dirtyPlan.js";
 import {
   type AppKeybindingHelpers,
-  codepointToImplicitTextMods,
   codepointToCtrlKeyCode,
+  codepointToImplicitTextMods,
   codepointToKeyCode,
 } from "./keybindings.js";
 import {
@@ -94,7 +94,12 @@ export type AppEventLoop = Readonly<{
   processTurn: (items: readonly WorkItem[]) => void;
 }>;
 
+type PendingShiftTextPair =
+  | Readonly<{ codepoint: number; keybindingConsumed: boolean; timeMs: number }>
+  | null;
+
 export function createEventLoop<S>(options: CreateEventLoopOptions<S>): AppEventLoop {
+  let pendingShiftTextPair: PendingShiftTextPair = null;
   function commitUpdates(): void {
     const drained = options.updates.drain();
     if (drained.length === 0) return;
@@ -167,10 +172,6 @@ export function createEventLoop<S>(options: CreateEventLoopOptions<S>): AppEvent
     const droppedBatches = batch.droppedBatches;
 
     try {
-      let pendingShiftTextPair:
-        | Readonly<{ codepoint: number; keybindingConsumed: boolean; timeMs: number }>
-        | null = null;
-
       if (engineTruncated || droppedBatches > 0) {
         if (!options.emit({ kind: "overrun", engineTruncated, droppedBatches })) return;
         if (options.getRuntimeState() !== "Running") return;
@@ -317,8 +318,8 @@ export function createEventLoop<S>(options: CreateEventLoopOptions<S>): AppEvent
                 const keyCode = shouldRouteCtrlText
                   ? ctrlKeyCode
                   : codepointToKeyCode(ev.codepoint);
-                const mods =
-                  (shouldRouteCtrlText ? ZR_MOD_CTRL : 0) | codepointToImplicitTextMods(ev.codepoint);
+                const mods = (shouldRouteCtrlText ? ZR_MOD_CTRL : 0)
+                  | codepointToImplicitTextMods(ev.codepoint);
                 if (keyCode !== null) {
                   const syntheticKeyEvent = {
                     kind: "key" as const,

--- a/packages/core/src/app/createApp/keybindings.ts
+++ b/packages/core/src/app/createApp/keybindings.ts
@@ -11,6 +11,7 @@ import {
   registerModes,
   removeBindingsBySource,
 } from "../../keybindings/index.js";
+import { ZR_MOD_SHIFT } from "../../keybindings/keyCodes.js";
 import { DIRTY_VIEW } from "./dirtyPlan.js";
 
 const ROUTE_KEYBINDING_SOURCE = "__rezi:router";
@@ -59,6 +60,13 @@ export function codepointToCtrlKeyCode(codepoint: number): number | null {
     return codepoint + 64;
   }
   return null;
+}
+
+export function codepointToImplicitTextMods(codepoint: number): number {
+  if (codepoint >= 65 && codepoint <= 90) {
+    return ZR_MOD_SHIFT;
+  }
+  return 0;
 }
 
 export function computeKeybindingsEnabled<S>(

--- a/packages/core/src/keybindings/__tests__/keybinding.parse.test.ts
+++ b/packages/core/src/keybindings/__tests__/keybinding.parse.test.ts
@@ -212,9 +212,18 @@ describe("parseKeySequence area A", () => {
       assert.deepEqual(mixed.value, lower.value);
     });
 
-    test("uppercase and lowercase letters parse to same key code", () => {
+    test("bare uppercase letters parse as implicit shift+letter", () => {
       const upper = parseKeySequence("A");
-      const lower = parseKeySequence("a");
+      const explicit = parseKeySequence("shift+a");
+      assert.equal(upper.ok, true);
+      assert.equal(explicit.ok, true);
+      if (!upper.ok || !explicit.ok) return;
+      assert.deepEqual(upper.value, explicit.value);
+    });
+
+    test("ctrl+A still parses identically to ctrl+a", () => {
+      const upper = parseKeySequence("ctrl+A");
+      const lower = parseKeySequence("ctrl+a");
       assert.equal(upper.ok, true);
       assert.equal(lower.ok, true);
       if (!upper.ok || !lower.ok) return;

--- a/packages/core/src/keybindings/__tests__/parser.test.ts
+++ b/packages/core/src/keybindings/__tests__/parser.test.ts
@@ -41,6 +41,7 @@ describe("parseKeySequence", () => {
       assert.ok(key);
       if (!key) return;
       assert.equal(key.key, 65);
+      assert.equal(key.mods.shift, true);
     });
 
     test("digit", () => {
@@ -287,6 +288,17 @@ describe("parseKeySequence", () => {
   });
 
   describe("case insensitivity", () => {
+    test("bare uppercase letter implies shift", () => {
+      const upper = parseKeySequence("J");
+      const explicit = parseKeySequence("shift+j");
+
+      assert.equal(upper.ok, true);
+      assert.equal(explicit.ok, true);
+      if (!upper.ok || !explicit.ok) return;
+
+      assert.deepEqual(upper.value, explicit.value);
+    });
+
     test("CTRL+S equals ctrl+s", () => {
       const upper = parseKeySequence("CTRL+S");
       const lower = parseKeySequence("ctrl+s");

--- a/packages/core/src/keybindings/parser.ts
+++ b/packages/core/src/keybindings/parser.ts
@@ -153,14 +153,7 @@ function parseKeyPart(
     // Single character - convert to key code
     keyCode = charToKeyCode(keyName);
     const charCode = keyName.charCodeAt(0);
-    if (
-      charCode >= 65 &&
-      charCode <= 90 &&
-      !shift &&
-      !ctrl &&
-      !alt &&
-      !meta
-    ) {
+    if (charCode >= 65 && charCode <= 90 && !shift && !ctrl && !alt && !meta) {
       shift = true;
     }
   }

--- a/packages/core/src/keybindings/parser.ts
+++ b/packages/core/src/keybindings/parser.ts
@@ -34,10 +34,8 @@ function parseKeyPart(
     };
   }
 
-  const lower = part.toLowerCase();
-
   // Split on "+" to get modifiers and key
-  const pieces = lower.split("+");
+  const pieces = part.split("+");
   if (pieces.length === 0) {
     return {
       ok: false,
@@ -63,11 +61,12 @@ function parseKeyPart(
     }
 
     const isLast = i === pieces.length - 1;
+    const pieceLower = piece.toLowerCase();
 
-    if (MODIFIER_NAMES.has(piece)) {
+    if (MODIFIER_NAMES.has(pieceLower)) {
       // It's a modifier
       let modifier: "shift" | "ctrl" | "alt" | "meta" | null = null;
-      switch (piece) {
+      switch (pieceLower) {
         case "shift":
           modifier = "shift";
           shift = true;
@@ -144,14 +143,26 @@ function parseKeyPart(
 
   // Look up the key code
   let keyCode: number | null = null;
+  const keyNameLower = keyName.toLowerCase();
 
   // First try named keys
-  const namedCode = KEY_NAME_TO_CODE.get(keyName);
+  const namedCode = KEY_NAME_TO_CODE.get(keyNameLower);
   if (namedCode !== undefined) {
     keyCode = namedCode;
   } else if (keyName.length === 1) {
     // Single character - convert to key code
     keyCode = charToKeyCode(keyName);
+    const charCode = keyName.charCodeAt(0);
+    if (
+      charCode >= 65 &&
+      charCode <= 90 &&
+      !shift &&
+      !ctrl &&
+      !alt &&
+      !meta
+    ) {
+      shift = true;
+    }
   }
 
   if (keyCode === null) {


### PR DESCRIPTION
## Summary
- parse bare uppercase letters as implicit `shift+letter` bindings
- infer shift for uppercase text fallback and avoid double-routing paired `key+text` events
- add focused parser and app coverage for lowercase vs uppercase bindings

Depends on: https://github.com/RtlZeroMemory/Zireael/pull/109

Closes #318

## Testing
- npm -w @rezi-ui/core run build
- node --test packages/core/dist/keybindings/__tests__/parser.test.js packages/core/dist/keybindings/__tests__/keybinding.parse.test.js packages/core/dist/app/__tests__/shortcutEnforcement.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * Uppercase letters in keyboard shortcuts now implicitly include the Shift modifier (e.g., "J" → "Shift+J").
  * Text-input routing now coordinates with Shift-modified key events to prevent duplicate or misrouted input.

* **Tests**
  * Added tests for uppercase vs lowercase shortcut handling, Shift+text pairing (including across frames), and correct routing to focused inputs.

* **Other**
  * Updated parsing tests and parsing behavior to reflect implicit Shift for bare uppercase letters.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->