### PR TITLE
testing: add terminal-real harness MVP

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5281,9 +5281,7 @@
       "license": "Apache-2.0",
       "dependencies": {
         "@rezi-ui/core": "0.1.0-alpha.61",
-        "@rezi-ui/native": "0.1.0-alpha.61"
-      },
-      "devDependencies": {
+        "@rezi-ui/native": "0.1.0-alpha.61",
         "@xterm/headless": "^6.0.0",
         "node-pty": "^1.1.0"
       },

--- a/packages/core/src/testing/__tests__/scenarioHarness.test.ts
+++ b/packages/core/src/testing/__tests__/scenarioHarness.test.ts
@@ -1,0 +1,165 @@
+import type { App } from "../../app/types.js";
+import { ui } from "../../index.js";
+import { assert, test } from "@rezi-ui/testkit";
+import {
+  createReferenceInputModalFixture,
+  evaluateScenarioResult,
+  referenceInputModalScenario,
+  runReplayScenario,
+  runSemanticScenario,
+  type ScenarioDefinition,
+  type ScenarioFixtureFactory,
+} from "../index.js";
+
+type ReplayState = Readonly<{ value: string }>;
+
+const replayScenario: ScenarioDefinition = Object.freeze({
+  schemaVersion: 1,
+  id: "replay-stateless-input",
+  title: "Replay runner supports stateless action assertions",
+  widgetFamily: "input-textarea",
+  behaviorStatement: "A stateless replay view can still assert routed input actions.",
+  evidenceRefs: Object.freeze([
+    "packages/core/src/repro/replay.ts",
+    "packages/core/src/testing/events.ts",
+  ]),
+  viewport: Object.freeze({ cols: 32, rows: 8 }),
+  theme: Object.freeze({ mode: "named", value: "default" }),
+  capabilityProfile: Object.freeze({
+    supportsMouse: true,
+    supportsBracketedPaste: true,
+    supportsFocusEvents: true,
+    supportsOsc52: true,
+    colorMode: "truecolor",
+  }),
+  scriptedInput: Object.freeze([
+    Object.freeze({ atMs: 0, event: Object.freeze({ kind: "text", text: "a" }) }),
+  ]),
+  expectedActions: Object.freeze([
+    Object.freeze({ id: "field", action: "input", value: "a", cursor: 1 }),
+  ]),
+  expectedScreenCheckpoints: Object.freeze([
+    Object.freeze({
+      id: "static-heading",
+      afterStep: 1,
+      assertionRef: "screen_region_assertion",
+      args: Object.freeze({
+        x: 0,
+        y: 1,
+        width: 32,
+        height: 1,
+        match: "exact",
+        text: Object.freeze([" Replay harness                 "]),
+      }),
+    }),
+  ]),
+  invariants: Object.freeze([
+    Object.freeze({
+      id: "no-duplicate-input",
+      assertionRef: "invariant_assertion",
+      args: Object.freeze({
+        kind: "action_absence",
+        action: Object.freeze({
+          id: "field",
+          action: "input",
+          payloadSubset: Object.freeze({ value: "aa" }),
+        }),
+      }),
+    }),
+  ]),
+  fidelityRequirement: "semantic-only",
+});
+
+const createReplayFixture: ScenarioFixtureFactory<ReplayState> = () => {
+  let app!: App<ReplayState>;
+  return Object.freeze({
+    initialState: Object.freeze({ value: "" }),
+    setup(nextApp) {
+      app = nextApp;
+    },
+    view(state) {
+      void app;
+      return ui.focusTrap({ id: "trap", active: true, initialFocus: "field" }, [
+        ui.column({ p: 1 }, [
+          ui.text("Replay harness"),
+          ui.input({ id: "field", value: state.value }),
+        ]),
+      ]);
+    },
+  });
+};
+
+test("semantic scenario runner: shared reference scenario passes", async () => {
+  const result = await runSemanticScenario({
+    scenario: referenceInputModalScenario,
+    createFixture: createReferenceInputModalFixture,
+  });
+  assert.equal(result.pass, true);
+  assert.equal(result.status, "PASS");
+  assert.deepEqual(result.mismatches, []);
+});
+
+test("replay scenario runner: stateless input scenario passes", async () => {
+  const result = await runReplayScenario({
+    scenario: replayScenario,
+    createFixture: createReplayFixture,
+  });
+  assert.equal(result.pass, true);
+  assert.equal(result.status, "PASS");
+  assert.deepEqual(result.mismatches, []);
+});
+
+test("replay scenario runner: cursor-dependent scenario fails clearly", async () => {
+  const result = await runReplayScenario({
+    scenario: {
+      ...replayScenario,
+      expectedCursorState: Object.freeze({
+        visible: true,
+        x: 1,
+        y: 2,
+        shape: 2,
+        blink: true,
+      }),
+    },
+    createFixture: createReplayFixture,
+  });
+  assert.equal(result.pass, false);
+  assert.equal(result.mismatches.some((item) => item.code === "ZR_SCENARIO_UNSUPPORTED"), true);
+});
+
+test("evaluateScenarioResult: cursor assertions compare final cursor snapshots", () => {
+  const { expectedActions: _expectedActions, ...cursorScenarioBase } = replayScenario;
+  const result = evaluateScenarioResult(
+    {
+      ...cursorScenarioBase,
+      expectedScreenCheckpoints: Object.freeze([]),
+      invariants: Object.freeze([]),
+      expectedCursorState: Object.freeze({
+        visible: true,
+        x: 2,
+        y: 1,
+        shape: 2,
+        blink: true,
+      }),
+    },
+    {
+      mode: "semantic",
+      actions: Object.freeze([]),
+      steps: Object.freeze([]),
+      finalScreen: Object.freeze({
+        cols: 32,
+        rows: 8,
+        lines: Object.freeze(Array.from({ length: 8 }, () => "".padEnd(32, " "))),
+      }),
+      finalCursor: Object.freeze({
+        visible: true,
+        x: 2,
+        y: 1,
+        shape: 2,
+        blink: true,
+      }),
+    },
+  );
+  assert.equal(result.pass, true);
+  assert.deepEqual(result.mismatches, []);
+});

--- a/packages/core/src/testing/assertions.ts
+++ b/packages/core/src/testing/assertions.ts
@@ -1,0 +1,215 @@
+import type { RoutedAction } from "../runtime/router/types.js";
+import type {
+  ScenarioCursorAssertion,
+  ScenarioCursorSnapshot,
+  ScenarioDefinition,
+  ScenarioInvariantAssertion,
+  ScenarioMismatch,
+  ScenarioRunResult,
+  ScenarioScreenRegionAssertion,
+  ScenarioScreenSnapshot,
+} from "./scenario.js";
+
+function isObjectRecord(value: unknown): value is Record<string, unknown> {
+  return typeof value === "object" && value !== null && !Array.isArray(value);
+}
+
+function matchesSubset(actual: unknown, expected: unknown): boolean {
+  if (expected === undefined) return true;
+  if (Array.isArray(expected)) {
+    if (!Array.isArray(actual) || actual.length !== expected.length) return false;
+    for (let i = 0; i < expected.length; i++) {
+      if (!matchesSubset(actual[i], expected[i])) return false;
+    }
+    return true;
+  }
+  if (isObjectRecord(expected)) {
+    if (!isObjectRecord(actual)) return false;
+    for (const [key, value] of Object.entries(expected)) {
+      if (!matchesSubset(actual[key], value)) return false;
+    }
+    return true;
+  }
+  return Object.is(actual, expected);
+}
+
+function actionPayload(action: RoutedAction): Readonly<Record<string, unknown>> {
+  const payload: Record<string, unknown> = {};
+  for (const [key, value] of Object.entries(action)) {
+    if (key === "id" || key === "action") continue;
+    payload[key] = value;
+  }
+  return payload;
+}
+
+function actionEquals(expected: RoutedAction, actual: RoutedAction): boolean {
+  if (expected.id !== actual.id || expected.action !== actual.action) return false;
+  return matchesSubset(actionPayload(actual), actionPayload(expected));
+}
+
+export function assertScenarioActions(
+  actual: readonly RoutedAction[],
+  expected: readonly RoutedAction[] | undefined,
+): readonly ScenarioMismatch[] {
+  if (expected === undefined) return Object.freeze([]);
+  const mismatches: ScenarioMismatch[] = [];
+  if (actual.length !== expected.length) {
+    mismatches.push({
+      code: "ZR_SCENARIO_ACTION_COUNT_MISMATCH",
+      path: "expectedActions",
+      detail: `Expected ${String(expected.length)} actions, observed ${String(actual.length)}`,
+      expected: expected.length,
+      actual: actual.length,
+    });
+  }
+  const max = Math.max(actual.length, expected.length);
+  for (let index = 0; index < max; index++) {
+    const want = expected[index];
+    const got = actual[index];
+    if (want === undefined || got === undefined) continue;
+    if (actionEquals(want, got)) continue;
+    mismatches.push({
+      code: "ZR_SCENARIO_ACTION_MISMATCH",
+      path: `expectedActions[${String(index)}]`,
+      detail: `Observed action does not match expected action at index ${String(index)}`,
+      expected: want,
+      actual: got,
+    });
+  }
+  return Object.freeze(mismatches);
+}
+
+export function assertScreenRegion(
+  screen: ScenarioScreenSnapshot,
+  args: ScenarioScreenRegionAssertion,
+  path: string,
+): ScenarioMismatch | null {
+  const expectedSource = typeof args.text === "string" ? args.text.split("\n") : [...args.text];
+  const expectedLines = expectedSource.map((line: string) => line.padEnd(args.width, " ").slice(0, args.width));
+  const actualLines: string[] = [];
+  for (let row = 0; row < args.height; row++) {
+    const line = screen.lines[args.y + row] ?? "".padEnd(screen.cols, " ");
+    actualLines.push(line.slice(args.x, args.x + args.width).padEnd(args.width, " "));
+  }
+  const matchMode = args.match ?? "exact";
+  const passed =
+    matchMode === "includes"
+      ? expectedLines.every((line: string, index: number) =>
+          (actualLines[index] ?? "").includes(line.trimEnd()),
+        )
+      : expectedLines.length === actualLines.length &&
+        expectedLines.every((line: string, index: number) => line === (actualLines[index] ?? ""));
+  if (passed) return null;
+  return {
+    code: "ZR_SCENARIO_SCREEN_MISMATCH",
+    path,
+    detail: `Screen region assertion failed (${matchMode})`,
+    expected: expectedLines,
+    actual: actualLines,
+  };
+}
+
+export function assertCursor(
+  actual: ScenarioCursorSnapshot | null,
+  expected: ScenarioCursorAssertion | undefined,
+): ScenarioMismatch | null {
+  if (expected === undefined) return null;
+  if (actual === null) {
+    return {
+      code: "ZR_SCENARIO_CURSOR_MISMATCH",
+      path: "expectedCursorState",
+      detail: "Expected cursor snapshot but none was captured",
+      expected,
+      actual: null,
+    };
+  }
+  if (
+    actual.visible !== expected.visible ||
+    actual.shape !== expected.shape ||
+    actual.blink !== expected.blink
+  ) {
+    return {
+      code: "ZR_SCENARIO_CURSOR_MISMATCH",
+      path: "expectedCursorState",
+      detail: "Cursor visibility or styling did not match expected state",
+      expected,
+      actual,
+    };
+  }
+  if (expected.visible && actual.visible && (actual.x !== expected.x || actual.y !== expected.y)) {
+    return {
+      code: "ZR_SCENARIO_CURSOR_MISMATCH",
+      path: "expectedCursorState",
+      detail: "Cursor position did not match expected state",
+      expected,
+      actual,
+    };
+  }
+  return null;
+}
+
+function assertInvariant(
+  actual: readonly RoutedAction[],
+  invariant: ScenarioInvariantAssertion,
+  path: string,
+): ScenarioMismatch | null {
+  if (invariant.kind === "action_absence") {
+    const found = actual.find((action) => {
+      if (invariant.action.id !== undefined && action.id !== invariant.action.id) return false;
+      if (invariant.action.action !== undefined && action.action !== invariant.action.action) {
+        return false;
+      }
+      return matchesSubset(actionPayload(action), invariant.action.payloadSubset);
+    });
+    if (found === undefined) return null;
+    return {
+      code: "ZR_SCENARIO_INVARIANT_MISMATCH",
+      path,
+      detail: "Invariant failed: forbidden action was observed",
+      expected: invariant,
+      actual: found,
+    };
+  }
+  return {
+    code: "ZR_SCENARIO_UNSUPPORTED",
+    path,
+    detail: `Unsupported invariant kind ${String((invariant as { kind: string }).kind)}`,
+  };
+}
+
+export function evaluateScenarioResult(
+  scenario: ScenarioDefinition,
+  partial: Omit<ScenarioRunResult, "status" | "pass" | "mismatches">,
+): ScenarioRunResult {
+  const mismatches: ScenarioMismatch[] = [];
+  mismatches.push(...assertScenarioActions(partial.actions, scenario.expectedActions));
+  for (const checkpoint of scenario.expectedScreenCheckpoints) {
+    const step = partial.steps.find((item) => item.step === checkpoint.afterStep);
+    if (!step) {
+      mismatches.push({
+        code: "ZR_SCENARIO_SCREEN_MISMATCH",
+        path: `expectedScreenCheckpoints.${checkpoint.id}`,
+        detail: `No observation was captured for step ${String(checkpoint.afterStep)}`,
+      });
+      continue;
+    }
+    const mismatch = assertScreenRegion(
+      step.screen,
+      checkpoint.args,
+      `expectedScreenCheckpoints.${checkpoint.id}`,
+    );
+    if (mismatch) mismatches.push(mismatch);
+  }
+  const cursorMismatch = assertCursor(partial.finalCursor, scenario.expectedCursorState);
+  if (cursorMismatch) mismatches.push(cursorMismatch);
+  for (const invariant of scenario.invariants) {
+    const mismatch = assertInvariant(partial.actions, invariant.args, `invariants.${invariant.id}`);
+    if (mismatch) mismatches.push(mismatch);
+  }
+  return Object.freeze({
+    ...partial,
+    status: mismatches.length === 0 ? "PASS" : "FAIL",
+    pass: mismatches.length === 0,
+    mismatches: Object.freeze(mismatches),
+  });
+}

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -24,3 +24,36 @@ export type {
   TestRendererOptions,
   TestViewport,
 } from "./renderer.js";
