### PR TITLE
testing: cover link behavior

### DIFF
--- a/packages/core/src/app/__tests__/widgetRenderer.integration.test.ts
+++ b/packages/core/src/app/__tests__/widgetRenderer.integration.test.ts
@@ -1051,7 +1051,9 @@ describe("WidgetRenderer integration battery", () => {
       noRenderHooks(),
     );
     assert.ok(res.ok);
-    const text = createTestRenderer({ viewport: { cols: 40, rows: 10 } }).render(vnode).toText();
+    const text = createTestRenderer({ viewport: { cols: 40, rows: 10 } })
+      .render(vnode)
+      .toText();
     assert.equal(text.includes("https://example.com/docs"), true);
 
     const rect = renderer.getRectByIdIndex().get("docs-link");
@@ -1068,9 +1070,7 @@ describe("WidgetRenderer integration battery", () => {
     assert.equal(presses, 0);
     assert.equal(renderer.getFocusedId(), "docs-link");
 
-    const up = renderer.routeEngineEvent(
-      mouseEvent(clickX, clickY, 4, { timeMs: 2, buttons: 0 }),
-    );
+    const up = renderer.routeEngineEvent(mouseEvent(clickX, clickY, 4, { timeMs: 2, buttons: 0 }));
     assert.deepEqual(up.action, { id: "docs-link", action: "press" });
     assert.equal(presses, 1);
     assert.equal(renderer.getFocusedId(), "docs-link");
@@ -1149,9 +1149,7 @@ describe("WidgetRenderer integration battery", () => {
     const down = renderer.routeEngineEvent(
       mouseEvent(clickX, clickY, 3, { timeMs: 1, buttons: 1 }),
     );
-    const up = renderer.routeEngineEvent(
-      mouseEvent(clickX, clickY, 4, { timeMs: 2, buttons: 0 }),
-    );
+    const up = renderer.routeEngineEvent(mouseEvent(clickX, clickY, 4, { timeMs: 2, buttons: 0 }));
 
     assert.equal(down.action, undefined);
     assert.equal(up.action, undefined);

--- a/packages/core/src/app/__tests__/widgetRenderer.integration.test.ts
+++ b/packages/core/src/app/__tests__/widgetRenderer.integration.test.ts
@@ -1027,6 +1027,55 @@ describe("WidgetRenderer integration battery", () => {
     assert.equal(presses, 2);
   });
 
+  test("link without a label uses the url text for mouse focus and press", () => {
+    const backend = createNoopBackend();
+    const renderer = new WidgetRenderer<void>({
+      backend,
+      requestRender: () => {},
+    });
+
+    let presses = 0;
+    const vnode = ui.column({}, [
+      ui.link({
+        id: "docs-link",
+        url: "https://example.com/docs",
+        onPress: () => presses++,
+      }),
+    ]);
+
+    const res = renderer.submitFrame(
+      () => vnode,
+      undefined,
+      { cols: 40, rows: 10 },
+      defaultTheme,
+      noRenderHooks(),
+    );
+    assert.ok(res.ok);
+    const text = createTestRenderer({ viewport: { cols: 40, rows: 10 } }).render(vnode).toText();
+    assert.equal(text.includes("https://example.com/docs"), true);
+
+    const rect = renderer.getRectByIdIndex().get("docs-link");
+    assert.ok(rect !== undefined, "link rect should exist");
+    if (!rect) return;
+
+    const clickX = rect.x + Math.max(0, Math.floor((rect.w - 1) / 2));
+    const clickY = rect.y;
+
+    const down = renderer.routeEngineEvent(
+      mouseEvent(clickX, clickY, 3, { timeMs: 1, buttons: 1 }),
+    );
+    assert.equal(down.action, undefined);
+    assert.equal(presses, 0);
+    assert.equal(renderer.getFocusedId(), "docs-link");
+
+    const up = renderer.routeEngineEvent(
+      mouseEvent(clickX, clickY, 4, { timeMs: 2, buttons: 0 }),
+    );
+    assert.deepEqual(up.action, { id: "docs-link", action: "press" });
+    assert.equal(presses, 1);
+    assert.equal(renderer.getFocusedId(), "docs-link");
+  });
+
   test("disabled link is not focusable and ignores Enter/Space", () => {
     const backend = createNoopBackend();
     const renderer = new WidgetRenderer<void>({
@@ -1061,6 +1110,53 @@ describe("WidgetRenderer integration battery", () => {
     renderer.routeEngineEvent(keyEvent(2 /* ENTER */));
     renderer.routeEngineEvent(keyEvent(32 /* SPACE */));
     assert.equal(presses, 0);
+  });
+
+  test("disabled link ignores mouse clicks and stays unfocused", () => {
+    const backend = createNoopBackend();
+    const renderer = new WidgetRenderer<void>({
+      backend,
+      requestRender: () => {},
+    });
+
+    let presses = 0;
+    const vnode = ui.column({}, [
+      ui.link({
+        id: "docs-link",
+        url: "https://example.com",
+        label: "Docs",
+        disabled: true,
+        onPress: () => presses++,
+      }),
+    ]);
+
+    const res = renderer.submitFrame(
+      () => vnode,
+      undefined,
+      { cols: 40, rows: 10 },
+      defaultTheme,
+      noRenderHooks(),
+    );
+    assert.ok(res.ok);
+
+    const rect = renderer.getRectByIdIndex().get("docs-link");
+    assert.ok(rect !== undefined, "link rect should exist");
+    if (!rect) return;
+
+    const clickX = rect.x + Math.max(0, Math.floor((rect.w - 1) / 2));
+    const clickY = rect.y;
+
+    const down = renderer.routeEngineEvent(
+      mouseEvent(clickX, clickY, 3, { timeMs: 1, buttons: 1 }),
+    );
+    const up = renderer.routeEngineEvent(
+      mouseEvent(clickX, clickY, 4, { timeMs: 2, buttons: 0 }),
+    );
+
+    assert.equal(down.action, undefined);
+    assert.equal(up.action, undefined);
+    assert.equal(presses, 0);
+    assert.equal(renderer.getFocusedId(), null);
   });
 
   test("focusZone grid navigation moves by columns deterministically", () => {


### PR DESCRIPTION
## Summary

- add app-level link mouse behavior coverage for hit-tested click focus and press routing
- cover the default `label -> url` fallback at integration fidelity so the visible text and click path stay aligned

## Families Covered

- link

## Tests Added, Rewritten, Removed

- added app-level integration coverage in `packages/core/src/app/__tests__/widgetRenderer.integration.test.ts` for unlabeled link mouse focus + press
- added app-level integration coverage in the same file for disabled-link mouse click no-op behavior
- rewrote no existing tests in this PR
- removed no tests in this PR

## Implementation Bugs Fixed

- none; the behavior-first tests passed once added

## Commands Run

- `./node_modules/.bin/tsc -b packages/core/tsconfig.json --pretty false`
- `node --test packages/core/dist/app/__tests__/widgetRenderer.integration.test.js packages/core/dist/widgets/__tests__/basicWidgets.render.test.js packages/core/dist/runtime/__tests__/widgetMeta.test.js packages/core/dist/renderer/__tests__/focusIndicators.test.js`

## Unresolved Areas Left Explicit

- broader navigation widgets (`tabs`, `accordion`, `breadcrumb`, `pagination`) still need separate contract selection and should not be inferred from this link slice
- hyperlink metadata emission and older-builder degradation remain covered at lower-level render fidelity rather than app-level routing fidelity

## Dependency Note

- none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests for link mouse and focus behavior: verifies links without explicit labels render visible URL text, ensure mouse-down sets focus without triggering activation, and mouse-up produces a press action and increments press count while maintaining focus.
  * Added tests for disabled links confirming mouse interactions produce no action, onPress is not called, and focus remains unset.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->