### PR TITLE
testing: cover select behavior

### DIFF
--- a/packages/core/src/app/__tests__/selectRouting.test.ts
+++ b/packages/core/src/app/__tests__/selectRouting.test.ts
@@ -8,10 +8,7 @@ function keyDown(key: number): ZrevEvent {
   return { kind: "key", timeMs: 0, key, mods: 0, action: "down" };
 }
 
-function createSelect(
-  value: string,
-  onChange?: (next: string) => void,
-): SelectProps {
+function createSelect(value: string, onChange?: (next: string) => void): SelectProps {
   return {
     id: "theme",
     value,
@@ -24,10 +21,7 @@ function createSelect(
   };
 }
 
-function route(
-  event: ZrevEvent,
-  props: SelectProps,
-): ReturnType<typeof routeSelectKeyDown> {
+function route(event: ZrevEvent, props: SelectProps): ReturnType<typeof routeSelectKeyDown> {
   return routeSelectKeyDown(event, {
     focusedId: props.id,
     selectById: new Map([[props.id, props]]),

--- a/packages/core/src/app/__tests__/selectRouting.test.ts
+++ b/packages/core/src/app/__tests__/selectRouting.test.ts
@@ -1,0 +1,60 @@
+import { assert, describe, test } from "@rezi-ui/testkit";
+import type { ZrevEvent } from "../../events.js";
+import { ZR_KEY_DOWN, ZR_KEY_UP } from "../../keybindings/keyCodes.js";
+import type { SelectProps } from "../../widgets/types.js";
+import { routeSelectKeyDown } from "../widgetRenderer/keyboardRouting.js";
+
+function keyDown(key: number): ZrevEvent {
+  return { kind: "key", timeMs: 0, key, mods: 0, action: "down" };
+}
+
+function createSelect(
+  value: string,
+  onChange?: (next: string) => void,
+): SelectProps {
+  return {
+    id: "theme",
+    value,
+    options: Object.freeze([
+      { value: "dark", label: "Dark" },
+      { value: "light", label: "Light", disabled: true },
+      { value: "system", label: "System" },
+    ]),
+    ...(onChange ? { onChange } : {}),
+  };
+}
+
+function route(
+  event: ZrevEvent,
+  props: SelectProps,
+): ReturnType<typeof routeSelectKeyDown> {
+  return routeSelectKeyDown(event, {
+    focusedId: props.id,
+    selectById: new Map([[props.id, props]]),
+  });
+}
+
+describe("select routing contracts", () => {
+  test("ArrowUp and ArrowDown wrap across enabled options at the boundaries", () => {
+    const wrapDownChanges: string[] = [];
+    const downFromLast = route(
+      keyDown(ZR_KEY_DOWN),
+      createSelect("system", (next) => wrapDownChanges.push(next)),
+    );
+    assert.deepEqual(downFromLast, { needsRender: true });
+    assert.deepEqual(wrapDownChanges, ["dark"]);
+
+    const upChanges: string[] = [];
+    const upFromFirst = route(
+      keyDown(ZR_KEY_UP),
+      createSelect("dark", (next) => upChanges.push(next)),
+    );
+    assert.deepEqual(upFromFirst, { needsRender: true });
+    assert.deepEqual(upChanges, ["system"]);
+  });
+
+  test("select without onChange ignores arrow-key cycling commands", () => {
+    assert.equal(route(keyDown(ZR_KEY_DOWN), createSelect("dark")), null);
+    assert.equal(route(keyDown(ZR_KEY_UP), createSelect("dark")), null);
+  });
+});

--- a/packages/core/src/app/__tests__/widgetRenderer.integration.test.ts
+++ b/packages/core/src/app/__tests__/widgetRenderer.integration.test.ts
@@ -713,6 +713,73 @@ describe("WidgetRenderer integration battery", () => {
     assert.deepEqual(values, ["light", "system"]);
   });
 
+  test("select mouse click focuses without changing value and ArrowDown advances from the focused widget", () => {
+    const backend = createNoopBackend();
+    const renderer = new WidgetRenderer<void>({
+      backend,
+      requestRender: () => {},
+    });
+
+    let value = "dark";
+    const values: string[] = [];
+    const view = () =>
+      ui.column({}, [
+        ui.text(`Selected:${value}`),
+        ui.select({
+          id: "theme",
+          value,
+          options: [
+            { value: "dark", label: "Dark" },
+            { value: "light", label: "Light", disabled: true },
+            { value: "system", label: "System" },
+          ],
+          onChange: (nextValue) => {
+            value = nextValue;
+            values.push(nextValue);
+          },
+        }),
+      ]);
+
+    let res = renderer.submitFrame(
+      () => view(),
+      undefined,
+      { cols: 40, rows: 6 },
+      defaultTheme,
+      noRenderHooks(),
+    );
+    assert.ok(res.ok);
+
+    const rect = renderer.getRectByIdIndex().get("theme");
+    assert.ok(rect !== undefined);
+    if (!rect) return;
+    const x = rect.x + Math.max(0, Math.floor((rect.w - 1) / 2));
+    const y = rect.y + Math.max(0, Math.floor((rect.h - 1) / 2));
+
+    renderer.routeEngineEvent(mouseEvent(x, y, 3, { timeMs: 1, buttons: 1 }));
+    renderer.routeEngineEvent(mouseEvent(x, y, 4, { timeMs: 2 }));
+    assert.equal(renderer.getFocusedId(), "theme");
+    assert.equal(value, "dark");
+    assert.deepEqual(values, []);
+
+    renderer.routeEngineEvent(keyEvent(21 /* DOWN */));
+    assert.equal(value, "system");
+    assert.deepEqual(values, ["system"]);
+
+    res = renderer.submitFrame(
+      () => view(),
+      undefined,
+      { cols: 40, rows: 6 },
+      defaultTheme,
+      noRenderHooks(),
+    );
+    assert.ok(res.ok);
+
+    const text = createTestRenderer({ viewport: { cols: 40, rows: 6 } })
+      .render(view())
+      .toText();
+    assert.equal(text.includes("Selected:system"), true);
+  });
+
   test("focusTrap wraps TAB within active trap", () => {
     const backend = createNoopBackend();
     const renderer = new WidgetRenderer<void>({

--- a/packages/core/src/renderer/__tests__/focusIndicators.test.ts
+++ b/packages/core/src/renderer/__tests__/focusIndicators.test.ts
@@ -338,6 +338,25 @@ describe("focus indicator rendering contracts", () => {
     assert.equal(op?.style?.underline === true, false);
   });
 
+  test("select focusConfig indicator:none suppresses focus styling", () => {
+    const textOps = drawTextOps(
+      renderOps(
+        ui.select({
+          id: "sel-none",
+          value: "one",
+          options: Object.freeze([{ value: "one", label: "One" }]),
+          focusConfig: Object.freeze({ indicator: "none" }),
+        }),
+        "sel-none",
+        defaultTheme,
+      ),
+    );
+    const op = findDrawTextByToken(textOps, "One");
+    assert.ok(op !== null, "select should render");
+    assert.equal(op?.style?.bold === true, false);
+    assert.equal(op?.style?.underline === true, false);
+  });
+
   test("slider focusConfig indicator:none suppresses focus styling", () => {
     const focusedDefault = drawTextOps(
       renderOps(


### PR DESCRIPTION
## Summary
- cover the remaining documented `select` interaction gaps without reopening `dropdown`
- add direct routing coverage only for the select edge cases that were not already covered cleanly at higher fidelity
- add renderer-integration mouse-focus coverage and renderer focus-style coverage for `focusConfig: { indicator: "none" }`

## Tests added, rewritten, removed
- added `packages/core/src/app/__tests__/selectRouting.test.ts` for arrow-wrap boundaries and the degraded `no onChange` path
- added renderer-integration coverage in `packages/core/src/app/__tests__/widgetRenderer.integration.test.ts` for mouse click focus followed by `ArrowDown` selection change
- added renderer focus-style coverage in `packages/core/src/renderer/__tests__/focusIndicators.test.ts` for `select` with `focusConfig: { indicator: "none" }`
- removed no tests

## Implementation bugs fixed because valid tests exposed them
- none; the documented behavior already matched the current implementation for this slice

## Test commands run
- `./node_modules/.bin/tsc -b packages/core/tsconfig.json --pretty false`
- `node --test packages/core/dist/app/__tests__/selectRouting.test.js packages/core/dist/app/__tests__/widgetRenderer.integration.test.js packages/core/dist/app/__tests__/widgetBehavior.contracts.test.js packages/core/dist/renderer/__tests__/focusIndicators.test.js packages/core/dist/runtime/__tests__/widgetMeta.test.js packages/core/dist/widgets/__tests__/formWidgets.test.js`

## Remaining explicit gaps
- stale-value fallback on keyboard advance remains unasserted because the current docs do not state the exact fallback target strongly enough
- select still has no standalone semantic shared scenario for mouse focus; this slice keeps that at renderer-integration fidelity instead of inventing a broader scenario contract

## Dependency note
- no stack dependency


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added unit tests for select keyboard navigation covering arrow-key cycling, wrap-around behavior, and skipping disabled options.
  * Added integration tests verifying select mouse focus behavior and keyboard-driven value changes/onChange invocation.
  * Added focus-indicator tests ensuring select rendering respects "none" indicator (no focus styling).
<!-- end of auto-generated comment: release notes by coderabbit.ai -->