+
+export { runSemanticScenario } from "./semanticScenario.js";
+export { runReplayScenario } from "./replayScenario.js";
+export {
+  createScenarioScreenSnapshot,
+  validateScenarioDefinition,
+  type ScenarioCapabilityProfile,
+  type ScenarioCursorAssertion,
+  type ScenarioCursorSnapshot,
+  type ScenarioDefinition,
+  type ScenarioExpectedAction,
+  type ScenarioFixture,
+  type ScenarioFixtureFactory,
+  type ScenarioInvariant,
+  type ScenarioInvariantAssertion,
+  type ScenarioKeyMod,
+  type ScenarioMismatch,
+  type ScenarioMismatchCode,
+  type ScenarioRunResult,
+  type ScenarioScreenCheckpoint,
+  type ScenarioScreenRegionAssertion,
+  type ScenarioScreenSnapshot,
+  type ScenarioScriptedInputEvent,
+  type ScenarioScriptedInputStep,
+  type ScenarioStepObservation,
+  type ScenarioTheme,
+  type ScenarioWidgetFamily,
+} from "./scenario.js";
+export { evaluateScenarioResult } from "./assertions.js";
+export {
+  referenceInputModalScenario,
+  createReferenceInputModalFixture,
+} from "./referenceScenarios/inputModalBlocking.js";

--- a/packages/core/src/testing/referenceScenarios/inputModalBlocking.ts
+++ b/packages/core/src/testing/referenceScenarios/inputModalBlocking.ts
@@ -1,0 +1,178 @@
+import type { App } from "../../app/types.js";
+import { ui } from "../../index.js";
+import type { ScenarioDefinition, ScenarioFixtureFactory } from "../scenario.js";
+
+type InputModalScenarioState = Readonly<{
+  value: string;
+  modalOpen: boolean;
+}>;
+
+export const referenceInputModalScenario: ScenarioDefinition = Object.freeze({
+  schemaVersion: 1,
+  id: "input-modal-blocking-focus-restore",
+  title: "Input editing pauses behind modal and resumes after close",
+  widgetFamily: "input-textarea",
+  behaviorStatement:
+    "A focused input accepts edits, an opened modal blocks background typing, and closing the modal restores focus so typing resumes immediately.",
+  evidenceRefs: Object.freeze([
+    "docs/widgets/input.md",
+    "docs/widgets/modal.md",
+    "docs/guide/input-and-focus.md",
+    "packages/core/src/runtime/__tests__/inputEditor.contract.test.ts",
+    "packages/core/src/runtime/__tests__/focus.layers.test.ts",
+    "packages/core/src/widgets/__tests__/modal.focus.test.ts",
+  ]),
+  viewport: Object.freeze({ cols: 48, rows: 14 }),
+  theme: Object.freeze({ mode: "named", value: "default" }),
+  capabilityProfile: Object.freeze({
+    supportsMouse: false,
+    supportsBracketedPaste: false,
+    supportsFocusEvents: false,
+    supportsOsc52: false,
+    colorMode: "none",
+  }),
+  scriptedInput: Object.freeze([
+    Object.freeze({ atMs: 0, event: Object.freeze({ kind: "text", text: "a" }) }),
+    Object.freeze({ atMs: 1, event: Object.freeze({ kind: "key", key: "o", mods: Object.freeze(["ctrl"] as const) }) }),
+    Object.freeze({ atMs: 2, event: Object.freeze({ kind: "text", text: "b" }) }),
+    Object.freeze({ atMs: 3, event: Object.freeze({ kind: "key", key: "enter" }) }),
+    Object.freeze({ atMs: 4, event: Object.freeze({ kind: "text", text: "c" }) }),
+  ]),
+  expectedActions: Object.freeze([
+    Object.freeze({ id: "field", action: "input", value: "a", cursor: 1 }),
+    Object.freeze({ id: "modal-close", action: "press" }),
+    Object.freeze({ id: "field", action: "input", value: "ac", cursor: 2 }),
+  ]),
+  expectedScreenCheckpoints: Object.freeze([
+    Object.freeze({
+      id: "value-after-first-edit",
+      afterStep: 1,
+      assertionRef: "screen_region_assertion",
+      args: Object.freeze({
+        x: 0,
+        y: 0,
+        width: 48,
+        height: 4,
+        match: "exact",
+        text: Object.freeze([
+          "                                                ",
+          " Reference scenario                             ",
+          "                                                ",
+          " Value:a                                        ",
+        ]),
+      }),
+    }),
+    Object.freeze({
+      id: "modal-visible",
+      afterStep: 2,
+      assertionRef: "screen_region_assertion",
+      args: Object.freeze({
+        x: 0,
+        y: 3,
+        width: 48,
+        height: 6,
+        match: "exact",
+        text: Object.freeze([
+          "░░░░░░░┌─Pause editing─────────────────┐░░░░░░░░",
+          "░░░░░░░│░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│░░░░░░░░",
+          "░░░░░░░│Modal blocks background typing░│░░░░░░░░",
+          "░░░░░░░│░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│░░░░░░░░",
+          "░░░░░░░│░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│░░░░░░░░",
+          "░░░░░░░│░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░░│░░░░░░░░",
+        ]),
+      }),
+    }),
+    Object.freeze({
+      id: "value-after-resume",
+      afterStep: 5,
+      assertionRef: "screen_region_assertion",
+      args: Object.freeze({
+        x: 0,
+        y: 0,
+        width: 48,
+        height: 4,
+        match: "exact",
+        text: Object.freeze([
+          "                                                ",
+          " Reference scenario                             ",
+          "                                                ",
+          " Value:ac                                       ",
+        ]),
+      }),
+    }),
+  ]),
+  invariants: Object.freeze([
+    Object.freeze({
+      id: "no-blocked-input-leak",
+      assertionRef: "invariant_assertion",
+      args: Object.freeze({
+        kind: "action_absence",
+        action: Object.freeze({
+          id: "field",
+          action: "input",
+          payloadSubset: Object.freeze({ value: "ab" }),
+        }),
+      }),
+    }),
+  ]),
+  fidelityRequirement: "terminal-real",
+  notes:
+    "Uses a keyboard shortcut to open the modal so the scenario can prove blocking and focus restore without depending on select/dropdown or OSC52 fallback behavior.",
+  unresolvedAssumptions: Object.freeze([
+    "MVP uses a minimal typed key/text alias layer for scriptedInput.event instead of strict low-level event objects.",
+  ]),
+});
+
+export const createReferenceInputModalFixture: ScenarioFixtureFactory<InputModalScenarioState> = () => {
+  let app!: App<InputModalScenarioState>;
+  return Object.freeze({
+    initialState: Object.freeze({ value: "", modalOpen: false }),
+    setup(nextApp) {
+      app = nextApp;
+      app.keys({
+        "ctrl+o": () => {
+          app.update((state) => (state.modalOpen ? state : { ...state, modalOpen: true }));
+        },
+      });
+    },
+    view(state) {
+      const baseContent = ui.column({ p: 1, gap: 1 }, [
+        ui.text("Reference scenario"),
+        ui.text(`Value:${state.value}`),
+        ui.input({
+          id: "field",
+          value: state.value,
+          onInput: (value) => {
+            app.update((current) => ({ ...current, value }));
+          },
+        }),
+        ui.text("Ctrl+O opens modal"),
+      ]);
+      const base = ui.focusTrap({ id: "root-trap", active: true, initialFocus: "field" }, [
+        baseContent,
+      ]);
+      if (!state.modalOpen) return base;
+      return ui.layers([
+        base,
+        ui.modal({
+          id: "pause-modal",
+          title: "Pause editing",
+          initialFocus: "modal-close",
+          returnFocusTo: "field",
+          closeOnEscape: false,
+          closeOnBackdrop: false,
+          content: ui.text("Modal blocks background typing"),
+          actions: [
+            ui.button({
+              id: "modal-close",
+              label: "Resume",
+              onPress: () => {
+                app.update((current) => ({ ...current, modalOpen: false }));
+              },
+            }),
+          ],
+        }),
+      ]);
+    },
+  });
+};

