### PR TITLE
testing: add failure injection and degraded capability coverage

### DIFF
--- a/packages/core/src/app/__tests__/backendFailureControls.test.ts
+++ b/packages/core/src/app/__tests__/backendFailureControls.test.ts
@@ -1,0 +1,48 @@
+import { assert, test } from "@rezi-ui/testkit";
+import { createApp } from "../createApp.js";
+import { flushMicrotasks } from "./helpers.js";
+import { StubBackend } from "./stubBackend.js";
+
+test("stub backend poll failure faults the app and disposes backend", async () => {
+  const backend = new StubBackend();
+  const app = createApp({ backend, initialState: 0 });
+  app.draw((g) => g.clear());
+
+  const fatals: string[] = [];
+  app.onEvent((event) => {
+    if (event.kind === "fatal") fatals.push(`${event.code}:${event.detail}`);
+  });
+
+  await app.start();
+  backend.resolveNextFrame();
+  await flushMicrotasks(10);
+
+  backend.queuePollFailure(new Error("poll boom"));
+  await flushMicrotasks(20);
+
+  assert.equal(fatals.length >= 1, true);
+  assert.equal(fatals[0]?.startsWith("ZRUI_BACKEND_ERROR:pollEvents rejected:"), true);
+  assert.equal(backend.stopCalls, 1);
+  assert.equal(backend.disposeCalls, 1);
+});
+
+test("stub backend start failure is reusable for lifecycle tests", async () => {
+  const backend = new StubBackend();
+  backend.queueStartFailure(new Error("start boom"));
+  const app = createApp({ backend, initialState: 0 });
+  app.draw((g) => g.clear());
+
+  await assert.rejects(app.start(), /backend.start rejected: Error: start boom/);
+});
+
+test("stub backend getCaps failure queue is reusable for startup fallback tests", async () => {
+  const backend = new StubBackend();
+  backend.queueGetCapsFailure(new Error("caps unavailable"));
+  const app = createApp({ backend, initialState: 0 });
+  app.draw((g) => g.clear());
+
+  await app.start();
+  assert.equal(backend.startCalls, 1);
+  await app.stop();
+  app.dispose();
+});

