### PR TITLE
test(node): isolate HSR tmpdir leak regression

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on Keep a Changelog and the project follows Semantic Version
 
 ## [Unreleased]
 
+## [0.1.0-alpha.63] - 2026-04-14
+
+### Tests
+
+- **node/hsr**: Isolated temp-dir environment in `hotStateReload` leak regression so the Node 22 Ubuntu release lane no longer picks up unrelated `rezi-hsr-*` directories.
+
+### CI / Tooling
+
+- **release**: Follow-up release tag for the failed `v0.1.0-alpha.62` run (`node 22 / ubuntu-latest` test flake).
+
 ## [0.1.0-alpha.62] - 2026-04-14
 
 ### Features

--- a/packages/node/src/__tests__/hotStateReload.test.ts
+++ b/packages/node/src/__tests__/hotStateReload.test.ts
@@ -378,12 +378,18 @@ test("createHotStateReload stop before start does not leak temp session director
     const isolatedTmp = join(dir, ".tmp");
     mkdirSync(isolatedTmp, { recursive: true });
 
-    const originalTmpdir = process.env["TMPDIR"];
-    const originalTmp = process.env["TMP"];
-    const originalTemp = process.env["TEMP"];
-    process.env["TMPDIR"] = isolatedTmp;
-    process.env["TMP"] = isolatedTmp;
-    process.env["TEMP"] = isolatedTmp;
+    const env = process.env as NodeJS.ProcessEnv & {
+      TMPDIR: string | undefined;
+      TMP: string | undefined;
+      TEMP: string | undefined;
+    };
+    const fallbackTmpdir = tmpdir();
+    const originalTmpdir = env.TMPDIR;
+    const originalTmp = env.TMP;
+    const originalTemp = env.TEMP;
+    env.TMPDIR = isolatedTmp;
+    env.TMP = isolatedTmp;
+    env.TEMP = isolatedTmp;
 
     try {
       const before = new Set(listHsrSessionDirs());
@@ -401,12 +407,12 @@ test("createHotStateReload stop before start does not leak temp session director
       const leaked = after.filter((name) => !before.has(name));
       assert.deepEqual(leaked, []);
     } finally {
-      if (originalTmpdir === undefined) delete process.env["TMPDIR"];
-      else process.env["TMPDIR"] = originalTmpdir;
-      if (originalTmp === undefined) delete process.env["TMP"];
-      else process.env["TMP"] = originalTmp;
-      if (originalTemp === undefined) delete process.env["TEMP"];
-      else process.env["TEMP"] = originalTemp;
+      if (originalTmpdir === undefined) env.TMPDIR = fallbackTmpdir;
+      else env.TMPDIR = originalTmpdir;
+      if (originalTmp === undefined) env.TMP = fallbackTmpdir;
+      else env.TMP = originalTmp;
+      if (originalTemp === undefined) env.TEMP = fallbackTmpdir;
+      else env.TEMP = originalTemp;
     }
   });
 });

--- a/packages/node/src/__tests__/hotStateReload.test.ts
+++ b/packages/node/src/__tests__/hotStateReload.test.ts
@@ -375,20 +375,39 @@ test("createHotStateReload stop before start does not leak temp session director
   await withTempDir(async (dir) => {
     writeWidgetModule(dir, "v1");
     const viewModule = writeViewModule(dir);
-    const before = new Set(listHsrSessionDirs());
-    const controller = createHotStateReload<State>({
-      app: {
-        replaceView: () => {},
-      },
-      viewModule,
-      moduleRoot: dir,
-    });
+    const isolatedTmp = join(dir, ".tmp");
+    mkdirSync(isolatedTmp, { recursive: true });
 
-    await controller.stop();
+    const originalTmpdir = process.env["TMPDIR"];
+    const originalTmp = process.env["TMP"];
+    const originalTemp = process.env["TEMP"];
+    process.env["TMPDIR"] = isolatedTmp;
+    process.env["TMP"] = isolatedTmp;
+    process.env["TEMP"] = isolatedTmp;
 
-    const after = listHsrSessionDirs();
-    const leaked = after.filter((name) => !before.has(name));
-    assert.deepEqual(leaked, []);
+    try {
+      const before = new Set(listHsrSessionDirs());
+      const controller = createHotStateReload<State>({
+        app: {
+          replaceView: () => {},
+        },
+        viewModule,
+        moduleRoot: dir,
+      });
+
+      await controller.stop();
+
+      const after = listHsrSessionDirs();
+      const leaked = after.filter((name) => !before.has(name));
+      assert.deepEqual(leaked, []);
+    } finally {
+      if (originalTmpdir === undefined) delete process.env["TMPDIR"];
+      else process.env["TMPDIR"] = originalTmpdir;
+      if (originalTmp === undefined) delete process.env["TMP"];
+      else process.env["TMP"] = originalTmp;
+      if (originalTemp === undefined) delete process.env["TEMP"];
+      else process.env["TEMP"] = originalTemp;
+    }
   });
 });
 


### PR DESCRIPTION
## Summary
- isolate TMPDIR/TMP/TEMP to a per-test directory in the HSR stop-before-start leak regression
- avoid cross-test tmpdir interference seen in node 22 ubuntu release lane
- add changelog follow-up entry for v0.1.0-alpha.63

## Validation
- npm run build
- node scripts/run-tests.mjs --scope packages --filter hotStateReload.test.js

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed a regression in hot state reload on Node 22 and Ubuntu environments where temporary directory isolation was not properly handled, preventing interference from unrelated temporary files.

* **CI / Tooling**
  * Added a follow-up release tag to address a previously failed release attempt related to Node 22 environment compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->