--- a/packages/core/src/testing/replayScenario.ts
+++ b/packages/core/src/testing/replayScenario.ts
@@ -1,0 +1,328 @@
+import { runReproReplayHarness, type ReproBundle, type ReproReplayExpectedAction } from "../repro/index.js";
+import { DEFAULT_TERMINAL_CAPS, type TerminalCaps } from "../terminalCaps.js";
+import { defaultTheme } from "../theme/defaultTheme.js";
+import { compileTheme } from "../theme/theme.js";
+import { createTestRenderer } from "./renderer.js";
+import {
+  createScenarioScreenSnapshot,
+  type ScenarioCapabilityProfile,
+  type ScenarioDefinition,
+  type ScenarioExpectedAction,
+  type ScenarioFixtureFactory,
+  type ScenarioMismatch,
+  type ScenarioRunResult,
+  type ScenarioScriptedInputEvent,
+  type ScenarioStepObservation,
+} from "./scenario.js";
+import { evaluateScenarioResult } from "./assertions.js";
+import { encodeZrevBatchV1, type TestZrevEvent } from "./events.js";
+import {
+  ZR_KEY_BACKSPACE,
+  ZR_KEY_DELETE,
+  ZR_KEY_DOWN,
+  ZR_KEY_END,
+  ZR_KEY_ENTER,
+  ZR_KEY_ESCAPE,
+  ZR_KEY_HOME,
+  ZR_KEY_LEFT,
+  ZR_KEY_PAGE_DOWN,
+  ZR_KEY_PAGE_UP,
+  ZR_KEY_RIGHT,
+  ZR_KEY_SPACE,
+  ZR_KEY_TAB,
+  ZR_KEY_UP,
+  charToKeyCode,
+  ZR_MOD_ALT,
+  ZR_MOD_CTRL,
+  ZR_MOD_META,
+  ZR_MOD_SHIFT,
+} from "../keybindings/keyCodes.js";
+
+function colorModeToCapsColor(mode: ScenarioCapabilityProfile["colorMode"]): TerminalCaps["colorMode"] {
+  if (mode === "16") return 1;
+  if (mode === "256") return 2;
+  if (mode === "truecolor") return 3;
+  return 0;
+}
+
+function toTerminalCaps(profile: ScenarioCapabilityProfile): TerminalCaps {
+  return Object.freeze({
+    ...DEFAULT_TERMINAL_CAPS,
+    colorMode: colorModeToCapsColor(profile.colorMode),
+    supportsMouse: profile.supportsMouse,
+    supportsBracketedPaste: profile.supportsBracketedPaste,
+    supportsFocusEvents: profile.supportsFocusEvents,
+    supportsOsc52: profile.supportsOsc52,
+    supportsCursorShape: true,
+  });
+}
+
+function keyNameToCode(key: string | number): number {
+  if (typeof key === "number") return key;
+  const normalized = key.trim().toLowerCase();
+  if (normalized.length === 1) return charToKeyCode(normalized) ?? 0;
+  switch (normalized) {
+    case "enter":
+    case "return":
+      return ZR_KEY_ENTER;
+    case "escape":
+    case "esc":
+      return ZR_KEY_ESCAPE;
+    case "tab":
+      return ZR_KEY_TAB;
+    case "space":
+      return ZR_KEY_SPACE;
+    case "backspace":
+      return ZR_KEY_BACKSPACE;
+    case "delete":
+    case "del":
+      return ZR_KEY_DELETE;
+    case "home":
+      return ZR_KEY_HOME;
+    case "end":
+      return ZR_KEY_END;
+    case "pageup":
+      return ZR_KEY_PAGE_UP;
+    case "pagedown":
+      return ZR_KEY_PAGE_DOWN;
+    case "left":
+      return ZR_KEY_LEFT;
+    case "right":
+      return ZR_KEY_RIGHT;
+    case "up":
+      return ZR_KEY_UP;
+    case "down":
+      return ZR_KEY_DOWN;
+    default:
+      throw new Error(`Unsupported replay scenario key ${JSON.stringify(key)}`);
+  }
+}
+
+function keyModsToMask(mods: readonly string[] | undefined): number {
+  let mask = 0;
+  for (const mod of mods ?? []) {
+    if (mod === "shift") mask |= ZR_MOD_SHIFT;
+    else if (mod === "ctrl") mask |= ZR_MOD_CTRL;
+    else if (mod === "alt") mask |= ZR_MOD_ALT;
+    else if (mod === "meta") mask |= ZR_MOD_META;
+  }
+  return mask;
+}
+
+function eventToZrevEvents(event: ScenarioScriptedInputEvent): readonly TestZrevEvent[] {
+  switch (event.kind) {
+    case "text":
+      return Object.freeze(
+        Array.from(event.text).map((glyph) => ({
+          kind: "text" as const,
+          timeMs: 1,
+          codepoint: glyph.codePointAt(0) ?? 0,
+        })),
+      );
+    case "paste":
+      return Object.freeze([
+        {
+          kind: "paste" as const,
+          timeMs: 1,
+          bytes: new TextEncoder().encode(event.text),
+        },
+      ]);
+    case "resize":
+      return Object.freeze([
+        {
+          kind: "resize" as const,
+          timeMs: 1,
+          cols: event.cols,
+          rows: event.rows,
+        },
+      ]);
+    case "key":
+      return Object.freeze([
+        {
+          kind: "key" as const,
+          timeMs: 1,
+          key: keyNameToCode(event.key),
+          mods: keyModsToMask(event.mods),
+          action: "down",
+        },
+      ]);
+  }
+}
+
+function bytesToHex(bytes: Uint8Array): string {
+  let out = "";
+  for (const byte of bytes) out += byte.toString(16).padStart(2, "0");
+  return out;
+}
+
+function resizeEventsFrom(event: ScenarioScriptedInputEvent): readonly Readonly<{
+  eventIndex: number;
+  cols: number;
+  rows: number;
+  timeMs: number;
+}>[] {
+  if (event.kind !== "resize") return Object.freeze([]);
+  return Object.freeze([
+    Object.freeze({ eventIndex: 0, cols: event.cols, rows: event.rows, timeMs: 1 }),
+  ]);
+}
+
+function toReplayExpectedActions(
+  expected: readonly ScenarioExpectedAction[] | undefined,
+): readonly ReproReplayExpectedAction[] {
+  const out: ReproReplayExpectedAction[] = [];
+  for (const action of expected ?? []) {
+    if (action.action === "press") {
+      out.push(Object.freeze({ id: action.id, action: "press" }));
+      continue;
+    }
+    if (action.action === "input") {
+      out.push(
+        Object.freeze({
+          id: action.id,
+          action: "input",
+          value: action.value,
+          cursor: action.cursor,
+        }),
+      );
+      continue;
+    }
+    throw new Error(`Replay MVP supports only press/input expectedActions (got ${action.action})`);
+  }
+  return Object.freeze(out);
+}
+
+function createReplayBundle(scenario: ScenarioDefinition): ReproBundle {
+  const batches = scenario.scriptedInput.map((step, index) => {
+    const encodedEvents = eventToZrevEvents(step.event);
+    const bytes = encodeZrevBatchV1({ events: encodedEvents });
+    return Object.freeze({
+      step: index + 1,
+      deltaMs: step.atMs,
+      byteLength: bytes.byteLength,
+      bytesHex: bytesToHex(bytes),
+      eventCount: encodedEvents.length,
+      droppedBatches: 0,
+      resizeEvents: resizeEventsFrom(step.event),
+    });
+  });
+  return Object.freeze({
+    schema: "rezi-repro-v1",
+    captureConfig: Object.freeze({
+      captureRawEvents: true,
+      captureDrawlistBytes: false,
+      maxEventBytes: 1 << 20,
+      maxDrawlistBytes: 0,
+      maxFrames: 1024,
+      fpsCap: 60,
+      cursorProtocolVersion: 2,
+    }),
+    capsSnapshot: Object.freeze({
+      terminalCaps: toTerminalCaps(scenario.capabilityProfile),
+      backendCaps: Object.freeze({
+        maxEventBytes: 1 << 20,
+        fpsCap: 60,
+        cursorProtocolVersion: 2,
+      }),
+    }),
+    timingModel: Object.freeze({
+      kind: "deterministic",
+      clock: "monotonic-ms",
+      replayStrategy: "recorded-delta",
+      timeUnit: "ms",
+      baseTimeMs: 0,
+    }),
+    eventCapture: Object.freeze({
+      ordering: "poll-order",
+      timing: "step-delta-ms",
+      bounds: Object.freeze({
+        maxBatches: Math.max(1, batches.length),
+        maxEvents: Math.max(1, batches.reduce((sum, item) => sum + item.eventCount, 0)),
+        maxBytes: Math.max(1, batches.reduce((sum, item) => sum + item.byteLength, 0)),
+      }),
+      totals: Object.freeze({
+        capturedBatches: batches.length,
+        capturedEvents: batches.reduce((sum, item) => sum + item.eventCount, 0),
+        capturedBytes: batches.reduce((sum, item) => sum + item.byteLength, 0),
+        runtimeDroppedBatches: 0,
+        omittedBatches: 0,
+        omittedEvents: 0,
+        omittedBytes: 0,
+      }),
+      truncation: Object.freeze({
+        mode: "drop-tail-batch",
+        truncated: false,
+        reason: null,
+        firstOmittedStep: null,
+      }),
+      batches: Object.freeze(batches),
+    }),
+  });
+}
+
+export async function runReplayScenario<S>(opts: Readonly<{
+  scenario: ScenarioDefinition;
+  createFixture: ScenarioFixtureFactory<S>;
+}>): Promise<ScenarioRunResult> {
+  const fixture = opts.createFixture();
+  const renderer = createTestRenderer({
+    viewport: opts.scenario.viewport,
+    theme: fixture.theme ?? defaultTheme.definition,
+  });
+  const staticText = renderer.render(fixture.view(fixture.initialState), {
+    viewport: opts.scenario.viewport,
+    theme: fixture.theme ?? defaultTheme.definition,
+    focusedId: null,
+  }).toText();
+  const staticScreen = createScenarioScreenSnapshot(opts.scenario.viewport, staticText);
+  const steps: ScenarioStepObservation[] = opts.scenario.scriptedInput.map((_, index) =>
+    Object.freeze({
+      step: index + 1,
+      screen: staticScreen,
+      cursor: null,
+      actions: Object.freeze([]),
+    }),
+  );
+
+  const replayResult = await runReproReplayHarness({
+    bundle: createReplayBundle(opts.scenario),
+    view: () => fixture.view(fixture.initialState),
+    initialViewport: opts.scenario.viewport,
+    theme: compileTheme(fixture.theme ?? defaultTheme.definition),
+    expectedActions: toReplayExpectedActions(opts.scenario.expectedActions),
+    invariants: { noFatal: true, noOverrun: true },
+  });
+
+  const result = evaluateScenarioResult(opts.scenario, {
+    mode: "replay",
+    actions: Object.freeze(
+      replayResult.replay.actions.map((action) => {
+        if (action.action === "input") {
+          return Object.freeze({
+            id: action.id,
+            action: "input" as const,
+            value: action.value,
+            cursor: action.cursor,
+          });
+        }
+        return Object.freeze({ id: action.id, action: "press" as const });
+      }),
+    ),
+    steps: Object.freeze(steps),
+    finalScreen: staticScreen,
+    finalCursor: null,
+  });
+
+  if (opts.scenario.expectedCursorState === undefined) return result;
+  const mismatch: ScenarioMismatch = Object.freeze({
+    code: "ZR_SCENARIO_UNSUPPORTED",
+    path: "expectedCursorState",
+    detail: "Replay MVP does not capture live cursor state; use semantic or PTY mode for cursor-dependent scenarios",
+  });
+  return Object.freeze({
+    ...result,
+    status: "FAIL",
+    pass: false,
+    mismatches: Object.freeze([...result.mismatches, mismatch]),
+  });
+}