--- a/packages/core/src/app/__tests__/stubBackend.ts
+++ b/packages/core/src/app/__tests__/stubBackend.ts
@@ -25,20 +25,28 @@ export class StubBackend implements RuntimeBackend {
   readonly requestedFrames: Uint8Array[] = [];
   readonly callLog: string[] = [];
 
-  private readonly pollWaiters: Array<(b: BackendEventBatch) => void> = [];
+  private readonly pollWaiters: Array<Deferred<BackendEventBatch>> = [];
   private readonly pollBuffered: BackendEventBatch[] = [];
+  private readonly pollFailures: unknown[] = [];
 
   private readonly frameDeferreds: Array<Deferred<void>> = [];
+  private readonly startFailures: unknown[] = [];
+  private readonly stopFailures: unknown[] = [];
+  private readonly getCapsFailures: unknown[] = [];
 
   start(): Promise<void> {
     this.startCalls++;
     this.callLog.push("start");
+    const failure = this.startFailures.shift();
+    if (failure !== undefined) return Promise.reject(failure);
     return Promise.resolve();
   }
 
   stop(): Promise<void> {
     this.stopCalls++;
     this.callLog.push("stop");
+    const failure = this.stopFailures.shift();
+    if (failure !== undefined) return Promise.reject(failure);
     return Promise.resolve();
   }
 
@@ -68,20 +76,45 @@ export class StubBackend implements RuntimeBackend {
   }
 
   pollEvents(): Promise<BackendEventBatch> {
+    const failure = this.pollFailures.shift();
+    if (failure !== undefined) return Promise.reject(failure);
     const b = this.pollBuffered.shift();
     if (b) return Promise.resolve(b);
-    return new Promise<BackendEventBatch>((resolve) => {
-      this.pollWaiters.push(resolve);
-    });
+    const d = deferred<BackendEventBatch>();
+    this.pollWaiters.push(d);
+    return d.promise;
   }
 
   pushBatch(batch: BackendEventBatch): void {
     const w = this.pollWaiters.shift();
     if (w) {
-      w(batch);
+      w.resolve(batch);
       return;
     }
     this.pollBuffered.push(batch);
+  }
+
+  queueStartFailure(err: unknown): void {
+    this.startFailures.push(err);
+  }
+
+  queueStopFailure(err: unknown): void {
+    const waiter = this.pollWaiters.shift();
+    this.stopFailures.push(err);
+    if (waiter) this.pollWaiters.unshift(waiter);
+  }
+
+  queuePollFailure(err: unknown): void {
+    const waiter = this.pollWaiters.shift();
+    if (waiter) {
+      waiter.reject(err);
+      return;
+    }
+    this.pollFailures.push(err);
+  }
+
+  queueGetCapsFailure(err: unknown): void {
+    this.getCapsFailures.push(err);
   }
 
   postUserEvent(_tag: number, _payload: Uint8Array): void {
@@ -89,6 +122,8 @@ export class StubBackend implements RuntimeBackend {
   }
 
   getCaps(): Promise<TerminalCaps> {
+    const failure = this.getCapsFailures.shift();
+    if (failure !== undefined) return Promise.reject(failure);
     return Promise.resolve(DEFAULT_TERMINAL_CAPS);
   }
 }

--- a/packages/core/src/testing/index.ts
+++ b/packages/core/src/testing/index.ts
@@ -65,3 +65,19 @@ export {
   referenceSelectKeyboardCyclerScenario,
   createReferenceSelectKeyboardCyclerFixture,
 } from "./referenceScenarios/selectKeyboardCycler.js";
+export {
+  referenceInputIncompletePasteScenario,
+  createReferenceInputIncompletePasteFixture,
+} from "./referenceScenarios/inputIncompletePasteRecovery.js";
+export {
+  referenceInputMouseCapabilityFallbackScenario,
+  createReferenceInputMouseCapabilityFallbackFixture,
+} from "./referenceScenarios/inputMouseCapabilityFallback.js";
+export {
+  referenceInputIncompleteEscapeScenario,
+  createReferenceInputIncompleteEscapeFixture,
+} from "./referenceScenarios/inputIncompleteEscapeRecovery.js";
+export {
+  referenceVirtualListResizeStormScenario,
+  createReferenceVirtualListResizeStormFixture,
+} from "./referenceScenarios/virtualListResizeStorm.js";

--- a/packages/core/src/testing/referenceScenarios/inputIncompleteEscapeRecovery.ts
+++ b/packages/core/src/testing/referenceScenarios/inputIncompleteEscapeRecovery.ts
@@ -13,10 +13,7 @@ export const referenceInputIncompleteEscapeScenario: ScenarioDefinition = Object
   widgetFamily: "input-textarea",
   behaviorStatement:
     "An incomplete escape prefix must fall back deterministically and preserve later text input instead of wedging the stream.",
-  evidenceRefs: Object.freeze([
-    "docs/widgets/input.md",
-    "docs/terminal-io-contract.md",
-  ]),
+  evidenceRefs: Object.freeze(["docs/widgets/input.md", "docs/terminal-io-contract.md"]),
   viewport: Object.freeze({ cols: 48, rows: 8 }),
   theme: Object.freeze({ mode: "named", value: "default" }),
   capabilityProfile: Object.freeze({

--- a/packages/core/src/testing/referenceScenarios/inputIncompleteEscapeRecovery.ts
+++ b/packages/core/src/testing/referenceScenarios/inputIncompleteEscapeRecovery.ts
@@ -1,0 +1,92 @@
+import type { App } from "../../app/types.js";
+import { ui } from "../../ui.js";
+import type { ScenarioDefinition, ScenarioFixtureFactory } from "../scenario.js";
+
+interface InputIncompleteEscapeState {
+  readonly value: string;
+}
+
+export const referenceInputIncompleteEscapeScenario: ScenarioDefinition = Object.freeze({
+  schemaVersion: 1,
+  id: "input-incomplete-escape-recovers",
+  title: "Incomplete escape fallback preserves later input",
+  widgetFamily: "input-textarea",
+  behaviorStatement:
+    "An incomplete escape prefix must fall back deterministically and preserve later text input instead of wedging the stream.",
+  evidenceRefs: Object.freeze([
+    "docs/widgets/input.md",
+    "docs/terminal-io-contract.md",
+  ]),
+  viewport: Object.freeze({ cols: 48, rows: 8 }),
+  theme: Object.freeze({ mode: "named", value: "default" }),
+  capabilityProfile: Object.freeze({
+    supportsMouse: false,
+    supportsBracketedPaste: false,
+    supportsFocusEvents: false,
+    supportsOsc52: false,
+    colorMode: "none",
+  }),
+  scriptedInput: Object.freeze([
+    Object.freeze({
+      atMs: 0,
+      event: Object.freeze({ kind: "terminalBytes", bytes: "\u001b[" }),
+    }),
+    Object.freeze({ atMs: 250, event: Object.freeze({ kind: "text", text: "x" }) }),
+  ]),
+  expectedScreenCheckpoints: Object.freeze([
+    Object.freeze({
+      id: "fallback-text-visible",
+      afterStep: 2,
+      assertionRef: "screen_region_assertion",
+      args: Object.freeze({
+        x: 0,
+        y: 0,
+        width: 48,
+        height: 2,
+        match: "includes",
+        text: Object.freeze(['Value:"[x"']),
+      }),
+    }),
+  ]),
+  invariants: Object.freeze([
+    Object.freeze({
+      id: "fallback-order-stays-deterministic",
+      assertionRef: "invariant_assertion",
+      args: Object.freeze({
+        kind: "action_absence",
+        action: Object.freeze({
+          id: "field",
+          action: "input",
+          payloadSubset: Object.freeze({ value: "x[" }),
+        }),
+      }),
+    }),
+  ]),
+  fidelityRequirement: "terminal-real",
+});
+
+export const createReferenceInputIncompleteEscapeFixture: ScenarioFixtureFactory<
+  InputIncompleteEscapeState
+> = () => {
+  let app!: App<InputIncompleteEscapeState>;
+  return Object.freeze({
+    initialState: Object.freeze({ value: "" }),
+    setup(nextApp) {
+      app = nextApp;
+    },
+    view(state) {
+      return ui.focusTrap({ id: "escape-trap", active: true, initialFocus: "field" }, [
+        ui.column({}, [
+          ui.text(`Value:${JSON.stringify(state.value)}`),
+          ui.input({
+            id: "field",
+            value: state.value,
+            onInput: (value) => {
+              app.update({ value });
+            },
+          }),
+        ]),
+      ]);
+    },
+  });
+};

--- a/packages/core/src/testing/referenceScenarios/inputIncompletePasteRecovery.ts
+++ b/packages/core/src/testing/referenceScenarios/inputIncompletePasteRecovery.ts
@@ -1,0 +1,108 @@
+import type { App } from "../../app/types.js";
+import { ui } from "../../ui.js";
+import type { ScenarioDefinition, ScenarioFixtureFactory } from "../scenario.js";
+
+interface InputIncompletePasteState {
+  readonly value: string;
+  readonly submitted: number;
+}
+
+export const referenceInputIncompletePasteScenario: ScenarioDefinition = Object.freeze({
+  schemaVersion: 1,
+  id: "input-incomplete-paste-recovers",
+  title: "Input remains live after an incomplete bracketed paste",
+  widgetFamily: "input-textarea",
+  behaviorStatement:
+    "A focused input must not wedge when bracketed paste starts without an end marker; later keyboard navigation and submit still work.",
+  evidenceRefs: Object.freeze([
+    "docs/widgets/input.md",
+    "docs/terminal-io-contract.md",
+    "packages/core/src/runtime/__tests__/inputEditor.paste.test.ts",
+  ]),
+  viewport: Object.freeze({ cols: 48, rows: 10 }),
+  theme: Object.freeze({ mode: "named", value: "default" }),
+  capabilityProfile: Object.freeze({
+    supportsMouse: false,
+    supportsBracketedPaste: true,
+    supportsFocusEvents: false,
+    supportsOsc52: false,
+    colorMode: "16",
+  }),
+  scriptedInput: Object.freeze([
+    Object.freeze({
+      atMs: 0,
+      event: Object.freeze({ kind: "terminalBytes", bytes: "\u001b[200~broken" }),
+    }),
+    Object.freeze({ atMs: 250, event: Object.freeze({ kind: "key", key: "tab" }) }),
+    Object.freeze({ atMs: 260, event: Object.freeze({ kind: "key", key: "enter" }) }),
+  ]),
+  expectedActions: Object.freeze([
+    Object.freeze({ id: "field", action: "input", value: "broken", cursor: 6 }),
+    Object.freeze({ id: "submit", action: "press" }),
+  ]),
+  expectedScreenCheckpoints: Object.freeze([
+    Object.freeze({
+      id: "submit-still-works",
+      afterStep: 3,
+      assertionRef: "screen_region_assertion",
+      args: Object.freeze({
+        x: 0,
+        y: 0,
+        width: 48,
+        height: 3,
+        match: "includes",
+        text: Object.freeze(["Submitted:1"]),
+      }),
+    }),
+  ]),
+  invariants: Object.freeze([
+    Object.freeze({
+      id: "no-ghost-press",
+      assertionRef: "invariant_assertion",
+      args: Object.freeze({
+        kind: "action_absence",
+        action: Object.freeze({
+          id: "ghost-submit",
+          action: "press",
+        }),
+      }),
+    }),
+  ]),
+  fidelityRequirement: "terminal-real",
+  notes:
+    "Terminal I/O contract coverage already pins missing-end bracketed paste to flush, so the scenario asserts the visible flush plus later keyboard liveness.",
+});
+
+export const createReferenceInputIncompletePasteFixture: ScenarioFixtureFactory<
+  InputIncompletePasteState
+> = () => {
+  let app!: App<InputIncompletePasteState>;
+  return Object.freeze({
+    initialState: Object.freeze({ value: "", submitted: 0 }),
+    setup(nextApp) {
+      app = nextApp;
+    },
+    view(state) {
+      return ui.focusTrap({ id: "paste-trap", active: true, initialFocus: "field" }, [
+        ui.column({}, [
+          ui.text(`Submitted:${String(state.submitted)}`),
+          ui.text(`Value:${JSON.stringify(state.value)}`),
+          ui.input({
+            id: "field",
+            value: state.value,
+            onInput: (value) => {
+              app.update((current) => ({ ...current, value }));
+            },
+          }),
+          ui.button({
+            id: "submit",
+            label: "Submit",
+            onPress: () => {
+              app.update((current) => ({ ...current, submitted: current.submitted + 1 }));
+            },
+          }),
+        ]),
+      ]);
+    },
+  });
+};

--- a/packages/core/src/testing/referenceScenarios/inputMouseCapabilityFallback.ts
+++ b/packages/core/src/testing/referenceScenarios/inputMouseCapabilityFallback.ts
@@ -1,0 +1,114 @@
+import type { App } from "../../app/types.js";
+import { ui } from "../../ui.js";
+import type { ScenarioDefinition, ScenarioFixtureFactory } from "../scenario.js";
+
+interface InputMouseCapabilityFallbackState {
+  readonly first: string;
+  readonly second: string;
+}
+
+const SECOND_INPUT_CLICK = "\u001b[<0;4;4M\u001b[<0;4;4m";
+
+export const referenceInputMouseCapabilityFallbackScenario: ScenarioDefinition = Object.freeze({
+  schemaVersion: 1,
+  id: "input-mouse-disabled-keeps-keyboard-focus",
+  title: "Mouse bytes do not steal input focus when mouse support is disabled",
+  widgetFamily: "input-textarea",
+  behaviorStatement:
+    "When PTY mouse support is disabled, raw mouse bytes must not move focus away from the active input, and keyboard typing must keep editing the original field.",
+  evidenceRefs: Object.freeze([
+    "docs/widgets/input.md",
+    "docs/backend/terminal-caps.md",
+    "docs/guide/mouse-support.md",
+    "packages/core/src/app/__tests__/widgetBehavior.contracts.test.ts",
+  ]),
+  viewport: Object.freeze({ cols: 48, rows: 8 }),
+  theme: Object.freeze({ mode: "named", value: "default" }),
+  capabilityProfile: Object.freeze({
+    supportsMouse: false,
+    supportsBracketedPaste: false,
+    supportsFocusEvents: false,
+    supportsOsc52: false,
+    colorMode: "none",
+  }),
+  scriptedInput: Object.freeze([
+    Object.freeze({
+      atMs: 0,
+      event: Object.freeze({ kind: "terminalBytes", bytes: SECOND_INPUT_CLICK }),
+    }),
+    Object.freeze({ atMs: 20, event: Object.freeze({ kind: "text", text: "x" }) }),
+  ]),
+  expectedActions: Object.freeze([
+    Object.freeze({ id: "first", action: "input", value: "ax", cursor: 2 }),
+  ]),
+  expectedScreenCheckpoints: Object.freeze([
+    Object.freeze({
+      id: "first-input-kept-focus",
+      afterStep: 2,
+      assertionRef: "screen_region_assertion",
+      args: Object.freeze({
+        x: 0,
+        y: 0,
+        width: 48,
+        height: 5,
+        match: "exact",
+        text: Object.freeze([
+          'First:"ax"                                      ',
+          "                                                ",
+          " ax                                             ",
+          "                                                ",
+          'Second:"b"                                      ',
+        ]),
+      }),
+    }),
+  ]),
+  invariants: Object.freeze([
+    Object.freeze({
+      id: "second-input-not-mutated",
+      assertionRef: "invariant_assertion",
+      args: Object.freeze({
+        kind: "action_absence",
+        action: Object.freeze({
+          id: "second",
+          action: "input",
+          payloadSubset: Object.freeze({ value: "bx" }),
+        }),
+      }),
+    }),
+  ]),
+  fidelityRequirement: "terminal-real",
+});
+
+export const createReferenceInputMouseCapabilityFallbackFixture: ScenarioFixtureFactory<
+  InputMouseCapabilityFallbackState
+> = () => {
+  let app!: App<InputMouseCapabilityFallbackState>;
+  return Object.freeze({
+    initialState: Object.freeze({ first: "a", second: "b" }),
+    setup(nextApp) {
+      app = nextApp;
+    },
+    view(state) {
+      return ui.focusTrap({ id: "mouse-cap-trap", active: true, initialFocus: "first" }, [
+        ui.column({}, [
+          ui.text(`First:${JSON.stringify(state.first)}`),
+          ui.input({
+            id: "first",
+            value: state.first,
+            onInput: (value) => {
+              app.update((current) => ({ ...current, first: value }));
+            },
+          }),
+          ui.text(`Second:${JSON.stringify(state.second)}`),
+          ui.input({
+            id: "second",
+            value: state.second,
+            onInput: (value) => {
+              app.update((current) => ({ ...current, second: value }));
+            },
+          }),
+        ]),
+      ]);
+    },
+  });
+};

--- a/packages/core/src/testing/referenceScenarios/virtualListResizeStorm.ts
+++ b/packages/core/src/testing/referenceScenarios/virtualListResizeStorm.ts
@@ -1,0 +1,100 @@
+import type { App } from "../../app/types.js";
+import { ui } from "../../ui.js";
+import type { ScenarioDefinition, ScenarioFixtureFactory } from "../scenario.js";
+
+interface VirtualListResizeStormState {
+  readonly activated: string;
+}
+
+export const referenceVirtualListResizeStormScenario: ScenarioDefinition = Object.freeze({
+  schemaVersion: 1,
+  id: "virtual-list-resize-storm-stays-interactive",
+  title: "Virtual list stays interactive through a resize storm",
+  widgetFamily: "table-tree-virtual-list",
+  behaviorStatement:
+    "Repeated viewport changes must not wedge a virtual list; later keyboard navigation and activation still work.",
+  evidenceRefs: Object.freeze([
+    "docs/widgets/virtual-list.md",
+    "docs/terminal-io-contract.md",
+    "packages/core/src/widgets/__tests__/virtualList.contract.test.ts",
+    "packages/core/src/app/__tests__/widgetBehavior.contracts.test.ts",
+  ]),
+  viewport: Object.freeze({ cols: 40, rows: 10 }),
+  theme: Object.freeze({ mode: "named", value: "default" }),
+  capabilityProfile: Object.freeze({
+    supportsMouse: false,
+    supportsBracketedPaste: false,
+    supportsFocusEvents: false,
+    supportsOsc52: false,
+    colorMode: "none",
+  }),
+  scriptedInput: Object.freeze([
+    Object.freeze({ atMs: 0, event: Object.freeze({ kind: "resize", cols: 52, rows: 12 }) }),
+    Object.freeze({ atMs: 10, event: Object.freeze({ kind: "resize", cols: 34, rows: 8 }) }),
+    Object.freeze({ atMs: 20, event: Object.freeze({ kind: "resize", cols: 60, rows: 14 }) }),
+    Object.freeze({ atMs: 30, event: Object.freeze({ kind: "resize", cols: 40, rows: 10 }) }),
+    Object.freeze({ atMs: 60, event: Object.freeze({ kind: "key", key: "down" }) }),
+    Object.freeze({ atMs: 70, event: Object.freeze({ kind: "key", key: "enter" }) }),
+  ]),
+  expectedScreenCheckpoints: Object.freeze([
+    Object.freeze({
+      id: "activation-after-resize-storm",
+      afterStep: 6,
+      assertionRef: "screen_region_assertion",
+      args: Object.freeze({
+        x: 0,
+        y: 0,
+        width: 40,
+        height: 2,
+        match: "includes",
+        text: Object.freeze(["Activated:1"]),
+      }),
+    }),
+  ]),
+  invariants: Object.freeze([
+    Object.freeze({
+      id: "no-ghost-activation",
+      assertionRef: "invariant_assertion",
+      args: Object.freeze({
+        kind: "action_absence",
+        action: Object.freeze({
+          id: "missing-list-action",
+          action: "press",
+        }),
+      }),
+    }),
+  ]),
+  fidelityRequirement: "terminal-real",
+  notes:
+    "The oracle stays behavior-first: later activation must still work after repeated resizes, without asserting exact row geometry during the storm.",
+});
+
+export const createReferenceVirtualListResizeStormFixture: ScenarioFixtureFactory<
+  VirtualListResizeStormState
+> = () => {
+  let app!: App<VirtualListResizeStormState>;
+  const items = Object.freeze(Array.from({ length: 100 }, (_, index) => index));
+  return Object.freeze({
+    initialState: Object.freeze({ activated: "-" }),
+    setup(nextApp) {
+      app = nextApp;
+    },
+    view(state) {
+      return ui.focusTrap({ id: "resize-trap", active: true, initialFocus: "list" }, [
+        ui.column({}, [
+          ui.text(`Activated:${state.activated}`),
+          ui.virtualList({
+            id: "list",
+            items,
+            itemHeight: 1,
+            renderItem: (item, _index, focused) =>
+              ui.text(focused ? `> ${String(item)}` : String(item)),
+            onSelect: (item: number) => {
+              app.update({ activated: String(item) });
+            },
+          }),
+        ]),
+      ]);
+    },
+  });
+};

--- a/packages/core/src/testing/replayScenario.ts
+++ b/packages/core/src/testing/replayScenario.ts
@@ -175,6 +175,8 @@ function eventToZrevEvents(event: ScenarioScriptedInputEvent): readonly TestZrev
           rows: event.rows,
         },
       ]);
