### PR TITLE
testing: cover file node cache invalidation

### DIFF
--- a/packages/core/src/app/__tests__/fileNodeCache.test.ts
+++ b/packages/core/src/app/__tests__/fileNodeCache.test.ts
@@ -1,0 +1,76 @@
+import { assert, test } from "@rezi-ui/testkit";
+import { createTreeStateStore } from "../../runtime/localState.js";
+import type { FlattenedNode } from "../../widgets/tree.js";
+import type { FileNode } from "../../widgets/types.js";
+import { makeFileNodeFlatCache, readFileNodeFlatCache } from "../widgetRenderer/fileNodeCache.js";
+
+function makeData(leafPath: string): FileNode {
+  return Object.freeze({
+    name: "root",
+    path: "/",
+    type: "directory" as const,
+    children: Object.freeze([
+      Object.freeze({ name: leafPath.slice(1), path: leafPath, type: "file" as const }),
+    ]),
+  });
+}
+
+function makeFlatNodes(data: FileNode): readonly FlattenedNode<FileNode>[] {
+  const root = data;
+  const leaf = data.children?.[0];
+  if (!leaf) return Object.freeze([]);
+  return Object.freeze([
+    {
+      node: root,
+      depth: 0,
+      siblingIndex: 0,
+      siblingCount: 1,
+      key: root.path,
+      parentKey: null,
+      hasChildren: true,
+      ancestorIsLast: Object.freeze([]),
+    },
+    {
+      node: leaf,
+      depth: 1,
+      siblingIndex: 0,
+      siblingCount: 1,
+      key: leaf.path,
+      parentKey: root.path,
+      hasChildren: false,
+      ancestorIsLast: Object.freeze([true]),
+    },
+  ] satisfies readonly FlattenedNode<FileNode>[]);
+}
+
+test("fileNodeCache returns cached flat nodes while data and expanded refs stay stable", () => {
+  const treeStore = createTreeStateStore();
+  const data = makeData("/old.txt");
+  const expanded = Object.freeze(["/"]);
+  const flatNodes = makeFlatNodes(data);
+
+  treeStore.set("picker", {
+    flatCache: makeFileNodeFlatCache(data, expanded, flatNodes),
+  });
+
+  const cached = readFileNodeFlatCache(treeStore.get("picker"), data, expanded);
+  assert.equal(cached, flatNodes);
+});
+
+test("fileNodeCache invalidates when data or expanded refs change", () => {
+  const treeStore = createTreeStateStore();
+  const data = makeData("/old.txt");
+  const expanded = Object.freeze(["/"]);
+  const flatNodes = makeFlatNodes(data);
+
+  treeStore.set("picker", {
+    flatCache: makeFileNodeFlatCache(data, expanded, flatNodes),
+  });
+
+  const nextData = makeData("/new.txt");
+  const nextExpanded = Object.freeze(["/"]);
+
+  assert.equal(readFileNodeFlatCache(treeStore.get("picker"), nextData, expanded), null);
+  assert.equal(readFileNodeFlatCache(treeStore.get("picker"), data, nextExpanded), null);
+  assert.equal(readFileNodeFlatCache(treeStore.get("picker"), data, expanded), flatNodes);
+});

--- a/packages/core/src/app/__tests__/filePickerRouting.contracts.test.ts
+++ b/packages/core/src/app/__tests__/filePickerRouting.contracts.test.ts
@@ -347,5 +347,4 @@ describe("file tree explorer routing contracts", () => {
     );
     assert.deepEqual(selected, []);
   });
-
 });

--- a/packages/core/src/app/__tests__/filePickerRouting.contracts.test.ts
+++ b/packages/core/src/app/__tests__/filePickerRouting.contracts.test.ts
@@ -126,41 +126,6 @@ describe("file picker routing contracts", () => {
     assert.deepEqual(selected, []);
   });
 