--- a/packages/core/src/testing/scenario.ts
+++ b/packages/core/src/testing/scenario.ts
@@ -1,0 +1,215 @@
+import type { App } from "../app/types.js";
+import type { CursorShape } from "../abi.js";
+import type { RoutedAction } from "../runtime/router/types.js";
+import type { ThemeDefinition } from "../theme/tokens.js";
+import type { VNode } from "../widgets/types.js";
+
+export type ScenarioWidgetFamily =
+  | "input-textarea"
+  | "select-dropdown"
+  | "modal-overlay-dialog"
+  | "table-tree-virtual-list";
+
+export type ScenarioColorMode = "none" | "16" | "256" | "truecolor";
+export type ScenarioTheme = Readonly<{ mode: "named"; value: "default" }>;
+export type ScenarioKeyMod = "shift" | "ctrl" | "alt" | "meta";
+
+export type ScenarioCapabilityProfile = Readonly<{
+  supportsMouse: boolean;
+  supportsBracketedPaste: boolean;
+  supportsFocusEvents: boolean;
+  supportsOsc52: boolean;
+  colorMode: ScenarioColorMode;
+}>;
+
+export type ScenarioScriptedInputEvent =
+  | Readonly<{ kind: "text"; text: string }>
+  | Readonly<{ kind: "paste"; text: string }>
+  | Readonly<{ kind: "resize"; cols: number; rows: number }>
+  | Readonly<{ kind: "key"; key: string | number; mods?: readonly ScenarioKeyMod[] }>;
+
+export type ScenarioScriptedInputStep = Readonly<{
+  atMs: number;
+  event: ScenarioScriptedInputEvent;
+}>;
+
+export type ScenarioExpectedAction = RoutedAction;
+
+export type ScenarioScreenRegionAssertion = Readonly<{
+  x: number;
+  y: number;
+  width: number;
+  height: number;
+  match?: "exact" | "includes";
+  text: string | readonly string[];
+}>;
+
+export type ScenarioCursorAssertion =
+  | Readonly<{
+      visible: false;
+      shape: CursorShape;
+      blink: boolean;
+    }>
+  | Readonly<{
+      visible: true;
+      x: number;
+      y: number;
+      shape: CursorShape;
+      blink: boolean;
+    }>;
+
+export type ScenarioInvariantAssertion = Readonly<{
+  kind: "action_absence";
+  action: Readonly<{
+    id?: string;
+    action?: RoutedAction["action"];
+    payloadSubset?: Readonly<Record<string, unknown>>;
+  }>;
+}>;
+
+export type ScenarioScreenCheckpoint = Readonly<{
+  id: string;
+  afterStep: number;
+  assertionRef: "screen_region_assertion";
+  args: ScenarioScreenRegionAssertion;
+}>;
+
+export type ScenarioInvariant = Readonly<{
+  id: string;
+  assertionRef: "invariant_assertion";
+  args: ScenarioInvariantAssertion;
+}>;
+
+export type ScenarioDefinition = Readonly<{
+  schemaVersion: 1;
+  id: string;
+  title: string;
+  widgetFamily: ScenarioWidgetFamily;
+  behaviorStatement: string;
+  evidenceRefs: readonly string[];
+  viewport: Readonly<{ cols: number; rows: number }>;
+  theme: ScenarioTheme;
+  capabilityProfile: ScenarioCapabilityProfile;
+  scriptedInput: readonly ScenarioScriptedInputStep[];
+  expectedActions?: readonly ScenarioExpectedAction[];
+  expectedScreenCheckpoints: readonly ScenarioScreenCheckpoint[];
+  expectedCursorState?: ScenarioCursorAssertion;
+  invariants: readonly ScenarioInvariant[];
+  fidelityRequirement: "semantic-only" | "terminal-real";
+  notes?: string;
+  unresolvedAssumptions?: readonly string[];
+}>;
+
+export type ScenarioScreenSnapshot = Readonly<{
+  cols: number;
+  rows: number;
+  lines: readonly string[];
+}>;
+
+export type ScenarioCursorSnapshot = ScenarioCursorAssertion;
+
+export type ScenarioStepObservation = Readonly<{
+  step: number;
+  screen: ScenarioScreenSnapshot;
+  cursor: ScenarioCursorSnapshot | null;
+  actions: readonly ScenarioExpectedAction[];
+}>;
+
+export type ScenarioMismatchCode =
+  | "ZR_SCENARIO_INVALID"
+  | "ZR_SCENARIO_UNSUPPORTED"
+  | "ZR_SCENARIO_ACTION_COUNT_MISMATCH"
+  | "ZR_SCENARIO_ACTION_MISMATCH"
+  | "ZR_SCENARIO_SCREEN_MISMATCH"
+  | "ZR_SCENARIO_CURSOR_MISMATCH"
+  | "ZR_SCENARIO_INVARIANT_MISMATCH"
+  | "ZR_SCENARIO_RUNTIME_FATAL";
+
+export type ScenarioMismatch = Readonly<{
+  code: ScenarioMismatchCode;
+  path: string;
+  detail: string;
+  expected?: unknown;
+  actual?: unknown;
+}>;
+
+export type ScenarioRunResult = Readonly<{
+  mode: "semantic" | "replay" | "pty";
+  status: "PASS" | "FAIL";
+  pass: boolean;
+  actions: readonly ScenarioExpectedAction[];
+  steps: readonly ScenarioStepObservation[];
+  finalScreen: ScenarioScreenSnapshot;
+  finalCursor: ScenarioCursorSnapshot | null;
+  mismatches: readonly ScenarioMismatch[];
+}>;
+
+export type ScenarioFixture<S> = Readonly<{
+  initialState: S;
+  theme?: ThemeDefinition;
+  setup?: (app: App<S>) => void;
+  view: (state: S) => VNode;
+}>;
+
+export type ScenarioFixtureFactory<S> = () => ScenarioFixture<S>;
+
+export function createScenarioScreenSnapshot(
+  viewport: Readonly<{ cols: number; rows: number }>,
+  text: string,
+): ScenarioScreenSnapshot {
+  const rawLines = text.split("\n");
+  const lines: string[] = [];
+  for (let row = 0; row < viewport.rows; row++) {
+    const raw = rawLines[row] ?? "";
+    lines.push(raw.padEnd(viewport.cols, " ").slice(0, viewport.cols));
+  }
+  return Object.freeze({
+    cols: viewport.cols,
+    rows: viewport.rows,
+    lines: Object.freeze(lines),
+  });
+}
+
+export function validateScenarioDefinition(scenario: ScenarioDefinition): readonly ScenarioMismatch[] {
+  const mismatches: ScenarioMismatch[] = [];
+  if (scenario.schemaVersion !== 1) {
+    mismatches.push({
+      code: "ZR_SCENARIO_INVALID",
+      path: "schemaVersion",
+      detail: `Expected schemaVersion=1 (got ${String(scenario.schemaVersion)})`,
+      expected: 1,
+      actual: scenario.schemaVersion,
+    });
+  }
+  if (scenario.evidenceRefs.length === 0) {
+    mismatches.push({
+      code: "ZR_SCENARIO_INVALID",
+      path: "evidenceRefs",
+      detail: "Scenario must include at least one evidenceRef",
+    });
+  }
+  if (scenario.expectedScreenCheckpoints.length === 0) {
+    mismatches.push({
+      code: "ZR_SCENARIO_INVALID",
+      path: "expectedScreenCheckpoints",
+      detail: "Scenario must include at least one screen checkpoint",
+    });
+  }
+  if (scenario.invariants.length === 0) {
+    mismatches.push({
+      code: "ZR_SCENARIO_INVALID",
+      path: "invariants",
+      detail: "Scenario must include at least one invariant",
+    });
+  }
+  if (scenario.theme.mode !== "named" || scenario.theme.value !== "default") {
+    mismatches.push({
+      code: "ZR_SCENARIO_UNSUPPORTED",
+      path: "theme",
+      detail: `Only theme { mode: \"named\", value: \"default\" } is supported in this MVP`,
+      expected: { mode: "named", value: "default" },
+      actual: scenario.theme,
+    });
+  }
+  return Object.freeze(mismatches);
+}