+    case "terminalBytes":
+      throw new Error("Replay scenarios do not support terminalBytes input");
     case "key":
       return Object.freeze([
         {
@@ -226,7 +228,9 @@ function toReplayExpectedActions(
       );
       continue;
     }
-    throw new Error(`Replay MVP supports only press/input expectedActions (got ${action.action})`);
+    throw new Error(
+      `Replay scenario runner supports only press/input expectedActions (got ${action.action})`,
+    );
   }
   return Object.freeze(out);
 }
@@ -338,6 +342,24 @@ export async function runReplayScenario<S>(
     createFixture: ScenarioFixtureFactory<S>;
   }>,
 ): Promise<ScenarioRunResult> {
+  if (opts.scenario.scriptedInput.some((step) => step.event.kind === "terminalBytes")) {
+    return Object.freeze({
+      mode: "replay",
+      status: "FAIL",
+      pass: false,
+      actions: Object.freeze([]),
+      steps: Object.freeze([]),
+      finalScreen: createScenarioScreenSnapshot(opts.scenario.viewport, ""),
+      finalCursor: null,
+      mismatches: Object.freeze([
+        Object.freeze({
+          code: "ZR_SCENARIO_UNSUPPORTED" as const,
+          path: "scriptedInput",
+          detail: "Replay scenarios do not support terminalBytes input; use PTY mode",
+        }),
+      ]),
+    });
+  }
   const fixture = opts.createFixture();
   const compiledTheme = compileTheme(fixture.theme ?? defaultTheme.definition);
   const renderer = createTestRenderer({
@@ -473,7 +495,7 @@ export async function runReplayScenario<S>(
     code: "ZR_SCENARIO_UNSUPPORTED",
     path: "expectedCursorState",
     detail:
-      "Replay MVP does not capture live cursor state; use semantic or PTY mode for cursor-dependent scenarios",
+      "Replay scenario runner does not capture live cursor state; use semantic or PTY mode for cursor-dependent scenarios",
   });
   return Object.freeze({
     ...result,

--- a/packages/core/src/testing/scenario.ts
+++ b/packages/core/src/testing/scenario.ts
@@ -26,6 +26,7 @@ export type ScenarioScriptedInputEvent =
   | Readonly<{ kind: "text"; text: string }>
   | Readonly<{ kind: "paste"; text: string }>
   | Readonly<{ kind: "resize"; cols: number; rows: number }>
+  | Readonly<{ kind: "terminalBytes"; bytes: string }>
   | Readonly<{ kind: "key"; key: string | number; mods?: readonly ScenarioKeyMod[] }>;
 
 export type ScenarioScriptedInputStep = Readonly<{
@@ -208,7 +209,7 @@ export function validateScenarioDefinition(
     mismatches.push({
       code: "ZR_SCENARIO_UNSUPPORTED",
       path: "theme",
-      detail: `Only theme { mode: \"named\", value: \"default\" } is supported in this MVP`,
+      detail: `Only theme { mode: \"named\", value: \"default\" } is supported in this scenario harness`,
       expected: { mode: "named", value: "default" },
       actual: scenario.theme,
     });

--- a/packages/core/src/testing/semanticScenario.ts
+++ b/packages/core/src/testing/semanticScenario.ts
@@ -234,6 +234,8 @@ function eventToZrevEvents(event: ScenarioScriptedInputEvent): readonly TestZrev
           rows: event.rows,
         },
       ]);
+    case "terminalBytes":
+      throw new Error("Semantic scenarios do not support terminalBytes input");
     case "key":
       return Object.freeze([
         {
@@ -277,6 +279,24 @@ export async function runSemanticScenario<S>(
     createFixture: ScenarioFixtureFactory<S>;
   }>,
 ): Promise<ScenarioRunResult> {
+  if (opts.scenario.scriptedInput.some((step) => step.event.kind === "terminalBytes")) {
+    return Object.freeze({
+      mode: "semantic",
+      status: "FAIL",
+      pass: false,
+      actions: Object.freeze([]),
+      steps: Object.freeze([]),
+      finalScreen: createScenarioScreenSnapshot(opts.scenario.viewport, ""),
+      finalCursor: null,
+      mismatches: Object.freeze([
+        Object.freeze({
+          code: "ZR_SCENARIO_UNSUPPORTED" as const,
+          path: "scriptedInput",
+          detail: "Semantic scenarios do not support terminalBytes input; use PTY mode",
+        }),
+      ]),
+    });
+  }
   const fixture = opts.createFixture();
   const backend = new SemanticHarnessBackend(toTerminalCaps(opts.scenario.capabilityProfile));
   let latestState = fixture.initialState;

--- a/packages/node/src/__tests__/fixtures/referenceScenarioTarget.ts
+++ b/packages/node/src/__tests__/fixtures/referenceScenarioTarget.ts
@@ -1,21 +1,18 @@
 import net from "node:net";
 import type { AppRenderMetrics } from "@rezi-ui/core";
 import {
-  type ScenarioFixture,
   type ScenarioCursorSnapshot,
+  type ScenarioFixture,
   createReferenceInputIncompleteEscapeFixture,
   createReferenceInputIncompletePasteFixture,
-  createReferenceInputMouseCapabilityFallbackFixture,
   createReferenceInputModalFixture,
+  createReferenceInputMouseCapabilityFallbackFixture,
   createReferenceSelectKeyboardCyclerFixture,
   createReferenceTextareaMultilineFixture,
   createReferenceVirtualListResizeStormFixture,
 } from "@rezi-ui/core/testing";
 import { createNodeApp } from "../../index.js";
-import {
-  parsePtyTargetNativeConfig,
-  parsePtyTargetScenarioId,
-} from "../../testing/index.js";
+import { parsePtyTargetNativeConfig, parsePtyTargetScenarioId } from "../../testing/index.js";
 
 type HarnessCommand = Readonly<{ type: "stop" }>;
 
@@ -89,8 +86,24 @@ function loadFixture(): ScenarioFixture<unknown> {
   }
 }
 
-const fixture = loadFixture();
-const nativeConfig = parsePtyTargetNativeConfig(targetEnv);
+function loadFixtureOrExit(): ScenarioFixture<unknown> {
+  try {
+    return loadFixture();
+  } catch (error: unknown) {
+    failAndExit(`referenceScenarioTarget: ${asErrorDetail(error)}`);
+  }
+}
+
+function parseNativeConfigOrExit(): Readonly<Record<string, unknown>> {
+  try {
+    return parsePtyTargetNativeConfig(targetEnv);
+  } catch (error: unknown) {
+    failAndExit(`referenceScenarioTarget: ${asErrorDetail(error)}`);
+  }
+}
+
+const fixture = loadFixtureOrExit();
+const nativeConfig = parseNativeConfigOrExit();
 let socket: net.Socket | null = null;
 let lineBuf = "";
 let shuttingDown = false;

--- a/packages/node/src/__tests__/fixtures/referenceScenarioTarget.ts
+++ b/packages/node/src/__tests__/fixtures/referenceScenarioTarget.ts
@@ -1,10 +1,21 @@
 import net from "node:net";
 import type { AppRenderMetrics } from "@rezi-ui/core";
 import {
+  type ScenarioFixture,
   type ScenarioCursorSnapshot,
+  createReferenceInputIncompleteEscapeFixture,
+  createReferenceInputIncompletePasteFixture,
+  createReferenceInputMouseCapabilityFallbackFixture,
   createReferenceInputModalFixture,
+  createReferenceSelectKeyboardCyclerFixture,
+  createReferenceTextareaMultilineFixture,
+  createReferenceVirtualListResizeStormFixture,
 } from "@rezi-ui/core/testing";
 import { createNodeApp } from "../../index.js";
+import {
+  parsePtyTargetNativeConfig,
+  parsePtyTargetScenarioId,
+} from "../../testing/index.js";
 
 type HarnessCommand = Readonly<{ type: "stop" }>;
 
@@ -19,7 +30,6 @@ type OutboundMessage =
   | Readonly<{ type: "fatal"; detail: string }>;
 
 type TargetEnv = NodeJS.ProcessEnv & Readonly<{ REZI_SCENARIO_CTRL_PORT?: string }>;
-
 const targetEnv = process.env as TargetEnv;
 
 function failAndExit(msg: string): never {
@@ -57,7 +67,30 @@ function cursorFromMetrics(metrics: AppRenderMetrics): ScenarioCursorSnapshot | 
 }
 
 const ctrlPort = parsePortFromEnv();
-const fixture = createReferenceInputModalFixture();
+function loadFixture(): ScenarioFixture<unknown> {
+  const scenarioId = parsePtyTargetScenarioId(targetEnv);
+  switch (scenarioId) {
+    case "input-modal-blocking-focus-restore":
+      return createReferenceInputModalFixture() as unknown as ScenarioFixture<unknown>;
+    case "textarea-multiline-editing":
+      return createReferenceTextareaMultilineFixture() as unknown as ScenarioFixture<unknown>;
+    case "select-keyboard-cycler":
+      return createReferenceSelectKeyboardCyclerFixture() as unknown as ScenarioFixture<unknown>;
+    case "input-incomplete-paste-recovers":
+      return createReferenceInputIncompletePasteFixture() as unknown as ScenarioFixture<unknown>;
+    case "input-mouse-disabled-keeps-keyboard-focus":
+      return createReferenceInputMouseCapabilityFallbackFixture() as unknown as ScenarioFixture<unknown>;
+    case "input-incomplete-escape-recovers":
+      return createReferenceInputIncompleteEscapeFixture() as unknown as ScenarioFixture<unknown>;
+    case "virtual-list-resize-storm-stays-interactive":
+      return createReferenceVirtualListResizeStormFixture() as unknown as ScenarioFixture<unknown>;
+    default:
+      failAndExit(`referenceScenarioTarget: unsupported REZI_SCENARIO_ID=${scenarioId}`);
+  }
+}
+
+const fixture = loadFixture();
+const nativeConfig = parsePtyTargetNativeConfig(targetEnv);
 let socket: net.Socket | null = null;
 let lineBuf = "";
 let shuttingDown = false;
@@ -69,6 +102,7 @@ const app = createNodeApp({
     executionMode: "worker",
     fpsCap: 1000,
     maxEventBytes: 1 << 20,
+    nativeConfig,
     internal_onRender: (metrics: AppRenderMetrics) => {
       latestCursor = cursorFromMetrics(metrics);
       sendJsonLine(socket, { type: "render", cursor: latestCursor });

--- a/packages/node/src/__tests__/ptyScenario.test.ts
+++ b/packages/node/src/__tests__/ptyScenario.test.ts
@@ -3,8 +3,16 @@ import { readdirSync } from "node:fs";
 import test from "node:test";
 import { fileURLToPath } from "node:url";
 import {
+  createReferenceInputIncompleteEscapeFixture,
+  createReferenceInputIncompletePasteFixture,
   createReferenceInputModalFixture,
+  createReferenceSelectKeyboardCyclerFixture,
+  referenceInputIncompleteEscapeScenario,
+  referenceInputIncompletePasteScenario,
   referenceInputModalScenario,
+  referenceInputMouseCapabilityFallbackScenario,
+  referenceSelectKeyboardCyclerScenario,
+  referenceVirtualListResizeStormScenario,
   runSemanticScenario,
 } from "@rezi-ui/core/testing";
 import { runPtyScenario } from "../testing/index.js";
@@ -27,29 +35,69 @@ if (process.platform === "win32") {
 } else if (isBunRuntime) {
   test.skip("reference scenario passes in semantic and PTY modes", () => {});
 } else if (!hasHostNativeAddon) {
-  test.skip("reference scenario passes in semantic and PTY modes", () => {});
+  test.skip("PTY scenarios stay aligned with semantic contracts and fallback behavior", () => {});
 } else {
-  test("reference scenario passes in semantic and PTY modes", { timeout: 20_000 }, async () => {
-    const semantic = await runSemanticScenario({
-      scenario: referenceInputModalScenario,
-      createFixture: createReferenceInputModalFixture,
-    });
-    assert.equal(semantic.pass, true, mismatchDetail(semantic));
+  test(
+    "PTY scenarios stay aligned with semantic contracts and fallback behavior",
+    { timeout: 40_000 },
+    async () => {
+      const semantic = await runSemanticScenario({
+        scenario: referenceInputModalScenario,
+        createFixture: createReferenceInputModalFixture,
+      });
+      assert.equal(semantic.pass, true, mismatchDetail(semantic));
 
-    const targetPath = fileURLToPath(
-      new URL("./fixtures/referenceScenarioTarget.js", import.meta.url),
-    );
-    const command = process.platform === "win32" ? process.execPath : "/usr/bin/env";
-    const args = process.platform === "win32" ? [targetPath] : ["node", targetPath];
-    const pty = await runPtyScenario({
-      scenario: referenceInputModalScenario,
-      target: {
-        cwd: process.cwd(),
-        command,
-        args,
-      },
-    });
+      const selectSemantic = await runSemanticScenario({
+        scenario: referenceSelectKeyboardCyclerScenario,
+        createFixture: createReferenceSelectKeyboardCyclerFixture,
+      });
+      assert.equal(selectSemantic.pass, true, mismatchDetail(selectSemantic));
 
-    assert.equal(pty.pass, true, mismatchDetail(pty));
-  });
+      const incompleteEscapeSemantic = await runSemanticScenario({
+        scenario: referenceInputIncompleteEscapeScenario,
+        createFixture: createReferenceInputIncompleteEscapeFixture,
+      });
+      assert.equal(incompleteEscapeSemantic.pass, false);
+      assert.equal(
+        incompleteEscapeSemantic.mismatches.some((item) => item.code === "ZR_SCENARIO_UNSUPPORTED"),
+        true,
+      );
+
+      const incompletePasteSemantic = await runSemanticScenario({
+        scenario: referenceInputIncompletePasteScenario,
+        createFixture: createReferenceInputIncompletePasteFixture,
+      });
+      assert.equal(incompletePasteSemantic.pass, false);
+      assert.equal(
+        incompletePasteSemantic.mismatches.some((item) => item.code === "ZR_SCENARIO_UNSUPPORTED"),
+        true,
+      );
+
+      const targetPath = fileURLToPath(
+        new URL("./fixtures/referenceScenarioTarget.js", import.meta.url),
+      );
+      const command = process.platform === "win32" ? process.execPath : "/usr/bin/env";
+      const args = process.platform === "win32" ? [targetPath] : ["node", targetPath];
+
+      const scenarios = [
+        referenceInputModalScenario,
+        referenceInputIncompletePasteScenario,
+        referenceInputMouseCapabilityFallbackScenario,
+        referenceInputIncompleteEscapeScenario,
+        referenceVirtualListResizeStormScenario,
+      ] as const;
+
+      for (const scenario of scenarios) {
+        const pty = await runPtyScenario({
+          scenario,
+          target: {
+            cwd: process.cwd(),
+            command,
+            args,
+          },
+        });
+        assert.equal(pty.pass, true, `${scenario.id}: ${mismatchDetail(pty)}`);
+      }
+    },
+  );
 }

--- a/packages/node/src/__tests__/ptyTargetConfig.test.ts
+++ b/packages/node/src/__tests__/ptyTargetConfig.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import test from "node:test";
+import type { ScenarioCapabilityProfile } from "@rezi-ui/core/testing";
+import {
+  buildPtyTargetEnv,
+  parsePtyTargetNativeConfig,
+  parsePtyTargetScenarioId,
+  resolvePtyCapabilityProfile,
+} from "../testing/index.js";
+
+const fullProfile: ScenarioCapabilityProfile = Object.freeze({
+  supportsMouse: true,
+  supportsBracketedPaste: true,
+  supportsFocusEvents: true,
+  supportsOsc52: true,
+  colorMode: "truecolor",
+});
+
+test("resolvePtyCapabilityProfile applies named reductions without widening other fields", () => {
+  const profile = resolvePtyCapabilityProfile(fullProfile, "keyboard-only");
+  assert.deepEqual(profile, {
+    ...fullProfile,
+    supportsMouse: false,
+  });
+});
+
+test("buildPtyTargetEnv encodes scenario id, native capability gates, and TERM overrides", () => {
+  const env = buildPtyTargetEnv({
+    scenarioId: "input-incomplete-paste-recovers",
+    capabilityProfile: Object.freeze({
+      supportsMouse: false,
+      supportsBracketedPaste: true,
+      supportsFocusEvents: false,
+      supportsOsc52: false,
+      colorMode: "16",
+    }),
+    env: Object.freeze({ EXTRA_FLAG: "1" }),
+  });
+
+  assert.equal(env["REZI_SCENARIO_ID"], "input-incomplete-paste-recovers");
+  assert.equal(env["TERM"], "xterm");
+  assert.equal(env["COLORTERM"], undefined);
+  assert.equal(env["EXTRA_FLAG"], "1");
+  assert.equal(env["ZIREAEL_CAP_MOUSE"], "0");
+  assert.equal(env["ZIREAEL_CAP_BRACKETED_PASTE"], "1");
+  assert.equal(env["ZIREAEL_CAP_FOCUS_EVENTS"], "0");
+  assert.equal(env["ZIREAEL_CAP_OSC52"], "0");
+
+  const nativeConfig = parsePtyTargetNativeConfig(env);
+  assert.deepEqual(nativeConfig, {
+    plat: {
+      enableMouse: false,
+      enableBracketedPaste: true,
+      enableFocusEvents: false,
+      enableOsc52: false,
+    },
+  });
+  assert.equal(parsePtyTargetScenarioId(env), "input-incomplete-paste-recovers");
+});

--- a/packages/node/src/__tests__/ptyTargetConfig.test.ts
+++ b/packages/node/src/__tests__/ptyTargetConfig.test.ts
@@ -8,6 +8,18 @@ import {
   resolvePtyCapabilityProfile,
 } from "../testing/index.js";
 
+type PtyTargetEnvAssertions = ReturnType<typeof buildPtyTargetEnv> &
+  Readonly<{
+    REZI_SCENARIO_ID?: string;
+    TERM?: string;
+    COLORTERM?: string;
+    EXTRA_FLAG?: string;
+    ZIREAEL_CAP_MOUSE?: string;
+    ZIREAEL_CAP_BRACKETED_PASTE?: string;
+    ZIREAEL_CAP_FOCUS_EVENTS?: string;
+    ZIREAEL_CAP_OSC52?: string;
+  }>;
+
 const fullProfile: ScenarioCapabilityProfile = Object.freeze({
   supportsMouse: true,
   supportsBracketedPaste: true,
@@ -35,16 +47,16 @@ test("buildPtyTargetEnv encodes scenario id, native capability gates, and TERM o
       colorMode: "16",
     }),
     env: Object.freeze({ EXTRA_FLAG: "1" }),
-  });
+  }) as PtyTargetEnvAssertions;
 
-  assert.equal(env["REZI_SCENARIO_ID"], "input-incomplete-paste-recovers");
-  assert.equal(env["TERM"], "xterm");
-  assert.equal(env["COLORTERM"], undefined);
-  assert.equal(env["EXTRA_FLAG"], "1");
-  assert.equal(env["ZIREAEL_CAP_MOUSE"], "0");
-  assert.equal(env["ZIREAEL_CAP_BRACKETED_PASTE"], "1");
-  assert.equal(env["ZIREAEL_CAP_FOCUS_EVENTS"], "0");
-  assert.equal(env["ZIREAEL_CAP_OSC52"], "0");
+  assert.equal(env.REZI_SCENARIO_ID, "input-incomplete-paste-recovers");
+  assert.equal(env.TERM, "xterm");
+  assert.equal(env.COLORTERM, undefined);
+  assert.equal(env.EXTRA_FLAG, "1");
+  assert.equal(env.ZIREAEL_CAP_MOUSE, "0");
+  assert.equal(env.ZIREAEL_CAP_BRACKETED_PASTE, "1");
+  assert.equal(env.ZIREAEL_CAP_FOCUS_EVENTS, "0");
+  assert.equal(env.ZIREAEL_CAP_OSC52, "0");
 
   const nativeConfig = parsePtyTargetNativeConfig(env);
   assert.deepEqual(nativeConfig, {

--- a/packages/node/src/__tests__/worker/testShims/configurableNative.ts
+++ b/packages/node/src/__tests__/worker/testShims/configurableNative.ts
@@ -14,6 +14,14 @@ type NativeCaps = Readonly<{
   sgrAttrsSupported: number;
 }>;
 
+type ConfigRecord = Readonly<{ testBehavior?: unknown }>;
+type TestBehaviorRecord = Readonly<{
+  caps?: unknown;
+  submitResult?: unknown;
+  presentResult?: unknown;
+  pollBytesBase64?: unknown;
+}>;
+
 type EngineState = Readonly<{
   destroyed: { value: boolean };
   queue: Uint8Array[];
@@ -50,13 +58,14 @@ function asPlainRecord(value: unknown): Record<string, unknown> | null {
 
 function readTestBehavior(config: unknown): Record<string, unknown> {
   const record = asPlainRecord(config);
-  const behavior = record === null ? null : asPlainRecord(record["testBehavior"]);
+  const typedRecord = record as ConfigRecord | null;
+  const behavior = typedRecord === null ? null : asPlainRecord(typedRecord.testBehavior);
   return behavior ?? {};
 }
 
 function readCapsOverride(config: unknown): NativeCaps {
-  const behavior = readTestBehavior(config);
-  const caps = asPlainRecord(behavior["caps"]);
+  const behavior = readTestBehavior(config) as TestBehaviorRecord;
+  const caps = asPlainRecord(behavior.caps);
   return Object.freeze({
     ...DEFAULT_CAPS,
     ...(caps ?? {}),
@@ -80,7 +89,7 @@ function getEngine(engineId: number): EngineState | null {
 
 export const native = {
   engineCreate(config?: object | null): number {
-    const behavior = readTestBehavior(config);
+    const behavior = readTestBehavior(config) as TestBehaviorRecord;
     const id = nextEngineId++;
     engines.set(
       id,
@@ -88,9 +97,9 @@ export const native = {
         destroyed: { value: false },
         queue: [],
         caps: readCapsOverride(config),
-        submitResult: readInt(behavior["submitResult"]),
-        presentResult: readInt(behavior["presentResult"]),
-        pollBytes: readBytes(behavior["pollBytesBase64"]),
+        submitResult: readInt(behavior.submitResult),
+        presentResult: readInt(behavior.presentResult),
+        pollBytes: readBytes(behavior.pollBytesBase64),
       }),
     );
     return id;

--- a/packages/node/src/__tests__/worker/testShims/configurableNative.ts
+++ b/packages/node/src/__tests__/worker/testShims/configurableNative.ts
@@ -1,0 +1,146 @@
+type NativeCaps = Readonly<{
+  colorMode: number;
+  supportsMouse: boolean;
+  supportsBracketedPaste: boolean;
+  supportsFocusEvents: boolean;
+  supportsOsc52: boolean;
+  supportsSyncUpdate: boolean;
+  supportsScrollRegion: boolean;
+  supportsCursorShape: boolean;
+  supportsOutputWaitWritable: boolean;
+  supportsUnderlineStyles?: boolean;
+  supportsColoredUnderlines?: boolean;
+  supportsHyperlinks?: boolean;
+  sgrAttrsSupported: number;
+}>;
+
+type EngineState = Readonly<{
+  destroyed: { value: boolean };
+  queue: Uint8Array[];
+  caps: NativeCaps;
+  submitResult: number | null;
+  presentResult: number | null;
+  pollBytes: Uint8Array | null;
+}>;
+
+const DEFAULT_CAPS: NativeCaps = Object.freeze({
+  colorMode: 2,
+  supportsMouse: true,
+  supportsBracketedPaste: true,
+  supportsFocusEvents: true,
+  supportsOsc52: false,
+  supportsSyncUpdate: true,
+  supportsScrollRegion: true,
+  supportsCursorShape: true,
+  supportsOutputWaitWritable: true,
+  supportsUnderlineStyles: false,
+  supportsColoredUnderlines: false,
+  supportsHyperlinks: false,
+  sgrAttrsSupported: 0xffffffff,
+});
+
+let nextEngineId = 1;
+const engines = new Map<number, EngineState>();
+
+function asPlainRecord(value: unknown): Record<string, unknown> | null {
+  return typeof value === "object" && value !== null && !Array.isArray(value)
+    ? (value as Record<string, unknown>)
+    : null;
+}
+
+function readTestBehavior(config: unknown): Record<string, unknown> {
+  const record = asPlainRecord(config);
+  const behavior = record === null ? null : asPlainRecord(record["testBehavior"]);
+  return behavior ?? {};
+}
+
+function readCapsOverride(config: unknown): NativeCaps {
+  const behavior = readTestBehavior(config);
+  const caps = asPlainRecord(behavior["caps"]);
+  return Object.freeze({
+    ...DEFAULT_CAPS,
+    ...(caps ?? {}),
+  });
+}
+
+function readInt(value: unknown): number | null {
+  return typeof value === "number" && Number.isInteger(value) ? value : null;
+}
+
+function readBytes(value: unknown): Uint8Array | null {
+  if (typeof value !== "string" || value.length === 0) return null;
+  return Uint8Array.from(Buffer.from(value, "base64"));
+}
+
+function getEngine(engineId: number): EngineState | null {
+  const engine = engines.get(engineId);
+  if (engine === undefined || engine.destroyed.value) return null;
+  return engine;
+}
+
+export const native = {
+  engineCreate(config?: object | null): number {
+    const behavior = readTestBehavior(config);
+    const id = nextEngineId++;
+    engines.set(
+      id,
+      Object.freeze({
+        destroyed: { value: false },
+        queue: [],
+        caps: readCapsOverride(config),
+        submitResult: readInt(behavior["submitResult"]),
+        presentResult: readInt(behavior["presentResult"]),
+        pollBytes: readBytes(behavior["pollBytesBase64"]),
+      }),
+    );
+    return id;
+  },
+
+  engineDestroy(engineId: number): void {
+    const engine = engines.get(engineId);
+    if (engine === undefined) return;
+    engine.destroyed.value = true;
+    engines.delete(engineId);
+  },
+
+  engineSubmitDrawlist(engineId: number, _drawlist: Uint8Array): number {
+    const engine = getEngine(engineId);
+    if (engine === null) return -1;
+    if (engine.submitResult !== null) return engine.submitResult;
+    return 0;
+  },
+
+  enginePresent(engineId: number): number {
+    const engine = getEngine(engineId);
+    if (engine === null) return -1;
+    if (engine.presentResult !== null) return engine.presentResult;
+    return 0;
+  },
+
+  enginePollEvents(engineId: number, _timeoutMs: number, out: Uint8Array): number {
+    const engine = getEngine(engineId);
+    if (engine === null) return -1;
+    const bytes = engine.pollBytes ?? engine.queue.shift();
+    if (bytes === undefined || bytes === null) return 0;
+    if (bytes.byteLength > out.byteLength) return -3;
+    out.set(bytes);
+    return bytes.byteLength;
+  },
+
+  enginePostUserEvent(engineId: number, tag: number, payload: Uint8Array): number {
+    const engine = getEngine(engineId);
+    if (engine === null) return -1;
+    const header = new Uint8Array([tag & 0xff, payload.byteLength & 0xff]);
+    engine.queue.push(Uint8Array.from([...header, ...payload]));
+    return 0;
+  },
+
+  engineSetConfig(engineId: number, _cfg?: object | null): number {
+    return getEngine(engineId) === null ? -1 : 0;
+  },
+
+  engineGetCaps(engineId: number): NativeCaps {
+    const engine = getEngine(engineId);
+    return engine?.caps ?? DEFAULT_CAPS;
+  },
+} as const;

--- a/packages/node/src/__tests__/worker_integration.test.ts
+++ b/packages/node/src/__tests__/worker_integration.test.ts
@@ -736,12 +736,7 @@ test("backend: SAB mailbox pressure drains repeated frame bursts without fatal l
 
   const burst = Array.from({ length: 32 }, (_, index) =>
     backend.requestFrame(
-      Uint8Array.from([
-        index & 0xff,
-        (index + 1) & 0xff,
-        (index + 2) & 0xff,
-        (index + 3) & 0xff,
-      ]),
+      Uint8Array.from([index & 0xff, (index + 1) & 0xff, (index + 2) & 0xff, (index + 3) & 0xff]),
     ),
   );
   const settled = await Promise.allSettled(burst);

--- a/packages/node/src/__tests__/worker_integration.test.ts
+++ b/packages/node/src/__tests__/worker_integration.test.ts
@@ -70,6 +70,10 @@ function makeWorker(): Worker {
   return new Worker(entry, options);
 }
 
+function shimUrl(path: string): string {
+  return new URL(path, import.meta.url).href;
+}
+
 function waitFor(worker: Worker, pred: (m: Msg) => boolean): Promise<Msg> {
   return new Promise((resolve, reject) => {
     const onMsg = (m: unknown) => {
@@ -714,6 +718,46 @@ test("backend: mailbox resolves coalesced frame sequences", async () => {
   backend.dispose();
 });
 
+test("backend: SAB mailbox pressure drains repeated frame bursts without fatal loop", async () => {
+  const shim = new URL("./worker/testShims/mockNative.js", import.meta.url).href;
+  const backend = createNodeBackendInternal({
+    config: {
+      executionMode: "worker",
+      fpsCap: 1000,
+      maxEventBytes: 1024,
+      frameTransport: "sab",
+      frameSabSlotCount: 2,
+      frameSabSlotBytes: 256,
+    },
+    nativeShimModule: shim,
+  });
+
+  await backend.start();
+
+  const burst = Array.from({ length: 32 }, (_, index) =>
+    backend.requestFrame(
+      Uint8Array.from([
+        index & 0xff,
+        (index + 1) & 0xff,
+        (index + 2) & 0xff,
+        (index + 3) & 0xff,
+      ]),
+    ),
+  );
+  const settled = await Promise.allSettled(burst);
+  assert.equal(
+    settled.every((entry) => entry.status === "fulfilled"),
+    true,
+    JSON.stringify(settled),
+  );
+
+  // A final frame after the burst proves the backend stays live after pressure.
+  await backend.requestFrame(Uint8Array.from([201, 202, 203, 204]));
+
+  await backend.stop();
+  backend.dispose();
+});
+
 test("backend: requestFrame settles asynchronously after worker completion", async () => {
   const shim = new URL("./worker/testShims/mockNative.js", import.meta.url).href;
   const backend = createNodeBackendInternal({
@@ -1085,7 +1129,7 @@ test("backend: frame submission failure becomes fatal ZRUI_BACKEND_ERROR", async
 });
 
 test("backend: getCaps returns defaults before start and worker caps after start", async () => {
-  const shim = new URL("./worker/testShims/mockNative.js", import.meta.url).href;
+  const shim = shimUrl("./worker/testShims/mockNative.js");
   const backend = createNodeBackendInternal({
     config: { fpsCap: 1000, maxEventBytes: 1024 },
     nativeShimModule: shim,
@@ -1113,6 +1157,63 @@ test("backend: getCaps returns defaults before start and worker caps after start
   });
 
   await backend.stop();
+  backend.dispose();
+});
+
+test("backend: configurable native shim can override reported capabilities", async () => {
+  const shim = shimUrl("./worker/testShims/configurableNative.js");
+  const backend = createNodeBackendInternal({
+    config: {
+      fpsCap: 1000,
+      maxEventBytes: 1024,
+      nativeConfig: {
+        testBehavior: {
+          caps: {
+            supportsMouse: false,
+            supportsBracketedPaste: false,
+            supportsFocusEvents: false,
+            supportsOsc52: true,
+            colorMode: 1,
+          },
+        },
+      },
+    },
+    nativeShimModule: shim,
+  });
+
+  await backend.start();
+  const caps = await backend.getCaps();
+  assert.equal(caps.supportsMouse, false);
+  assert.equal(caps.supportsBracketedPaste, false);
+  assert.equal(caps.supportsFocusEvents, false);
+  assert.equal(caps.supportsOsc52, true);
+  assert.equal(caps.colorMode, 1);
+
+  await backend.stop();
+  backend.dispose();
+});
+
+test("backend: configurable native shim can force engine present failures", async () => {
+  const shim = shimUrl("./worker/testShims/configurableNative.js");
+  const backend = createNodeBackendInternal({
+    config: {
+      fpsCap: 1000,
+      maxEventBytes: 1024,
+      nativeConfig: {
+        testBehavior: {
+          presentResult: -2,
+        },
+      },
+    },
+    nativeShimModule: shim,
+  });
+
+  await backend.start();
+
+  await assert.rejects(backend.requestFrame(new Uint8Array([1, 2, 3, 4])), (error) => {
+    return error instanceof ZrUiError && error.code === "ZRUI_BACKEND_ERROR";
+  });
+
   backend.dispose();
 });
 
@@ -1156,9 +1257,9 @@ test("backend: perfSnapshot returns valid structure when REZI_PERF is enabled", 
   assert.ok("phases" in snapshot);
   assert.ok(typeof snapshot.phases === "object");
 
-  // Each phase should have the expected structure if present
-  for (const [phase, stats] of Object.entries(snapshot.phases)) {
-    assert.ok(typeof phase === "string");
+  // Each perf bucket should have the expected structure if present.
+  for (const [bucketName, stats] of Object.entries(snapshot.phases)) {
+    assert.ok(typeof bucketName === "string");
     assert.ok(stats !== null && typeof stats === "object");
     if (stats) {
       const s = stats as { count?: number; avg?: number; p50?: number; p95?: number; max?: number };

--- a/packages/node/src/testing/index.ts
+++ b/packages/node/src/testing/index.ts
@@ -9,6 +9,14 @@ export {
   type PtyScenarioHarnessTarget,
 } from "./ptyScenario.js";
 export {
+  buildPtyTargetEnv,
+  parsePtyTargetNativeConfig,
+  parsePtyTargetScenarioId,
+  resolvePtyCapabilityProfile,
+  type PtyCapabilityProfileInput,
+  type PtyCapabilityProfileName,
+} from "./ptyTargetConfig.js";
+export {
   createTerminalScreen,
   type TerminalScreenCursor,
   type TerminalScreenSnapshot,

--- a/packages/node/src/testing/ptyHarness.ts
+++ b/packages/node/src/testing/ptyHarness.ts
@@ -34,15 +34,17 @@ export async function startPtyHarness(opts: StartPtyHarnessOptions): Promise<Pty
   const filteredEnv = Object.fromEntries(
     Object.entries(opts.env ?? {}).filter(([, value]) => value !== undefined),
   ) as Readonly<Record<string, string> & { FORCE_COLOR?: string }>;
+  const termName =
+    filteredEnv["TERM"] ?? (process.platform === "win32" ? "xterm" : "xterm-256color");
   const term = pty.spawn(opts.command, [...(opts.args ?? [])], {
-    name: process.platform === "win32" ? "xterm" : "xterm-256color",
+    name: termName,
     cols: opts.cols,
     rows: opts.rows,
     cwd: opts.cwd,
     env: {
       ...inheritedEnv,
       ...filteredEnv,
-      TERM: process.platform === "win32" ? "xterm" : "xterm-256color",
+      TERM: termName,
       COLUMNS: String(opts.cols),
       LINES: String(opts.rows),
       FORCE_COLOR: filteredEnv.FORCE_COLOR ?? "1",

--- a/packages/node/src/testing/ptyHarness.ts
+++ b/packages/node/src/testing/ptyHarness.ts
@@ -33,9 +33,8 @@ export async function startPtyHarness(opts: StartPtyHarnessOptions): Promise<Pty
   ) as Readonly<Record<string, string>>;
   const filteredEnv = Object.fromEntries(
     Object.entries(opts.env ?? {}).filter(([, value]) => value !== undefined),
-  ) as Readonly<Record<string, string> & { FORCE_COLOR?: string }>;
-  const termName =
-    filteredEnv["TERM"] ?? (process.platform === "win32" ? "xterm" : "xterm-256color");
+  ) as Readonly<Record<string, string> & { TERM?: string; FORCE_COLOR?: string }>;
+  const termName = filteredEnv.TERM ?? (process.platform === "win32" ? "xterm" : "xterm-256color");
   const term = pty.spawn(opts.command, [...(opts.args ?? [])], {
     name: termName,
     cols: opts.cols,

--- a/packages/node/src/testing/ptyScenario.ts
+++ b/packages/node/src/testing/ptyScenario.ts
@@ -30,8 +30,8 @@ import {
   ZR_KEY_UP,
 } from "@rezi-ui/core/keybindings";
 import {
-  type ScenarioCursorSnapshot,
   type ScenarioCapabilityProfile,
+  type ScenarioCursorSnapshot,
   type ScenarioDefinition,
   type ScenarioMismatch,
   type ScenarioRunResult,
@@ -41,9 +41,9 @@ import {
 } from "@rezi-ui/core/testing";
 import { startPtyHarness } from "./ptyHarness.js";
 import {
+  type PtyCapabilityProfileInput,
   buildPtyTargetEnv,
   resolvePtyCapabilityProfile,
-  type PtyCapabilityProfileInput,
 } from "./ptyTargetConfig.js";
 import type { TerminalScreenCursor } from "./screen.js";
 

--- a/packages/node/src/testing/ptyScenario.ts
+++ b/packages/node/src/testing/ptyScenario.ts
@@ -31,6 +31,7 @@ import {
 } from "@rezi-ui/core/keybindings";
 import {
   type ScenarioCursorSnapshot,
+  type ScenarioCapabilityProfile,
   type ScenarioDefinition,
   type ScenarioMismatch,
   type ScenarioRunResult,
@@ -39,6 +40,11 @@ import {
   validateScenarioDefinition,
 } from "@rezi-ui/core/testing";
 import { startPtyHarness } from "./ptyHarness.js";
+import {
+  buildPtyTargetEnv,
+  resolvePtyCapabilityProfile,
+  type PtyCapabilityProfileInput,
+} from "./ptyTargetConfig.js";
 import type { TerminalScreenCursor } from "./screen.js";
 
 export type PtyScenarioHarnessTarget = Readonly<{
@@ -46,6 +52,7 @@ export type PtyScenarioHarnessTarget = Readonly<{
   command: string;
   args?: readonly string[];
   env?: Readonly<Record<string, string | undefined>>;
+  capabilityProfile?: PtyCapabilityProfileInput;
 }>;
 
 type HarnessCommand = Readonly<{ type: "stop" }>;
@@ -289,6 +296,8 @@ function eventToInputStep(
     }
     case "resize":
       return Object.freeze({ kind: "resize", cols: step.event.cols, rows: step.event.rows });
+    case "terminalBytes":
+      return Object.freeze({ kind: "write", data: step.event.bytes });
     case "key":
       return Object.freeze({ kind: "write", data: keyToBytes(step.event.key, step.event.mods) });
   }
@@ -489,12 +498,12 @@ function capabilityMismatches(
     ["supportsOsc52", scenario.capabilityProfile.supportsOsc52, actual.supportsOsc52],
   ] as const;
   for (const [name, required, supported] of capabilityChecks) {
-    if (!required || supported) continue;
+    if (required === supported) continue;
     mismatches.push({
       code: "ZR_SCENARIO_UNSUPPORTED",
       path: `capabilityProfile.${name}`,
-      detail: `PTY target does not support required capability ${name}`,
-      expected: true,
+      detail: `PTY target capability ${name} does not match the scenario requirement`,
+      expected: required,
       actual: supported,
     });
   }
@@ -595,15 +604,23 @@ export async function runPtyScenario(
     lastRenderAt: { value: Date.now() },
   });
   const control = await createControlServer(state);
+  const launchProfile: ScenarioCapabilityProfile = resolvePtyCapabilityProfile(
+    opts.scenario.capabilityProfile,
+    opts.target.capabilityProfile,
+  );
   const harness = await startPtyHarness(
     Object.freeze({
       cwd: opts.target.cwd,
       command: opts.target.command,
       ...(opts.target.args !== undefined ? { args: opts.target.args } : {}),
-      env: {
-        ...(opts.target.env ?? {}),
+      env: Object.freeze({
+        ...buildPtyTargetEnv({
+          scenarioId: opts.scenario.id,
+          capabilityProfile: launchProfile,
+          ...(opts.target.env === undefined ? {} : { env: opts.target.env }),
+        }),
         REZI_SCENARIO_CTRL_PORT: String(control.port),
-      },
+      }),
       cols: opts.scenario.viewport.cols,
       rows: opts.scenario.viewport.rows,
     }),

--- a/packages/node/src/testing/ptyTargetConfig.ts
+++ b/packages/node/src/testing/ptyTargetConfig.ts
@@ -45,11 +45,7 @@ export function resolvePtyCapabilityProfile(
   input: PtyCapabilityProfileInput | undefined = undefined,
 ): ScenarioCapabilityProfile {
   const overrides =
-    input === undefined
-      ? base
-      : typeof input === "string"
-        ? namedProfileOverrides(input)
-        : input;
+    input === undefined ? base : typeof input === "string" ? namedProfileOverrides(input) : input;
   return Object.freeze({
     ...base,
     ...overrides,
@@ -106,9 +102,7 @@ export function buildPtyTargetEnv(
     ...(args.env ?? {}),
     ...colorEnv,
     [PTY_TARGET_CAP_MOUSE_ENV]: args.capabilityProfile.supportsMouse ? "1" : "0",
-    [PTY_TARGET_CAP_BRACKETED_PASTE_ENV]: args.capabilityProfile.supportsBracketedPaste
-      ? "1"
-      : "0",
+    [PTY_TARGET_CAP_BRACKETED_PASTE_ENV]: args.capabilityProfile.supportsBracketedPaste ? "1" : "0",
     [PTY_TARGET_CAP_FOCUS_EVENTS_ENV]: args.capabilityProfile.supportsFocusEvents ? "1" : "0",
     [PTY_TARGET_CAP_OSC52_ENV]: args.capabilityProfile.supportsOsc52 ? "1" : "0",
     [PTY_TARGET_SCENARIO_ID_ENV]: args.scenarioId,

--- a/packages/node/src/testing/ptyTargetConfig.ts
+++ b/packages/node/src/testing/ptyTargetConfig.ts
@@ -1,0 +1,145 @@
+import type { ScenarioCapabilityProfile } from "@rezi-ui/core/testing";
+
+type EnvMap = Readonly<Record<string, string | undefined>>;
+
+export const PTY_TARGET_SCENARIO_ID_ENV = "REZI_SCENARIO_ID" as const;
+export const PTY_TARGET_NATIVE_CONFIG_ENV = "REZI_SCENARIO_NATIVE_CONFIG" as const;
+export const PTY_TARGET_CAP_MOUSE_ENV = "ZIREAEL_CAP_MOUSE" as const;
+export const PTY_TARGET_CAP_BRACKETED_PASTE_ENV = "ZIREAEL_CAP_BRACKETED_PASTE" as const;
+export const PTY_TARGET_CAP_FOCUS_EVENTS_ENV = "ZIREAEL_CAP_FOCUS_EVENTS" as const;
+export const PTY_TARGET_CAP_OSC52_ENV = "ZIREAEL_CAP_OSC52" as const;
+
+export type PtyCapabilityProfileName =
+  | "default-terminal"
+  | "keyboard-only"
+  | "paste-fallback"
+  | "focus-fallback"
+  | "clipboard-local-only"
+  | "low-color";
+
+export type PtyCapabilityProfileInput =
+  | PtyCapabilityProfileName
+  | Readonly<Partial<ScenarioCapabilityProfile>>;
+
+function namedProfileOverrides(
+  name: PtyCapabilityProfileName,
+): Readonly<Partial<ScenarioCapabilityProfile>> {
+  switch (name) {
+    case "default-terminal":
+      return Object.freeze({});
+    case "keyboard-only":
+      return Object.freeze({ supportsMouse: false });
+    case "paste-fallback":
+      return Object.freeze({ supportsBracketedPaste: false });
+    case "focus-fallback":
+      return Object.freeze({ supportsFocusEvents: false });
+    case "clipboard-local-only":
+      return Object.freeze({ supportsOsc52: false });
+    case "low-color":
+      return Object.freeze({ colorMode: "16" });
+  }
+}
+
+export function resolvePtyCapabilityProfile(
+  base: ScenarioCapabilityProfile,
+  input: PtyCapabilityProfileInput | undefined = undefined,
+): ScenarioCapabilityProfile {
+  const overrides =
+    input === undefined
+      ? base
+      : typeof input === "string"
+        ? namedProfileOverrides(input)
+        : input;
+  return Object.freeze({
+    ...base,
+    ...overrides,
+  });
+}
+
+function termEnvForColorMode(colorMode: ScenarioCapabilityProfile["colorMode"]): EnvMap {
+  switch (colorMode) {
+    case "none":
+      return Object.freeze({
+        TERM: "dumb",
+        COLORTERM: undefined,
+      });
+    case "16":
+      return Object.freeze({
+        TERM: "xterm",
+        COLORTERM: undefined,
+      });
+    case "256":
+      return Object.freeze({
+        TERM: "xterm-256color",
+        COLORTERM: undefined,
+      });
+    case "truecolor":
+      return Object.freeze({
+        TERM: "xterm-256color",
+        COLORTERM: "truecolor",
+      });
+  }
+}
+
+function nativeConfigForCapabilities(
+  profile: ScenarioCapabilityProfile,
+): Readonly<Record<string, unknown>> {
+  return Object.freeze({
+    plat: Object.freeze({
+      enableMouse: profile.supportsMouse,
+      enableBracketedPaste: profile.supportsBracketedPaste,
+      enableFocusEvents: profile.supportsFocusEvents,
+      enableOsc52: profile.supportsOsc52,
+    }),
+  });
+}
+
+export function buildPtyTargetEnv(
+  args: Readonly<{
+    scenarioId: string;
+    capabilityProfile: ScenarioCapabilityProfile;
+    env?: EnvMap;
+  }>,
+): EnvMap {
+  const colorEnv = termEnvForColorMode(args.capabilityProfile.colorMode);
+  return Object.freeze({
+    ...(args.env ?? {}),
+    ...colorEnv,
+    [PTY_TARGET_CAP_MOUSE_ENV]: args.capabilityProfile.supportsMouse ? "1" : "0",
+    [PTY_TARGET_CAP_BRACKETED_PASTE_ENV]: args.capabilityProfile.supportsBracketedPaste
+      ? "1"
+      : "0",
+    [PTY_TARGET_CAP_FOCUS_EVENTS_ENV]: args.capabilityProfile.supportsFocusEvents ? "1" : "0",
+    [PTY_TARGET_CAP_OSC52_ENV]: args.capabilityProfile.supportsOsc52 ? "1" : "0",
+    [PTY_TARGET_SCENARIO_ID_ENV]: args.scenarioId,
+    [PTY_TARGET_NATIVE_CONFIG_ENV]: JSON.stringify(
+      nativeConfigForCapabilities(args.capabilityProfile),
+    ),
+  });
+}
+
+export function parsePtyTargetScenarioId(env: EnvMap = process.env as EnvMap): string {
+  const raw = env[PTY_TARGET_SCENARIO_ID_ENV];
+  if (typeof raw !== "string" || raw.trim().length === 0) {
+    throw new Error(`${PTY_TARGET_SCENARIO_ID_ENV} is required`);
+  }
+  return raw.trim();
+}
+
+export function parsePtyTargetNativeConfig(
+  env: EnvMap = process.env as EnvMap,
+): Readonly<Record<string, unknown>> {
+  const raw = env[PTY_TARGET_NATIVE_CONFIG_ENV];
+  if (typeof raw !== "string" || raw.trim().length === 0) return Object.freeze({});
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw) as unknown;
+  } catch (error: unknown) {
+    const detail = error instanceof Error ? error.message : String(error);
+    throw new Error(`${PTY_TARGET_NATIVE_CONFIG_ENV} must be valid JSON: ${detail}`);
+  }
+  if (typeof parsed !== "object" || parsed === null || Array.isArray(parsed)) {
+    throw new Error(`${PTY_TARGET_NATIVE_CONFIG_ENV} must be a JSON object`);
+  }
+  return Object.freeze({ ...(parsed as Record<string, unknown>) });
+}


### PR DESCRIPTION
## Scope

- add reusable backend failure controls for shared app-runtime tests
- add reusable worker/native failure controls for capability and present-result failures
- standardize PTY target capability profiles and PTY-only byte-stream input steps
- add terminal-real fallback coverage for incomplete paste, mouse-disabled focus retention, incomplete escapes, and resize storms
- add deterministic SAB mailbox-pressure coverage

## Reusable controls

- `StubBackend` failure queues for `start`, `pollEvents`, and `getCaps`
- `configurableNative` worker shim controls for capability overrides and `enginePresent` failures
- `ptyTargetConfig` helpers for scenario id wiring, capability profiles, and PTY target env construction

## Scenarios

- `input-incomplete-paste-recovers`
- `input-mouse-disabled-keeps-keyboard-focus`
- `input-incomplete-escape-recovers`
- `virtual-list-resize-storm-stays-interactive`
- existing modal coverage re-run through the standardized PTY path under reduced capabilities

## Verification

- `./node_modules/.bin/tsc -b packages/core/tsconfig.json packages/node/tsconfig.json --pretty false`
- `npm -w @rezi-ui/native run build:native`
- `node --test packages/core/dist/app/__tests__/backendFailureControls.test.js packages/core/dist/app/__tests__/eventPump.test.js packages/core/dist/app/__tests__/terminalProfile.test.js packages/core/dist/testing/__tests__/referenceScenario.semantic.test.js`
- `node --test packages/node/dist/__tests__/ptyTargetConfig.test.js packages/node/dist/__tests__/worker_integration.test.js packages/node/dist/__tests__/ptyScenario.test.js`
- `node --test packages/node/dist/__e2e__/terminal_io_contract.e2e.test.js`

## Known limitations

- select fallback remains limited to the existing keyboard-backed contract; pointer fallback is still under-specified
- tree failure presentation remains under-specified, so no strict visible tree-failure oracle is added here
- OSC52 fallback UX remains under-specified, so coverage stays at capability reduction and stability

Closes #324
Closes #349
Closes #350
Closes #351
Closes #352
Closes #353
Closes #354


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Expanded coverage with multiple reference scenarios (incomplete paste/escape, mouse fallback, virtual-list resize), PTY vs semantic alignment, backend failure handling, PTY target config, and new integration worker tests; added a configurable native shim for realistic engine behavior.

* **New Features**
  * Added utilities to build/parse PTY scenario environments and capability profiles; added support for terminal-bytes scripted input in scenario harnesses.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->