-  test("stale flat-cache data is ignored after data identity changes", () => {
-    const treeStore = createTreeStateStore();
-    const opened: string[] = [];
-    const makeData = (leafPath: string): FileNode =>
-      Object.freeze({
-        name: "root",
-        path: "/",
-        type: "directory" as const,
-        children: Object.freeze([
-          Object.freeze({ name: leafPath.slice(1), path: leafPath, type: "file" as const }),
-        ]),
-      });
-
-    const first: FilePickerProps = {
-      id: "fp-stale",
-      rootPath: "/",
-      data: makeData("/old.txt"),
-      expandedPaths: Object.freeze(["/"]),
-      selectedPath: "/old.txt",
-      onSelect: () => {},
-      onChange: () => {},
-      onPress: (path) => opened.push(path),
-    };
-
-    const second: FilePickerProps = {
-      ...first,
-      data: makeData("/new.txt"),
-      selectedPath: "/new.txt",
-    };
-
-    assert.equal(routeFilePickerKeyDown(keyDown(ZR_KEY_ENTER), first, treeStore), true);
-    assert.equal(routeFilePickerKeyDown(keyDown(ZR_KEY_ENTER), second, treeStore), true);
-    assert.deepEqual(opened, ["/old.txt", "/new.txt"]);
-  });
-
   test("multi-select uses selectedPath as the active keyboard target before selection", () => {
     const treeStore = createTreeStateStore();
     const opened: string[] = [];
@@ -255,7 +220,7 @@ describe("file picker routing contracts", () => {
     ]);
   });
 
-  test("filter and showHidden update the visible routing surface and flat-cache contract", () => {
+  test("filter and showHidden update the visible routing surface", () => {
     const treeStore = createTreeStateStore();
     const selected: string[] = [];
     const opened: string[] = [];
@@ -383,37 +348,4 @@ describe("file tree explorer routing contracts", () => {
     assert.deepEqual(selected, []);
   });
 
-  test("stale flat-cache data is ignored after data identity changes", () => {
-    const treeStore = createTreeStateStore();
-    const activated: string[] = [];
-    const makeData = (leafPath: string): FileNode =>
-      Object.freeze({
-        name: "root",
-        path: "/",
-        type: "directory" as const,
-        children: Object.freeze([
-          Object.freeze({ name: leafPath.slice(1), path: leafPath, type: "file" as const }),
-        ]),
-      });
-
-    const first: FileTreeExplorerProps = {
-      id: "fte-stale",
-      data: makeData("/old.txt"),
-      expanded: Object.freeze(["/"]),
-      selected: "/old.txt",
-      onSelect: () => {},
-      onChange: () => {},
-      onPress: (node) => activated.push(node.path),
-    };
-
-    const second: FileTreeExplorerProps = {
-      ...first,
-      data: makeData("/new.txt"),
-      selected: "/new.txt",
-    };
-
-    assert.equal(routeFileTreeExplorerKeyDown(keyDown(ZR_KEY_ENTER), first, treeStore), true);
-    assert.equal(routeFileTreeExplorerKeyDown(keyDown(ZR_KEY_ENTER), second, treeStore), true);
-    assert.deepEqual(activated, ["/old.txt", "/new.txt"]);
-  });
 });


### PR DESCRIPTION
## Summary

- replace stale route-level flat-cache assertions with dedicated lower-level `fileNodeCache` contract tests
- keep the public file picker and file tree routing suites focused on visible keyboard and mouse behavior

## Families Covered

- filePicker
- fileTreeExplorer
- fileNodeCache

## Tests Added, Rewritten, Removed

- added lower-level cache coverage in `packages/core/src/app/__tests__/fileNodeCache.test.ts` for stable cache reuse and invalidation when `data` or `expanded` references change
- removed route-level stale-cache assertions from `packages/core/src/app/__tests__/filePickerRouting.contracts.test.ts` for file picker and file tree explorer
- retained the public routing coverage in the same file for keyboard, multi-select, and `filter` / `showHidden` visible routing behavior

## Implementation Bugs Fixed

- none; this PR tightens contract placement only

## Commands Run

- `./node_modules/.bin/tsc -b packages/core/tsconfig.json --pretty false`
- `node --test packages/core/dist/app/__tests__/fileNodeCache.test.js packages/core/dist/app/__tests__/filePickerRouting.contracts.test.js packages/core/dist/app/__tests__/widgetRenderer.integration.test.js packages/core/dist/app/__tests__/fileTreeExplorer.contextMenu.test.js`

## Unresolved Areas Left Explicit

- this PR does not broaden public file picker or file tree explorer behavior coverage beyond the retained routing and integration suites
- broader navigation-family contract selection remains separate work

## Dependency Note

- none

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests verifying flattened file-node caching and that cached results are only used when input references remain stable.
  * Simplified file picker/tree contract tests: removed certain activation assertions tied to prior cache assumptions and refocused routing tests on keyboard navigation and focus behavior.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->