--- a/packages/core/src/testing/semanticScenario.ts
+++ b/packages/core/src/testing/semanticScenario.ts
@@ -1,0 +1,357 @@
+import { createApp } from "../app/createApp.js";
+import type { RuntimeBreadcrumbSnapshot } from "../app/runtimeBreadcrumbs.js";
+import type { AppRenderMetrics } from "../app/types.js";
+import type { BackendEventBatch, RuntimeBackend } from "../backend.js";
+import { DEFAULT_TERMINAL_CAPS, type TerminalCaps } from "../terminalCaps.js";
+import { defaultTheme } from "../theme/defaultTheme.js";
+import { createTestRenderer } from "./renderer.js";
+import {
+  createScenarioScreenSnapshot,
+  type ScenarioCapabilityProfile,
+  type ScenarioCursorSnapshot,
+  type ScenarioDefinition,
+  type ScenarioFixtureFactory,
+  type ScenarioRunResult,
+  type ScenarioScriptedInputEvent,
+  type ScenarioStepObservation,
+} from "./scenario.js";
+import { evaluateScenarioResult } from "./assertions.js";
+import { encodeZrevBatchV1, type TestZrevEvent } from "./events.js";
+import {
+  ZR_KEY_BACKSPACE,
+  ZR_KEY_DELETE,
+  ZR_KEY_DOWN,
+  ZR_KEY_END,
+  ZR_KEY_ENTER,
+  ZR_KEY_ESCAPE,
+  ZR_KEY_HOME,
+  ZR_KEY_LEFT,
+  ZR_KEY_PAGE_DOWN,
+  ZR_KEY_PAGE_UP,
+  ZR_KEY_RIGHT,
+  ZR_KEY_SPACE,
+  ZR_KEY_TAB,
+  ZR_KEY_UP,
+  charToKeyCode,
+  ZR_MOD_ALT,
+  ZR_MOD_CTRL,
+  ZR_MOD_META,
+  ZR_MOD_SHIFT,
+} from "../keybindings/keyCodes.js";
+import type { RoutedAction } from "../runtime/router/types.js";
+
+function flushMicrotasks(count = 20): Promise<void> {
+  let promise = Promise.resolve();
+  for (let i = 0; i < count; i++) {
+    promise = promise.then(() => Promise.resolve());
+  }
+  return promise;
+}
+
+function colorModeToCapsColor(mode: ScenarioCapabilityProfile["colorMode"]): TerminalCaps["colorMode"] {
+  if (mode === "16") return 1;
+  if (mode === "256") return 2;
+  if (mode === "truecolor") return 3;
+  return 0;
+}
+
+function toTerminalCaps(profile: ScenarioCapabilityProfile): TerminalCaps {
+  return Object.freeze({
+    ...DEFAULT_TERMINAL_CAPS,
+    colorMode: colorModeToCapsColor(profile.colorMode),
+    supportsMouse: profile.supportsMouse,
+    supportsBracketedPaste: profile.supportsBracketedPaste,
+    supportsFocusEvents: profile.supportsFocusEvents,
+    supportsOsc52: profile.supportsOsc52,
+    supportsCursorShape: true,
+  });
+}
+
+class SemanticHarnessBackend implements RuntimeBackend {
+  readonly #caps: TerminalCaps;
+  readonly #waiters: Array<(batch: BackendEventBatch) => void> = [];
+  readonly #buffered: BackendEventBatch[] = [];
+
+  constructor(caps: TerminalCaps) {
+    this.#caps = caps;
+  }
+
+  start(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  stop(): Promise<void> {
+    return Promise.resolve();
+  }
+
+  dispose(): void {}
+
+  requestFrame(_drawlist: Uint8Array): Promise<void> {
+    return Promise.resolve();
+  }
+
+  pollEvents(): Promise<BackendEventBatch> {
+    const next = this.#buffered.shift();
+    if (next) return Promise.resolve(next);
+    return new Promise<BackendEventBatch>((resolve) => {
+      this.#waiters.push(resolve);
+    });
+  }
+
+  postUserEvent(_tag: number, _payload: Uint8Array): void {}
+
+  getCaps(): Promise<TerminalCaps> {
+    return Promise.resolve(this.#caps);
+  }
+
+  pushBytes(bytes: Uint8Array): void {
+    const batch: BackendEventBatch = {
+      bytes,
+      droppedBatches: 0,
+      release: () => {},
+    };
+    const waiter = this.#waiters.shift();
+    if (waiter) {
+      waiter(batch);
+      return;
+    }
+    this.#buffered.push(batch);
+  }
+}
+
+function keyNameToCode(key: string | number): number {
+  if (typeof key === "number") return key;
+  const normalized = key.trim().toLowerCase();
+  if (normalized.length === 1) return charToKeyCode(normalized) ?? 0;
+  switch (normalized) {
+    case "enter":
+    case "return":
+      return ZR_KEY_ENTER;
+    case "escape":
+    case "esc":
+      return ZR_KEY_ESCAPE;
+    case "tab":
+      return ZR_KEY_TAB;
+    case "space":
+      return ZR_KEY_SPACE;
+    case "backspace":
+      return ZR_KEY_BACKSPACE;
+    case "delete":
+    case "del":
+      return ZR_KEY_DELETE;
+    case "home":
+      return ZR_KEY_HOME;
+    case "end":
+      return ZR_KEY_END;
+    case "pageup":
+      return ZR_KEY_PAGE_UP;
+    case "pagedown":
+      return ZR_KEY_PAGE_DOWN;
+    case "left":
+      return ZR_KEY_LEFT;
+    case "right":
+      return ZR_KEY_RIGHT;
+    case "up":
+      return ZR_KEY_UP;
+    case "down":
+      return ZR_KEY_DOWN;
+    default:
+      throw new Error(`Unsupported semantic scenario key ${JSON.stringify(key)}`);
+  }
+}
+
+function keyModsToMask(mods: readonly string[] | undefined): number {
+  let mask = 0;
+  for (const mod of mods ?? []) {
+    if (mod === "shift") mask |= ZR_MOD_SHIFT;
+    else if (mod === "ctrl") mask |= ZR_MOD_CTRL;
+    else if (mod === "alt") mask |= ZR_MOD_ALT;
+    else if (mod === "meta") mask |= ZR_MOD_META;
+  }
+  return mask;
+}
+
+function eventToZrevEvents(event: ScenarioScriptedInputEvent): readonly TestZrevEvent[] {
+  switch (event.kind) {
+    case "text":
+      return Object.freeze(
+        Array.from(event.text).map((glyph) => ({
+          kind: "text" as const,
+          timeMs: 1,
+          codepoint: glyph.codePointAt(0) ?? 0,
+        })),
+      );
+    case "paste":
+      return Object.freeze([
+        {
+          kind: "paste" as const,
+          timeMs: 1,
+          bytes: new TextEncoder().encode(event.text),
+        },
+      ]);
+    case "resize":
+      return Object.freeze([
+        {
+          kind: "resize" as const,
+          timeMs: 1,
+          cols: event.cols,
+          rows: event.rows,
+        },
+      ]);
+    case "key":
+      return Object.freeze([
+        {
+          kind: "key" as const,
+          timeMs: 1,
+          key: keyNameToCode(event.key),
+          mods: keyModsToMask(event.mods),
+          action: "down",
+        },
+      ]);
+  }
+}
+
+function focusIdFromBreadcrumbs(snapshot: RuntimeBreadcrumbSnapshot | null): string | null {
+  return snapshot === null ? null : snapshot.focus.focusedId;
+}
+
+function asCursorSnapshot(snapshot: RuntimeBreadcrumbSnapshot | null): ScenarioCursorSnapshot | null {
+  if (snapshot === null || snapshot.cursor === null) return null;
+  if (snapshot.cursor.visible) {
+    return Object.freeze({
+      visible: true,
+      x: snapshot.cursor.x,
+      y: snapshot.cursor.y,
+      shape: snapshot.cursor.shape,
+      blink: snapshot.cursor.blink,
+    });
+  }
+  return Object.freeze({
+    visible: false,
+    shape: snapshot.cursor.shape,
+    blink: snapshot.cursor.blink,
+  });
+}
+
+export async function runSemanticScenario<S>(opts: Readonly<{
+  scenario: ScenarioDefinition;
+  createFixture: ScenarioFixtureFactory<S>;
+}>): Promise<ScenarioRunResult> {
+  const fixture = opts.createFixture();
+  const backend = new SemanticHarnessBackend(toTerminalCaps(opts.scenario.capabilityProfile));
+  let latestState = fixture.initialState;
+  let latestBreadcrumbs: RuntimeBreadcrumbSnapshot | null = null;
+  const actions: RoutedAction[] = [];
+  const fatal: Array<Readonly<{ code: string; detail: string }>> = [];
+  const runtimeApp = createApp<S>({
+    backend,
+    initialState: fixture.initialState,
+    config: {
+      internal_onRender: (metrics: AppRenderMetrics) => {
+        const breadcrumbs = (metrics as AppRenderMetrics & {
+          runtimeBreadcrumbs?: RuntimeBreadcrumbSnapshot;
+        }).runtimeBreadcrumbs;
+        if (breadcrumbs) latestBreadcrumbs = breadcrumbs;
+      },
+    },
+  });
+  fixture.setup?.(runtimeApp);
+  runtimeApp.onEvent((event) => {
+    if (event.kind === "action") actions.push(event);
+    if (event.kind === "fatal") fatal.push({ code: event.code, detail: event.detail });
+  });
+  runtimeApp.view((state) => {
+    latestState = state;
+    return fixture.view(state);
+  });
+
+  const renderer = createTestRenderer({
+    viewport: opts.scenario.viewport,
+    theme: fixture.theme ?? defaultTheme.definition,
+  });
+
+  let currentViewport = { ...opts.scenario.viewport };
+  const steps: ScenarioStepObservation[] = [];
+
+  try {
+    await runtimeApp.start();
+    backend.pushBytes(
+      encodeZrevBatchV1({
+        events: [
+          {
+            kind: "resize",
+            timeMs: 0,
+            cols: currentViewport.cols,
+            rows: currentViewport.rows,
+          },
+        ],
+      }),
+    );
+    await flushMicrotasks();
+
+    for (let index = 0; index < opts.scenario.scriptedInput.length; index++) {
+      const step = opts.scenario.scriptedInput[index];
+      if (step === undefined) continue;
+      const events = eventToZrevEvents(step.event);
+      if (step.event.kind === "resize") {
+        currentViewport = { cols: step.event.cols, rows: step.event.rows };
+      }
+      backend.pushBytes(encodeZrevBatchV1({ events }));
+      await flushMicrotasks();
+      const focusedId = focusIdFromBreadcrumbs(latestBreadcrumbs);
+      const screenRender = renderer.render(fixture.view(latestState), {
+        viewport: currentViewport,
+        theme: fixture.theme ?? defaultTheme.definition,
+        focusedId,
+      });
+      steps.push(
+        Object.freeze({
+          step: index + 1,
+          screen: createScenarioScreenSnapshot(currentViewport, screenRender.toText()),
+          cursor: asCursorSnapshot(latestBreadcrumbs),
+          actions: Object.freeze(actions.slice()),
+        }),
+      );
+    }
+  } finally {
+    try {
+      await runtimeApp.stop();
+    } catch {
+      // ignore harness teardown failures
+    }
+    runtimeApp.dispose();
+  }
+
+  const lastStep =
+    steps[steps.length - 1] ??
+    Object.freeze({
+      step: 0,
+      screen: createScenarioScreenSnapshot(currentViewport, ""),
+      cursor: asCursorSnapshot(latestBreadcrumbs),
+      actions: Object.freeze(actions.slice()),
+    });
+
+  const result = evaluateScenarioResult(opts.scenario, {
+    mode: "semantic",
+    actions: Object.freeze(actions.slice()),
+    steps: Object.freeze(steps),
+    finalScreen: lastStep.screen,
+    finalCursor: lastStep.cursor,
+  });
+  if (fatal.length === 0) return result;
+  return Object.freeze({
+    ...result,
+    status: "FAIL",
+    pass: false,
+    mismatches: Object.freeze([
+      ...result.mismatches,
+      ...fatal.map((item, index) =>
+        Object.freeze({
+          code: "ZR_SCENARIO_RUNTIME_FATAL" as const,
+          path: `fatal[${String(index)}]`,
+          detail: `${item.code}: ${item.detail}`,
+        }),
+      ),
+    ]),
+  });
+}

--- a/packages/node/package.json
+++ b/packages/node/package.json
@@ -18,6 +18,10 @@
     ".": {
       "types": "./dist/index.d.ts",
       "default": "./dist/index.js"
+    },
+    "./testing": {
+      "types": "./dist/testing/index.d.ts",
+      "default": "./dist/testing/index.js"
     }
   },
   "files": ["dist/", "README.md", "!dist/**/__tests__/**", "!dist/**/__e2e__/**"],
@@ -27,9 +31,7 @@
   },
   "dependencies": {
     "@rezi-ui/core": "0.1.0-alpha.61",
-    "@rezi-ui/native": "0.1.0-alpha.61"
-  },
-  "devDependencies": {
+    "@rezi-ui/native": "0.1.0-alpha.61",
     "@xterm/headless": "^6.0.0",
     "node-pty": "^1.1.0"
   }

--- a/packages/node/src/__tests__/fixtures/ptyEchoTarget.ts
+++ b/packages/node/src/__tests__/fixtures/ptyEchoTarget.ts
@@ -1,0 +1,26 @@
+function emit(line: string): void {
+  process.stdout.write(`${line}\n`);
+}
+
+let buffer = '';
+process.stdin.setEncoding('utf8');
+
+emit(`size:${String(process.stdout.columns ?? 0)}x${String(process.stdout.rows ?? 0)}`);
+
+process.on('SIGWINCH', () => {
+  emit(`size:${String(process.stdout.columns ?? 0)}x${String(process.stdout.rows ?? 0)}`);
+});
+
+process.stdin.on('data', (chunk: string) => {
+  buffer += chunk.replace(/\r/g, '\n');
+  for (;;) {
+    const idx = buffer.indexOf('\n');
+    if (idx < 0) break;
+    const line = buffer.slice(0, idx);
+    buffer = buffer.slice(idx + 1);
+    emit(`input:${line}`);
+    if (line === 'quit') {
+      process.exit(0);
+    }
+  }
+});

