### PR TITLE
testing: cover breadcrumb behavior

### DIFF
--- a/packages/core/src/app/__tests__/widgetRenderer.integration.test.ts
+++ b/packages/core/src/app/__tests__/widgetRenderer.integration.test.ts
@@ -14,6 +14,7 @@ import { DEFAULT_TERMINAL_CAPS } from "../../terminalCaps.js";
 import { createTestRenderer } from "../../testing/index.js";
 import { defaultTheme } from "../../theme/defaultTheme.js";
 import { getAccordionTriggerId } from "../../widgets/accordion.js";
+import { getBreadcrumbItemId } from "../../widgets/breadcrumb.js";
 import { getTabsTriggerId } from "../../widgets/tabs.js";
 import { TOAST_HEIGHT, getToastActionFocusId } from "../../widgets/toast.js";
 import { createApp } from "../createApp.js";
@@ -1459,6 +1460,59 @@ describe("WidgetRenderer integration battery", () => {
 
     renderer.routeEngineEvent(keyEvent(1 /* ESC */));
     assert.equal(renderer.getFocusedId(), generalTrigger);
+  });
+
+  test("breadcrumb keyboard focus moves across clickable items and Enter activates", () => {
+    const backend = createNoopBackend();
+    const renderer = new WidgetRenderer<void>({
+      backend,
+      requestRender: () => {},
+    });
+
+    const presses: string[] = [];
+    const vnode = ui.column({}, [
+      ui.breadcrumb({
+        id: "crumbs",
+        items: [
+          { label: "Home", onPress: () => presses.push("home") },
+          { label: "Docs", onPress: () => presses.push("docs") },
+          { label: "API" },
+        ],
+      }),
+    ]);
+
+    const firstId = getBreadcrumbItemId("crumbs", 0);
+    const secondId = getBreadcrumbItemId("crumbs", 1);
+    const lastId = getBreadcrumbItemId("crumbs", 2);
+
+    const res = renderer.submitFrame(
+      () => vnode,
+      undefined,
+      { cols: 50, rows: 8 },
+      defaultTheme,
+      noRenderHooks(),
+    );
+    assert.ok(res.ok);
+
+    const rects = renderer.getRectByIdIndex();
+    assert.ok(rects.get(firstId) !== undefined);
+    assert.ok(rects.get(secondId) !== undefined);
+    assert.equal(rects.get(lastId), undefined);
+
+    renderer.routeEngineEvent(keyEvent(3 /* TAB */));
+    assert.equal(renderer.getFocusedId(), firstId);
+
+    renderer.routeEngineEvent(keyEvent(3 /* TAB */));
+    assert.equal(renderer.getFocusedId(), secondId);
+
+    renderer.routeEngineEvent(keyEvent(3 /* TAB */, ZR_MOD_SHIFT));
+    assert.equal(renderer.getFocusedId(), firstId);
+
+    renderer.routeEngineEvent(keyEvent(3 /* TAB */));
+    assert.equal(renderer.getFocusedId(), secondId);
+
+    renderer.routeEngineEvent(keyEvent(2 /* ENTER */));
+    assert.deepEqual(presses, ["docs"]);
   });
 
   test("focusZone grid navigation moves by columns deterministically", () => {

--- a/packages/core/src/renderer/renderToDrawlist/widgets/navigation.ts
+++ b/packages/core/src/renderer/renderToDrawlist/widgets/navigation.ts
@@ -11,7 +11,6 @@ import {
   tabsRecipe,
 } from "../../../ui/recipes.js";
 import { getAccordionHeadersZoneId } from "../../../widgets/accordion.js";
-import { getBreadcrumbZoneId } from "../../../widgets/breadcrumb.js";
 import { getPaginationZoneId } from "../../../widgets/pagination.js";
 import { getTabsBarZoneId } from "../../../widgets/tabs.js";
 import { isVisibleRect } from "../indices.js";
@@ -127,9 +126,6 @@ function resolveNavigationControlZoneId(node: RuntimeInstance): string | undefin
     case "accordion": {
       return getAccordionHeadersZoneId(id);
     }
-    case "breadcrumb": {
-      return getBreadcrumbZoneId(id);
-    }
     case "pagination": {
       return getPaginationZoneId(id);
     }
@@ -143,6 +139,17 @@ function buildNavigationControlOverrides(
   dsProps: NavigationDsProps,
 ): ReadonlyMap<RuntimeInstance["instanceId"], RuntimeInstance> | null {
   if (!hasNavigationDsProps(dsProps)) return null;
+
+  if (node.vnode.kind === "breadcrumb") {
+    const overrides: [RuntimeInstance["instanceId"], RuntimeInstance][] = [];
+    for (const child of node.children) {
+      if (!child) continue;
+      const patchedChild = cloneWithNavigationDsProps(child, dsProps);
+      if (patchedChild === child) continue;
+      overrides.push([child.instanceId, patchedChild]);
+    }
+    return overrides.length === 0 ? null : new Map(overrides);
+  }
 
   const controlZoneId = resolveNavigationControlZoneId(node);
   if (controlZoneId === undefined) return null;

--- a/packages/core/src/widgets/__tests__/breadcrumb.test.ts
+++ b/packages/core/src/widgets/__tests__/breadcrumb.test.ts
@@ -90,9 +90,10 @@ describe("breadcrumb vnode construction", () => {
     }
   });
 
-  test("createBreadcrumbVNode applies custom separator", () => {
+  test("buildBreadcrumbChildren applies custom separator", () => {
     const children = buildBreadcrumbChildren({ ...props, separator: " / " });
     const row = children[0];
+    assert.equal(row?.kind, "row");
     if (row?.kind !== "row") return;
     const sep = row.children[1];
     assert.equal(sep?.kind, "text");

--- a/packages/core/src/widgets/__tests__/breadcrumb.test.ts
+++ b/packages/core/src/widgets/__tests__/breadcrumb.test.ts
@@ -2,14 +2,12 @@ import { assert, describe, test } from "@rezi-ui/testkit";
 import {
   DEFAULT_BREADCRUMB_SEPARATOR,
   buildBreadcrumbChildren,
-  createBreadcrumbVNode,
   getBreadcrumbItemId,
   getBreadcrumbZoneId,
   parseBreadcrumbItemId,
   resolveBreadcrumbClickableIndices,
   resolveBreadcrumbSeparator,
 } from "../breadcrumb.js";
-import { ui } from "../ui.js";
 
 const props = {
   id: "crumbs-main",
@@ -60,21 +58,29 @@ describe("breadcrumb helpers", () => {
 });
 
 describe("breadcrumb vnode construction", () => {
-  test("buildBreadcrumbChildren builds focus-zone wrapped row", () => {
+  test("buildBreadcrumbChildren includes clickable breadcrumb buttons before the current item", () => {
     const children = buildBreadcrumbChildren(props);
     assert.equal(children.length, 1);
-    assert.equal(children[0]?.kind, "focusZone");
-    if (children[0]?.kind !== "focusZone") return;
-    assert.equal(children[0].children.length, 1);
-    assert.equal(children[0].children[0]?.kind, "row");
+    const row = children[0];
+    assert.equal(row?.kind, "row");
+    if (row?.kind !== "row") return;
+    const first = row.children[0];
+    const second = row.children[2];
+    assert.equal(first?.kind, "button");
+    assert.equal(second?.kind, "button");
+    if (first?.kind === "button") {
+      assert.equal(first.props.id, getBreadcrumbItemId(props.id, 0));
+      assert.equal(first.props.label, "Home");
+    }
+    if (second?.kind === "button") {
+      assert.equal(second.props.id, getBreadcrumbItemId(props.id, 1));
+      assert.equal(second.props.label, "Docs");
+    }
   });
 
   test("last breadcrumb item is rendered as non-clickable text", () => {
     const children = buildBreadcrumbChildren(props);
-    const zone = children[0];
-    assert.equal(zone?.kind, "focusZone");
-    if (zone?.kind !== "focusZone") return;
-    const row = zone.children[0];
+    const row = children[0];
     assert.equal(row?.kind, "row");
     if (row?.kind !== "row") return;
     const last = row.children[row.children.length - 1];
@@ -84,29 +90,14 @@ describe("breadcrumb vnode construction", () => {
     }
   });
 
-  test("createBreadcrumbVNode emits breadcrumb kind", () => {
-    const vnode = createBreadcrumbVNode(props);
-    assert.equal(vnode.kind, "breadcrumb");
-    assert.equal(vnode.children.length, 1);
-  });
-
   test("createBreadcrumbVNode applies custom separator", () => {
-    const vnode = createBreadcrumbVNode({ ...props, separator: " / " });
-    assert.equal(vnode.kind, "breadcrumb");
-    if (vnode.kind !== "breadcrumb") return;
-    const zone = vnode.children[0];
-    if (zone?.kind !== "focusZone") return;
-    const row = zone.children[0];
+    const children = buildBreadcrumbChildren({ ...props, separator: " / " });
+    const row = children[0];
     if (row?.kind !== "row") return;
     const sep = row.children[1];
     assert.equal(sep?.kind, "text");
     if (sep?.kind === "text") {
       assert.equal(sep.text, " / ");
     }
-  });
-
-  test("ui.breadcrumb returns a layout-transparent composite wrapper vnode", () => {
-    const vnode = ui.breadcrumb({ items: props.items });
-    assert.equal(vnode.kind, "fragment");
   });
 });

--- a/packages/core/src/widgets/breadcrumb.ts
+++ b/packages/core/src/widgets/breadcrumb.ts
@@ -97,19 +97,7 @@ export function buildBreadcrumbChildren(
     children: Object.freeze(rowChildren),
   };
 
-  const zone: VNode = {
-    kind: "focusZone",
-    props: {
-      id: getBreadcrumbZoneId(props.id),
-      tabIndex: 0,
-      navigation: "linear",
-      columns: 1,
-      wrapAround: false,
-    },
-    children: Object.freeze([row]),
-  };
-
-  return Object.freeze([zone]);
+  return Object.freeze([row]);
 }
 
 export function createBreadcrumbVNode(props: BreadcrumbProps & Readonly<{ id: string }>): VNode {


### PR DESCRIPTION
## Summary
- cover `breadcrumb` keyboard focus movement and activation at renderer-integration fidelity
- fix breadcrumb keyboard traversal so `Tab` and `Shift+Tab` move across clickable crumbs as documented
- narrow lower-level breadcrumb tests to clickable-item semantics instead of wrapper shape

## Tests added, rewritten, removed
- added renderer-integration coverage in `packages/core/src/app/__tests__/widgetRenderer.integration.test.ts` for `Tab`, `Shift+Tab`, and `Enter` on clickable breadcrumb items
- rewrote `packages/core/src/widgets/__tests__/breadcrumb.test.ts` to keep deterministic clickable-item and separator coverage without pinning `focusZone` / `fragment` wrapper shape
- removed no test files

## Implementation bugs fixed because valid tests exposed them
- `packages/core/src/widgets/breadcrumb.ts` no longer wraps clickable crumbs in a `focusZone`; the previous structure caused repeated `Tab` to cycle by zone traversal instead of moving crumb-by-crumb
- `packages/core/src/renderer/renderToDrawlist/widgets/navigation.ts` now applies breadcrumb design-system overrides directly to child buttons after the wrapper removal

## Test commands run
- `./node_modules/.bin/tsc -b packages/core/tsconfig.json --pretty false`
- `node --test packages/core/dist/app/__tests__/widgetRenderer.integration.test.js packages/core/dist/widgets/__tests__/breadcrumb.test.js packages/core/dist/router/__tests__/helpers.test.js packages/core/dist/widgets/__tests__/widgetRenderSmoke.test.js`

## Remaining explicit gaps
- breadcrumb arrow-key behavior is still not documented as public contract and is left unasserted here
- `getBreadcrumbZoneId(...)` remains exported even though breadcrumb no longer uses a runtime focus-zone wrapper

## Dependency note
- no stack dependency


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added an integration test verifying breadcrumb keyboard navigation (Tab / Shift+Tab) and that Enter activates only the focused item.
  * Updated unit tests to reflect the breadcrumb’s new structure and to validate custom separator rendering.

* **Refactor**
  * Removed the breadcrumb focus-zone wrapper exposed to the renderer.
  * Applied navigation behavior at the individual breadcrumb-item level so items receive per-item navigation overrides.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->