--- a/packages/node/src/__tests__/fixtures/referenceScenarioTarget.ts
+++ b/packages/node/src/__tests__/fixtures/referenceScenarioTarget.ts
@@ -1,0 +1,175 @@
+import net from 'node:net';
+import type { AppRenderMetrics } from '@rezi-ui/core';
+import {
+  createReferenceInputModalFixture,
+  type ScenarioCursorSnapshot,
+} from '@rezi-ui/core/testing';
+import { createNodeApp } from '../../index.js';
+
+type HarnessCommand = Readonly<{ type: 'stop' }>;
+
+type OutboundMessage =
+  | Readonly<{
+      type: 'ready';
+      caps: Awaited<ReturnType<ReturnType<typeof createNodeApp>['backend']['getCaps']>>;
+    }>
+  | Readonly<{ type: 'action'; action: unknown }>
+  | Readonly<{ type: 'render'; cursor: ScenarioCursorSnapshot | null }>
+  | Readonly<{ type: 'fatal'; detail: string }>;
+
+type TargetEnv = NodeJS.ProcessEnv & Readonly<{ REZI_SCENARIO_CTRL_PORT?: string }>;
+
+const targetEnv = process.env as TargetEnv;
+
+function failAndExit(msg: string): never {
+  process.stderr.write(`${msg}\n`);
+  process.exit(1);
+}
+
+function parsePortFromEnv(): number {
+  const raw = targetEnv.REZI_SCENARIO_CTRL_PORT;
+  if (raw === undefined) failAndExit('referenceScenarioTarget: REZI_SCENARIO_CTRL_PORT is required');
+  const port = Number(raw);
+  if (!Number.isInteger(port) || port <= 0 || port > 65535) {
+    failAndExit(`referenceScenarioTarget: invalid REZI_SCENARIO_CTRL_PORT=${String(raw)}`);
+  }
+  return port;
+}
+
+function asErrorDetail(err: unknown): string {
+  return err instanceof Error ? `${err.name}: ${err.message}` : String(err);
+}
+
+function sendJsonLine(socket: net.Socket | null, msg: OutboundMessage): void {
+  socket?.write(`${JSON.stringify(msg)}\n`);
+}
+
+function cursorFromMetrics(metrics: AppRenderMetrics): ScenarioCursorSnapshot | null {
+  const breadcrumbs = (metrics as AppRenderMetrics & {
+    runtimeBreadcrumbs?: { cursor?: ScenarioCursorSnapshot | null };
+  }).runtimeBreadcrumbs;
+  return breadcrumbs?.cursor ?? null;
+}
+
+const ctrlPort = parsePortFromEnv();
+const fixture = createReferenceInputModalFixture();
+let socket: net.Socket | null = null;
+let lineBuf = '';
+let shuttingDown = false;
+let latestCursor: ScenarioCursorSnapshot | null = null;
+
+const app = createNodeApp({
+  initialState: fixture.initialState,
+  config: {
+    executionMode: 'worker',
+    fpsCap: 1000,
+    maxEventBytes: 1 << 20,
+    internal_onRender: (metrics: AppRenderMetrics) => {
+      latestCursor = cursorFromMetrics(metrics);
+      sendJsonLine(socket, { type: 'render', cursor: latestCursor });
+    },
+  },
+  ...(fixture.theme !== undefined ? { theme: fixture.theme } : {}),
+});
+
+fixture.setup?.(app);
+app.onEvent((event) => {
+  if (event.kind === 'action') {
+    sendJsonLine(socket, { type: 'action', action: event });
+    return;
+  }
+  if (event.kind === 'fatal') {
+    sendJsonLine(socket, { type: 'fatal', detail: `${event.code}: ${event.detail}` });
+  }
+});
+app.view((state) => fixture.view(state));
+
+async function shutdown(code: number): Promise<void> {
+  if (shuttingDown) return;
+  shuttingDown = true;
+  try {
+    await app.stop();
+  } catch {
+    // best-effort cleanup
+  }
+  try {
+    app.dispose();
+  } catch {
+    // best-effort cleanup
+  }
+  try {
+    socket?.end();
+  } catch {
+    // best-effort cleanup
+  }
+  process.exit(code);
+}
+
+function handleCommand(line: string): void {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed) as unknown;
+  } catch {
+    return;
+  }
+  if (typeof parsed !== 'object' || parsed === null) return;
+  const command = parsed as Partial<HarnessCommand>;
+  if (command.type === 'stop') {
+    void shutdown(0);
+  }
+}
+
+process.on('uncaughtException', (err) => {
+  sendJsonLine(socket, { type: 'fatal', detail: asErrorDetail(err) });
+  void shutdown(1);
+});
+
+process.on('unhandledRejection', (err) => {
+  sendJsonLine(socket, { type: 'fatal', detail: asErrorDetail(err) });
+  void shutdown(1);
+});
+
+await app.start();
+
+socket = await new Promise<net.Socket>((resolve, reject) => {
+  const nextSocket = net.createConnection({ host: '127.0.0.1', port: ctrlPort }, () => {
+    cleanup();
+    resolve(nextSocket);
+  });
+  const onError = (err: Error) => {
+    cleanup();
+    reject(err);
+  };
+  const cleanup = () => {
+    nextSocket.off('error', onError);
+  };
+  nextSocket.once('error', onError);
+});
+socket.setEncoding('utf8');
+socket.on('data', (chunk: string) => {
+  lineBuf += chunk;
+  for (;;) {
+    const idx = lineBuf.indexOf('\n');
+    if (idx < 0) break;
+    const line = lineBuf.slice(0, idx);
+    lineBuf = lineBuf.slice(idx + 1);
+    handleCommand(line);
+  }
+});
+socket.on('error', (err) => {
+  if (shuttingDown) return;
+  sendJsonLine(socket, { type: 'fatal', detail: asErrorDetail(err) });
+  void shutdown(1);
+});
+socket.on('close', () => {
+  if (shuttingDown) return;
+  void shutdown(0);
+});
+
+sendJsonLine(socket, {
+  type: 'ready',
+  caps: await app.backend.getCaps(),
+});
+sendJsonLine(socket, { type: 'render', cursor: latestCursor });

--- a/packages/node/src/__tests__/ptyScenario.test.ts
+++ b/packages/node/src/__tests__/ptyScenario.test.ts
@@ -1,0 +1,37 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { fileURLToPath } from 'node:url';
+import {
+  createReferenceInputModalFixture,
+  referenceInputModalScenario,
+  runSemanticScenario,
+} from '@rezi-ui/core/testing';
+import { runPtyScenario } from '../testing/index.js';
+
+const PTY_TEST_OPTIONS = process.platform === 'win32'
+  ? { skip: 'PTY scenario tests are skipped on Windows in this MVP' }
+  : {};
+
+function mismatchDetail(result: { mismatches: readonly unknown[] }): string {
+  return JSON.stringify(result.mismatches, null, 2);
+}
+
+test('reference scenario passes in semantic and PTY modes', PTY_TEST_OPTIONS, async () => {
+  const semantic = await runSemanticScenario({
+    scenario: referenceInputModalScenario,
+    createFixture: createReferenceInputModalFixture,
+  });
+  assert.equal(semantic.pass, true, mismatchDetail(semantic));
+
+  const targetPath = fileURLToPath(new URL('./fixtures/referenceScenarioTarget.js', import.meta.url));
+  const pty = await runPtyScenario({
+    scenario: referenceInputModalScenario,
+    target: {
+      cwd: process.cwd(),
+      command: process.execPath,
+      args: [targetPath],
+    },
+  });
+
+  assert.equal(pty.pass, true, mismatchDetail(pty));
+});

--- a/packages/node/src/__tests__/testingHarness.test.ts
+++ b/packages/node/src/__tests__/testingHarness.test.ts
@@ -1,0 +1,88 @@
+import assert from 'node:assert/strict';
+import test from 'node:test';
+import { setTimeout as delay } from 'node:timers/promises';
+import { fileURLToPath } from 'node:url';
+import {
+  createTerminalScreen,
+  startPtyHarness,
+  type PtyHarness,
+  type TerminalScreenSnapshot,
+} from '../testing/index.js';
+
+const PTY_TEST_OPTIONS = process.platform === 'win32'
+  ? { skip: 'PTY harness tests are skipped on Windows in this MVP' }
+  : {};
+
+async function waitForSnapshot(
+  harness: PtyHarness,
+  predicate: (snapshot: TerminalScreenSnapshot) => boolean,
+  timeoutMs = 2_000,
+): Promise<TerminalScreenSnapshot> {
+  const deadline = Date.now() + timeoutMs;
+  for (;;) {
+    const snapshot = harness.snapshot();
+    if (predicate(snapshot)) return snapshot;
+    if (Date.now() > deadline) {
+      throw new Error(`Timed out waiting for PTY snapshot: ${JSON.stringify(snapshot.screen.lines)}`);
+    }
+    await delay(20);
+  }
+}
+
+test('createTerminalScreen reconstructs visible lines and cursor position', async () => {
+  const screen = createTerminalScreen({ cols: 10, rows: 3 });
+  await screen.write('hello');
+  await screen.write('\r\nworld');
+
+  const snapshot = screen.snapshot();
+  assert.deepEqual(snapshot.screen.lines, ['hello     ', 'world     ', '          ']);
+  assert.deepEqual(snapshot.cursor, { visible: true, x: 5, y: 1 });
+});
+
+test(
+  'startPtyHarness applies viewport changes, relays input, and preserves final screen state',
+  PTY_TEST_OPTIONS,
+  async () => {
+    const targetPath = fileURLToPath(new URL('./fixtures/ptyEchoTarget.js', import.meta.url));
+    const harness = await startPtyHarness({
+      cwd: process.cwd(),
+      command: process.execPath,
+      args: [targetPath],
+      cols: 40,
+      rows: 8,
+    });
+
+    try {
+      await waitForSnapshot(harness, (snapshot) =>
+        snapshot.screen.lines.some((line) => line.includes('size:40x8')),
+      );
+
+      await harness.resize(52, 10);
+      await waitForSnapshot(harness, (snapshot) =>
+        snapshot.screen.lines.some((line) => line.includes('size:52x10')),
+      );
+
+      await harness.write('ping\r');
+      await waitForSnapshot(harness, (snapshot) =>
+        snapshot.screen.lines.some((line) => line.includes('input:ping')),
+      );
+
+      const beforeExit = harness.snapshot();
+      assert.ok(beforeExit.screen.lines.some((line) => line.includes('input:ping')));
+
+      await harness.write('quit\r');
+      const exit = await harness.waitForExit();
+      assert.equal(exit.exitCode, 0);
+
+      const afterExit = harness.snapshot();
+      assert.ok(afterExit.screen.lines.some((line) => line.includes('input:quit')));
+      assert.ok(afterExit.screen.lines.some((line) => line.includes('input:ping')));
+    } finally {
+      try {
+        harness.kill();
+      } catch {
+        // already exited
+      }
+    }
+  },
+);

--- a/packages/node/src/testing/index.ts
+++ b/packages/node/src/testing/index.ts
@@ -1,0 +1,15 @@
+export {
+  startPtyHarness,
+  type PtyExitResult,
+  type PtyHarness,
+  type StartPtyHarnessOptions,
+} from './ptyHarness.js';
+export {
+  runPtyScenario,
+  type PtyScenarioHarnessTarget,
+} from './ptyScenario.js';
+export {
+  createTerminalScreen,
+  type TerminalScreenCursor,
+  type TerminalScreenSnapshot,
+} from './screen.js';

--- a/packages/node/src/testing/ptyHarness.ts
+++ b/packages/node/src/testing/ptyHarness.ts
@@ -1,0 +1,74 @@
+import pty from "node-pty";
+import { createTerminalScreen, type TerminalScreenSnapshot } from "./screen.js";
+
+export type PtyExitResult = Readonly<{ exitCode: number; signal?: number }>;
+
+export type StartPtyHarnessOptions = Readonly<{
+  cwd: string;
+  command: string;
+  args?: readonly string[];
+  env?: Readonly<Record<string, string | undefined>>;
+  cols: number;
+  rows: number;
+}>;
+
+export type PtyHarness = Readonly<{
+  pid: number;
+  write: (data: string) => Promise<void>;
+  resize: (cols: number, rows: number) => Promise<void>;
+  snapshot: () => TerminalScreenSnapshot;
+  rawOutput: () => Uint8Array;
+  waitForExit: () => Promise<PtyExitResult>;
+  kill: (signal?: string) => void;
+}>;
+
+export async function startPtyHarness(opts: StartPtyHarnessOptions): Promise<PtyHarness> {
+  const screen = createTerminalScreen({ cols: opts.cols, rows: opts.rows });
+  const term = pty.spawn(opts.command, [...(opts.args ?? [])], {
+    name: process.platform === "win32" ? "xterm" : "xterm-256color",
+    cols: opts.cols,
+    rows: opts.rows,
+    cwd: opts.cwd,
+    env: {
+      ...Object.fromEntries(Object.entries(opts.env ?? {}).filter(([, value]) => value !== undefined)),
+      TERM: process.platform === "win32" ? "xterm" : "xterm-256color",
+      COLUMNS: String(opts.cols),
+      LINES: String(opts.rows),
+      FORCE_COLOR: "1",
+    },
+  });
+
+  const raw: Buffer[] = [];
+  const exitPromise = new Promise<PtyExitResult>((resolve) => {
+    term.onExit((event) => {
+      resolve(Object.freeze({ exitCode: event.exitCode, ...(event.signal === undefined ? {} : { signal: event.signal }) }));
+    });
+  });
+
+  term.onData((chunk) => {
+    raw.push(Buffer.from(chunk, "utf8"));
+    void screen.write(chunk);
+  });
+
+  return Object.freeze({
+    pid: term.pid,
+    write: async (data: string) => {
+      term.write(data);
+      await screen.flush();
+    },
+    resize: async (cols: number, rows: number) => {
+      term.resize(cols, rows);
+      await screen.resize(cols, rows);
+    },
+    snapshot: () => screen.snapshot(),
+    rawOutput: () => Uint8Array.from(Buffer.concat(raw)),
+    waitForExit: async () => {
+      const result = await exitPromise;
+      await screen.flush();
+      return result;
+    },
+    kill: (signal?: string) => {
+      term.kill(signal);
+    },
+  });
+}

--- a/packages/node/src/testing/ptyScenario.ts
+++ b/packages/node/src/testing/ptyScenario.ts
@@ -1,0 +1,450 @@
+import net from "node:net";
+import { setTimeout as delay } from "node:timers/promises";
+import type { RoutedAction, TerminalCaps } from "@rezi-ui/core";
+import {
+  evaluateScenarioResult,
+  validateScenarioDefinition,
+  type ScenarioCursorSnapshot,
+  type ScenarioDefinition,
+  type ScenarioMismatch,
+  type ScenarioRunResult,
+  type ScenarioStepObservation,
+} from "@rezi-ui/core/testing";
+import { startPtyHarness } from "./ptyHarness.js";
+import type { TerminalScreenCursor } from "./screen.js";
+
+export type PtyScenarioHarnessTarget = Readonly<{
+  cwd: string;
+  command: string;
+  args?: readonly string[];
+  env?: Readonly<Record<string, string | undefined>>;
+}>;
+
+type HarnessCommand = Readonly<{ type: "stop" }>;
+
+type HarnessMessage =
+  | Readonly<{ type: "ready"; caps: TerminalCaps }>
+  | Readonly<{ type: "action"; action: RoutedAction }>
+  | Readonly<{ type: "render"; cursor: ScenarioCursorSnapshot | null }>
+  | Readonly<{ type: "fatal"; detail: string }>;
+
+type ControlState = Readonly<{
+  socket: { current: net.Socket | null };
+  ready: { value: boolean };
+  caps: { value: TerminalCaps | null };
+  actions: RoutedAction[];
+  fatals: string[];
+  latestCursor: { value: ScenarioCursorSnapshot | null };
+  renderSeq: { value: number };
+  lastRenderAt: { value: number };
+}>;
+
+const READY_TIMEOUT_MS = 5_000;
+const STEP_TIMEOUT_MS = 2_000;
+const QUIET_WINDOW_MS = 40;
+
+type PtyInputStep =
+  | Readonly<{ kind: "write"; data: string }>
+  | Readonly<{ kind: "resize"; cols: number; rows: number }>;
+
+function keyToBytes(key: string | number, mods: readonly string[] | undefined): string {
+  const normalized = typeof key === "number" ? key : key.trim().toLowerCase();
+  const ctrl = mods?.includes("ctrl") ?? false;
+  const alt = mods?.includes("alt") ?? false;
+  const meta = mods?.includes("meta") ?? false;
+  if ((alt || meta) && typeof normalized === "string" && normalized.length === 1 && !ctrl) {
+    return `\u001b${normalized}`;
+  }
+  if (ctrl && typeof normalized === "string" && normalized.length === 1) {
+    const upper = normalized.toUpperCase();
+    const code = upper.charCodeAt(0);
+    if (code >= 65 && code <= 90) {
+      return String.fromCharCode(code - 64);
+    }
+  }
+  if (typeof normalized === "string" && normalized.length === 1 && !ctrl && !alt && !meta) {
+    return normalized;
+  }
+  switch (normalized) {
+    case "enter":
+    case "return":
+      return "\r";
+    case "escape":
+    case "esc":
+      return "\u001b";
+    case "tab":
+      return "\t";
+    case "backspace":
+      return "\u007f";
+    case "up":
+      return "\u001b[A";
+    case "down":
+      return "\u001b[B";
+    case "right":
+      return "\u001b[C";
+    case "left":
+      return "\u001b[D";
+    case "home":
+      return "\u001b[H";
+    case "end":
+      return "\u001b[F";
+    case "delete":
+    case "del":
+      return "\u001b[3~";
+    case "pageup":
+      return "\u001b[5~";
+    case "pagedown":
+      return "\u001b[6~";
+    default:
+      throw new Error(`Unsupported PTY scenario key ${JSON.stringify(key)} with mods ${JSON.stringify(mods ?? [])}`);
+  }
+}
+
+function eventToInputStep(
+  scenario: ScenarioDefinition,
+  step: ScenarioDefinition["scriptedInput"][number],
+): PtyInputStep {
+  switch (step.event.kind) {
+    case "text":
+      return Object.freeze({ kind: "write", data: step.event.text });
+    case "paste": {
+      const data = scenario.capabilityProfile.supportsBracketedPaste
+        ? `\u001b[200~${step.event.text}\u001b[201~`
+        : step.event.text;
+      return Object.freeze({ kind: "write", data });
+    }
+    case "resize":
+      return Object.freeze({ kind: "resize", cols: step.event.cols, rows: step.event.rows });
+    case "key":
+      return Object.freeze({ kind: "write", data: keyToBytes(step.event.key, step.event.mods) });
+  }
+}
+
+function combineCursor(
+  terminalCursor: TerminalScreenCursor,
+  reported: ScenarioCursorSnapshot | null,
+): ScenarioCursorSnapshot | null {
+  if (reported === null) {
+    return terminalCursor.visible
+      ? Object.freeze({ visible: true, x: terminalCursor.x, y: terminalCursor.y, shape: 2, blink: true })
+      : Object.freeze({ visible: false, shape: 2, blink: true });
+  }
+  if (!terminalCursor.visible || !reported.visible) {
+    return Object.freeze({ visible: false, shape: reported.shape, blink: reported.blink });
+  }
+  return Object.freeze({
+    visible: true,
+    x: terminalCursor.x,
+    y: terminalCursor.y,
+    shape: reported.shape,
+    blink: reported.blink,
+  });
+}
+
+function parseMessage(line: string): HarnessMessage | null {
+  const trimmed = line.trim();
+  if (trimmed.length === 0) return null;
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(trimmed) as unknown;
+  } catch {
+    return null;
+  }
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const record = parsed as Partial<HarnessMessage>;
+  if (record.type === "ready" && typeof (record as { caps?: TerminalCaps }).caps === "object") {
+    return Object.freeze({
+      type: "ready",
+      caps: (record as { caps: TerminalCaps }).caps,
+    });
+  }
+  if (record.type === "fatal" && typeof record.detail === "string") {
+    return Object.freeze({ type: "fatal", detail: record.detail });
+  }
+  if (record.type === "render") {
+    return Object.freeze({
+      type: "render",
+      cursor: (record as { cursor?: ScenarioCursorSnapshot | null }).cursor ?? null,
+    });
+  }
+  if (record.type === "action" && typeof (record as { action?: RoutedAction }).action === "object") {
+    return Object.freeze({ type: "action", action: (record as { action: RoutedAction }).action });
+  }
+  return null;
+}
+
+async function closeServer(server: net.Server): Promise<void> {
+  await new Promise<void>((resolve) => {
+    server.close(() => resolve());
+  });
+}
+
+async function createControlServer(state: ControlState): Promise<Readonly<{ port: number; server: net.Server }>> {
+  const server = net.createServer((socket) => {
+    state.socket.current = socket;
+    socket.setEncoding("utf8");
+    let buffer = "";
+    socket.on("data", (chunk: string) => {
+      buffer += chunk;
+      for (;;) {
+        const index = buffer.indexOf("\n");
+        if (index < 0) break;
+        const line = buffer.slice(0, index);
+        buffer = buffer.slice(index + 1);
+        const message = parseMessage(line);
+        if (message === null) continue;
+        if (message.type === "ready") {
+          state.ready.value = true;
+          state.caps.value = message.caps;
+          continue;
+        }
+        if (message.type === "action") {
+          state.actions.push(message.action);
+          continue;
+        }
+        if (message.type === "fatal") {
+          state.fatals.push(message.detail);
+          continue;
+        }
+        state.latestCursor.value = message.cursor;
+        state.renderSeq.value += 1;
+        state.lastRenderAt.value = Date.now();
+      }
+    });
+  });
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => {
+      server.off("error", reject);
+      resolve();
+    });
+  });
+  const address = server.address();
+  if (address === null || typeof address === "string") {
+    await closeServer(server);
+    throw new Error("Failed to allocate PTY scenario control port");
+  }
+  return Object.freeze({ port: address.port, server });
+}
+
+async function waitForReady(state: ControlState): Promise<void> {
+  const deadline = Date.now() + READY_TIMEOUT_MS;
+  while (!state.ready.value) {
+    if (Date.now() > deadline) throw new Error("Timed out waiting for PTY scenario target readiness");
+    await delay(10);
+  }
+}
+
+function colorModeMeets(
+  actual: TerminalCaps["colorMode"],
+  expected: ScenarioDefinition["capabilityProfile"]["colorMode"],
+): boolean {
+  if (expected === "none") return true;
+  if (expected === "16") return actual >= 1;
+  if (expected === "256") return actual >= 2;
+  return actual >= 3;
+}
+
+function capabilityMismatches(
+  scenario: ScenarioDefinition,
+  actual: TerminalCaps | null,
+): readonly ScenarioMismatch[] {
+  if (actual === null) {
+    return Object.freeze([
+      Object.freeze({
+        code: "ZR_SCENARIO_RUNTIME_FATAL" as const,
+        path: "capabilityProfile",
+        detail: "PTY scenario target did not report terminal capabilities",
+      }),
+    ]);
+  }
+  const mismatches: ScenarioMismatch[] = [];
+  if (!colorModeMeets(actual.colorMode, scenario.capabilityProfile.colorMode)) {
+    mismatches.push({
+      code: "ZR_SCENARIO_UNSUPPORTED",
+      path: "capabilityProfile.colorMode",
+      detail: "PTY target color mode does not satisfy the scenario requirement",
+      expected: scenario.capabilityProfile.colorMode,
+      actual: actual.colorMode,
+    });
+  }
+  const capabilityChecks = [
+    ["supportsMouse", scenario.capabilityProfile.supportsMouse, actual.supportsMouse],
+    [
+      "supportsBracketedPaste",
+      scenario.capabilityProfile.supportsBracketedPaste,
+      actual.supportsBracketedPaste,
+    ],
+    [
+      "supportsFocusEvents",
+      scenario.capabilityProfile.supportsFocusEvents,
+      actual.supportsFocusEvents,
+    ],
+    ["supportsOsc52", scenario.capabilityProfile.supportsOsc52, actual.supportsOsc52],
+  ] as const;
+  for (const [name, required, supported] of capabilityChecks) {
+    if (!required || supported) continue;
+    mismatches.push({
+      code: "ZR_SCENARIO_UNSUPPORTED",
+      path: `capabilityProfile.${name}`,
+      detail: `PTY target does not support required capability ${name}`,
+      expected: true,
+      actual: supported,
+    });
+  }
+  return Object.freeze(mismatches);
+}
+
+async function waitForQuiet(state: ControlState): Promise<void> {
+  const startedAt = Date.now();
+  const baselineRender = state.renderSeq.value;
+  while (Date.now() - startedAt <= STEP_TIMEOUT_MS) {
+    const hasNewRender = state.renderSeq.value > baselineRender;
+    const quietForMs = Date.now() - state.lastRenderAt.value;
+    if (hasNewRender && quietForMs >= QUIET_WINDOW_MS) return;
+    if (!hasNewRender && Date.now() - startedAt >= QUIET_WINDOW_MS) return;
+    await delay(10);
+  }
+  throw new Error("Timed out waiting for PTY scenario render to settle");
+}
+
+function sendCommand(socket: net.Socket | null, command: HarnessCommand): void {
+  if (socket === null || socket.destroyed || !socket.writable) return;
+  try {
+    socket.write(`${JSON.stringify(command)}\n`);
+  } catch {
+    // best-effort control channel
+  }
+}
+
+export async function runPtyScenario(opts: Readonly<{
+  scenario: ScenarioDefinition;
+  target: PtyScenarioHarnessTarget;
+}>): Promise<ScenarioRunResult> {
+  const validation = validateScenarioDefinition(opts.scenario);
+  if (validation.length > 0) {
+    return Object.freeze({
+      mode: "pty",
+      status: "FAIL",
+      pass: false,
+      actions: Object.freeze([]),
+      steps: Object.freeze([]),
+      finalScreen: Object.freeze({ cols: opts.scenario.viewport.cols, rows: opts.scenario.viewport.rows, lines: Object.freeze([]) }),
+      finalCursor: null,
+      mismatches: validation,
+    });
+  }
+
+  const state: ControlState = Object.freeze({
+    socket: { current: null },
+    ready: { value: false },
+    caps: { value: null },
+    actions: [],
+    fatals: [],
+    latestCursor: { value: null },
+    renderSeq: { value: 0 },
+    lastRenderAt: { value: Date.now() },
+  });
+  const control = await createControlServer(state);
+  const harness = await startPtyHarness(
+    Object.freeze({
+      cwd: opts.target.cwd,
+      command: opts.target.command,
+      ...(opts.target.args !== undefined ? { args: opts.target.args } : {}),
+      env: {
+        ...(opts.target.env ?? {}),
+        REZI_SCENARIO_CTRL_PORT: String(control.port),
+      },
+      cols: opts.scenario.viewport.cols,
+      rows: opts.scenario.viewport.rows,
+    }),
+  );
+
+  const steps: ScenarioStepObservation[] = [];
+  try {
+    await waitForReady(state);
+    const capabilityErrors = capabilityMismatches(opts.scenario, state.caps.value);
+    if (capabilityErrors.length > 0) {
+      const snapshot = harness.snapshot();
+      return Object.freeze({
+        mode: "pty",
+        status: "FAIL",
+        pass: false,
+        actions: Object.freeze(state.actions.slice()),
+        steps: Object.freeze([]),
+        finalScreen: snapshot.screen,
+        finalCursor: combineCursor(snapshot.cursor, state.latestCursor.value),
+        mismatches: capabilityErrors,
+      });
+    }
+    await waitForQuiet(state);
+
+    for (let index = 0; index < opts.scenario.scriptedInput.length; index++) {
+      const scenarioStep = opts.scenario.scriptedInput[index];
+      if (scenarioStep === undefined) continue;
+      const inputStep = eventToInputStep(opts.scenario, scenarioStep);
+      if (inputStep.kind === "write") {
+        await harness.write(inputStep.data);
+      } else {
+        await harness.resize(inputStep.cols, inputStep.rows);
+      }
+      await waitForQuiet(state);
+      const snapshot = harness.snapshot();
+      steps.push(
+        Object.freeze({
+          step: index + 1,
+          screen: snapshot.screen,
+          cursor: combineCursor(snapshot.cursor, state.latestCursor.value),
+          actions: Object.freeze(state.actions.slice()),
+        }),
+      );
+    }
+
+    const finalSnapshot = harness.snapshot();
+    const finalCursor = combineCursor(finalSnapshot.cursor, state.latestCursor.value);
+    sendCommand(state.socket.current, { type: "stop" });
+    const exit = await harness.waitForExit();
+    const baseResult = evaluateScenarioResult(opts.scenario, {
+      mode: "pty",
+      actions: Object.freeze(state.actions.slice()),
+      steps: Object.freeze(steps),
+      finalScreen: finalSnapshot.screen,
+      finalCursor,
+    });
+    const mismatches: ScenarioMismatch[] = [...baseResult.mismatches];
+    if (exit.exitCode !== 0) {
+      mismatches.push({
+        code: "ZR_SCENARIO_RUNTIME_FATAL",
+        path: "process.exitCode",
+        detail: `PTY target exited with code ${String(exit.exitCode)}`,
+        expected: 0,
+        actual: exit.exitCode,
+      });
+    }
+    for (let index = 0; index < state.fatals.length; index++) {
+      mismatches.push({
+        code: "ZR_SCENARIO_RUNTIME_FATAL",
+        path: `fatal[${String(index)}]`,
+        detail: state.fatals[index] ?? "unknown fatal",
+      });
+    }
+    return Object.freeze({
+      ...baseResult,
+      status: mismatches.length === 0 ? "PASS" : "FAIL",
+      pass: mismatches.length === 0,
+      mismatches: Object.freeze(mismatches),
+    });
+  } finally {
+    try {
+      sendCommand(state.socket.current, { type: "stop" });
+    } catch {
+      // best-effort shutdown
+    }
+    try {
+      harness.kill();
+    } catch {
+      // already exited
+    }
+    await closeServer(control.server);
+  }
+}

--- a/packages/node/src/testing/screen.ts
+++ b/packages/node/src/testing/screen.ts
@@ -1,0 +1,111 @@
+import xtermHeadless from "@xterm/headless";
+import type { ScenarioScreenSnapshot } from "@rezi-ui/core/testing";
+
+export type TerminalScreenCursor =
+  | Readonly<{ visible: false; x: number; y: number }>
+  | Readonly<{ visible: true; x: number; y: number }>;
+
+export type TerminalScreenSnapshot = Readonly<{
+  screen: ScenarioScreenSnapshot;
+  cursor: TerminalScreenCursor;
+}>;
+
+type HeadlessLine = { translateToString(trimRight?: boolean): string };
+type HeadlessTerminal = {
+  write(data: string, callback?: () => void): void;
+  resize(cols: number, rows: number): void;
+  buffer: {
+    active: {
+      cursorX: number;
+      cursorY: number;
+      getLine(row: number): HeadlessLine | undefined;
+    };
+  };
+  _core?: {
+    _inputHandler?: {
+      _coreService?: {
+        isCursorHidden?: boolean;
+      };
+    };
+  };
+};
+type HeadlessTerminalCtor = new (opts: {
+  cols: number;
+  rows: number;
+  allowProposedApi: boolean;
+  convertEol: boolean;
+  scrollback: number;
+}) => HeadlessTerminal;
+
+export function createTerminalScreen(opts: Readonly<{ cols: number; rows: number }>): {
+  write: (data: string) => Promise<void>;
+  flush: () => Promise<void>;
+  resize: (cols: number, rows: number) => Promise<void>;
+  snapshot: () => TerminalScreenSnapshot;
+} {
+  const Terminal = (xtermHeadless as unknown as { Terminal?: unknown }).Terminal;
+  if (typeof Terminal !== "function") {
+    throw new Error("Unexpected @xterm/headless shape: missing Terminal export");
+  }
+
+  let cols = opts.cols;
+  let rows = opts.rows;
+  const term = new (Terminal as HeadlessTerminalCtor)({
+    cols,
+    rows,
+    allowProposedApi: true,
+    convertEol: false,
+    scrollback: 0,
+  });
+
+  let pending = Promise.resolve();
+  const write = async (data: string): Promise<void> => {
+    pending = pending.then(
+      () =>
+        new Promise<void>((resolve) => {
+          term.write(data, resolve);
+        }),
+    );
+    await pending;
+  };
+
+  const flush = async (): Promise<void> => {
+    await pending;
+  };
+
+  const resize = async (nextCols: number, nextRows: number): Promise<void> => {
+    cols = nextCols;
+    rows = nextRows;
+    pending = pending.then(() => {
+      term.resize(nextCols, nextRows);
+    });
+    await pending;
+  };
+
+  const snapshot = (): TerminalScreenSnapshot => {
+    const lines: string[] = [];
+    for (let row = 0; row < rows; row++) {
+      const line = term.buffer.active.getLine(row);
+      const text = line?.translateToString(false) ?? "";
+      lines.push(text.padEnd(cols, " ").slice(0, cols));
+    }
+    const hidden = term._core?._inputHandler?._coreService?.isCursorHidden === true;
+    const cursor = hidden
+      ? Object.freeze({
+          visible: false as const,
+          x: term.buffer.active.cursorX,
+          y: term.buffer.active.cursorY,
+        })
+      : Object.freeze({
+          visible: true as const,
+          x: term.buffer.active.cursorX,
+          y: term.buffer.active.cursorY,
+        });
+    return Object.freeze({
+      screen: Object.freeze({ cols, rows, lines: Object.freeze(lines) }),
+      cursor,
+    });
+  };
+
+  return Object.freeze({ write, flush, resize, snapshot });
+}


### PR DESCRIPTION
## Scope
- promote a correctness-focused PTY harness into `@rezi-ui/node/testing`
- add the MVP shared scenario model, assertion helpers, semantic runner, and replay runner in `@rezi-ui/core/testing`
- add a PTY scenario runner that drives a real node backend target through a PTY and reconstructs the terminal screen
- land one shared reference scenario runnable in semantic and PTY modes

## Tasks covered
- #322
- #338
- #339
- #340
- #341
- #342
- #343

## Selected reference scenario
- input editing pauses behind a modal and resumes after close with focus restore

## Test commands run
- `npm install`
- `npx tsc -b packages/core/tsconfig.json packages/node/tsconfig.json --pretty false`
- `npm -w @rezi-ui/native run build:native`
- `node --test packages/core/dist/testing/__tests__/scenarioHarness.test.js packages/node/dist/__tests__/testingHarness.test.js packages/node/dist/__tests__/ptyScenario.test.js packages/node/dist/__e2e__/terminal_io_contract.e2e.test.js`

## Known limitations left for later EPICs
- replay mode still fails clearly for cursor-dependent scenarios instead of capturing live cursor state
- the reference scenario does not assert cursor coordinates because semantic and PTY cursor capture disagree by one cell for this flow
- PTY tests are explicitly skipped on Windows in the new node-side tests

## Notes
- the PTY path was verified only after building `@rezi-ui/native` in the worktree, so the real-backend claim here is based on an actual native-backed PTY run rather than a shimmed path

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## New Features

* Added comprehensive scenario-based testing framework for terminal applications
* Supports multiple execution modes: semantic simulation, replay scripting, and PTY-based testing
* Includes reusable test fixtures, assertion utilities, and reference scenarios for common workflows
* Expanded testing API with scenario definitions, result evaluation, and terminal screen utilities

<!-- end of auto-generated comment: release notes by coderabbit.ai -->