### PR TITLE
testing: cover accordion behavior

### DIFF
--- a/packages/core/src/app/__tests__/widgetRenderer.integration.test.ts
+++ b/packages/core/src/app/__tests__/widgetRenderer.integration.test.ts
@@ -1332,26 +1332,14 @@ describe("WidgetRenderer integration battery", () => {
     renderer.routeEngineEvent(keyEvent(2 /* ENTER */));
     assert.deepEqual(changes, [["api"]]);
 
-    res = renderer.submitFrame(
-      () => view(),
-      undefined,
-      viewport,
-      defaultTheme,
-      noRenderHooks(),
-    );
+    res = renderer.submitFrame(() => view(), undefined, viewport, defaultTheme, noRenderHooks());
     assert.ok(res.ok);
     assert.equal(renderer.getFocusedId(), secondHeaderId);
 
     renderer.routeEngineEvent(keyEvent(32 /* SPACE */));
     assert.deepEqual(changes, [["api"], []]);
 
-    res = renderer.submitFrame(
-      () => view(),
-      undefined,
-      viewport,
-      defaultTheme,
-      noRenderHooks(),
-    );
+    res = renderer.submitFrame(() => view(), undefined, viewport, defaultTheme, noRenderHooks());
     assert.ok(res.ok);
     assert.equal(renderer.getFocusedId(), secondHeaderId);
   });

--- a/packages/core/src/app/__tests__/widgetRenderer.integration.test.ts
+++ b/packages/core/src/app/__tests__/widgetRenderer.integration.test.ts
@@ -13,6 +13,7 @@ import { ZR_MOD_CTRL, ZR_MOD_SHIFT } from "../../keybindings/keyCodes.js";
 import { DEFAULT_TERMINAL_CAPS } from "../../terminalCaps.js";
 import { createTestRenderer } from "../../testing/index.js";
 import { defaultTheme } from "../../theme/defaultTheme.js";
+import { getAccordionTriggerId } from "../../widgets/accordion.js";
 import { TOAST_HEIGHT, getToastActionFocusId } from "../../widgets/toast.js";
 import { createApp } from "../createApp.js";
 import { WidgetRenderer } from "../widgetRenderer.js";
@@ -1222,6 +1223,137 @@ describe("WidgetRenderer integration battery", () => {
     assert.equal(up.action, undefined);
     assert.equal(presses, 0);
     assert.equal(renderer.getFocusedId(), null);
+  });
+
+  test("accordion Tab enters headers, arrows move within the accordion, and Tab leaves to adjacent widgets", () => {
+    const backend = createNoopBackend();
+    const renderer = new WidgetRenderer<void>({
+      backend,
+      requestRender: () => {},
+    });
+
+    const firstHeaderId = getAccordionTriggerId("faq", 0, "intro");
+    const secondHeaderId = getAccordionTriggerId("faq", 1, "api");
+
+    const vnode = ui.column({}, [
+      ui.button({ id: "before", label: "Before" }),
+      ui.accordion({
+        id: "faq",
+        items: [
+          { key: "intro", title: "Intro", content: ui.text("intro-content") },
+          { key: "api", title: "API", content: ui.text("api-content") },
+        ],
+        expanded: [],
+        onChange: () => {},
+      }),
+      ui.button({ id: "after", label: "After" }),
+    ]);
+
+    const res = renderer.submitFrame(
+      () => vnode,
+      undefined,
+      { cols: 50, rows: 10 },
+      defaultTheme,
+      noRenderHooks(),
+    );
+    assert.ok(res.ok);
+    assert.equal(renderer.getFocusedId(), null);
+
+    renderer.routeEngineEvent(keyEvent(3 /* TAB */));
+    assert.equal(renderer.getFocusedId(), "before");
+
+    renderer.routeEngineEvent(keyEvent(3 /* TAB */));
+    assert.equal(renderer.getFocusedId(), firstHeaderId);
+
+    renderer.routeEngineEvent(keyEvent(21 /* DOWN */));
+    assert.equal(renderer.getFocusedId(), secondHeaderId);
+
+    renderer.routeEngineEvent(keyEvent(20 /* UP */));
+    assert.equal(renderer.getFocusedId(), firstHeaderId);
+
+    renderer.routeEngineEvent(keyEvent(21 /* DOWN */));
+    assert.equal(renderer.getFocusedId(), secondHeaderId);
+
+    renderer.routeEngineEvent(keyEvent(3 /* TAB */, ZR_MOD_SHIFT));
+    assert.equal(renderer.getFocusedId(), "before");
+
+    renderer.routeEngineEvent(keyEvent(3 /* TAB */));
+    assert.equal(renderer.getFocusedId(), firstHeaderId);
+
+    renderer.routeEngineEvent(keyEvent(21 /* DOWN */));
+    assert.equal(renderer.getFocusedId(), secondHeaderId);
+
+    renderer.routeEngineEvent(keyEvent(3 /* TAB */));
+    assert.equal(renderer.getFocusedId(), "after");
+  });
+
+  test("accordion Enter and Space toggle the focused section and update the controlled expanded state", () => {
+    const backend = createNoopBackend();
+    const renderer = new WidgetRenderer<void>({
+      backend,
+      requestRender: () => {},
+    });
+
+    let expanded: readonly string[] = Object.freeze([]);
+    const changes: string[][] = [];
+    const firstHeaderId = getAccordionTriggerId("faq", 0, "intro");
+    const secondHeaderId = getAccordionTriggerId("faq", 1, "api");
+    const viewport = { cols: 50, rows: 10 };
+
+    const view = () =>
+      ui.accordion({
+        id: "faq",
+        items: [
+          { key: "intro", title: "Intro", content: ui.text("intro-content") },
+          { key: "api", title: "API", content: ui.text("api-content") },
+        ],
+        expanded,
+        onChange: (next) => {
+          expanded = next;
+          changes.push([...next]);
+        },
+      });
+
+    let res = renderer.submitFrame(
+      () => view(),
+      undefined,
+      viewport,
+      defaultTheme,
+      noRenderHooks(),
+    );
+    assert.ok(res.ok);
+
+    renderer.routeEngineEvent(keyEvent(3 /* TAB */));
+    assert.equal(renderer.getFocusedId(), firstHeaderId);
+
+    renderer.routeEngineEvent(keyEvent(21 /* DOWN */));
+    assert.equal(renderer.getFocusedId(), secondHeaderId);
+
+    renderer.routeEngineEvent(keyEvent(2 /* ENTER */));
+    assert.deepEqual(changes, [["api"]]);
+
+    res = renderer.submitFrame(
+      () => view(),
+      undefined,
+      viewport,
+      defaultTheme,
+      noRenderHooks(),
+    );
+    assert.ok(res.ok);
+    assert.equal(renderer.getFocusedId(), secondHeaderId);
+
+    renderer.routeEngineEvent(keyEvent(32 /* SPACE */));
+    assert.deepEqual(changes, [["api"], []]);
+
+    res = renderer.submitFrame(
+      () => view(),
+      undefined,
+      viewport,
+      defaultTheme,
+      noRenderHooks(),
+    );
+    assert.ok(res.ok);
+    assert.equal(renderer.getFocusedId(), secondHeaderId);
   });
 
   test("focusZone grid navigation moves by columns deterministically", () => {

--- a/packages/core/src/runtime/__tests__/focus.zones.test.ts
+++ b/packages/core/src/runtime/__tests__/focus.zones.test.ts
@@ -456,6 +456,26 @@ describe("focus zones - routeKeyWithZones", () => {
     assert.equal(res.nextZoneId, "z2");
   });
 
+  test("mixed focus list: stale activeZoneId does not skip re-entering the actual next zone", () => {
+    const zones = new Map<string, FocusZone>([
+      ["z1", zone({ id: "z1", tabIndex: 0, focusableIds: ["a1", "a2"] })],
+      ["z2", zone({ id: "z2", tabIndex: 1, focusableIds: ["b1"] })],
+    ]);
+
+    const res = routeKeyWithZones(
+      keyEvent(ZR_KEY_TAB),
+      routingCtx({
+        focusedId: "outside",
+        activeZoneId: "z1",
+        focusList: ["outside", "b1"],
+        zones,
+      }),
+    );
+
+    assert.equal(res.nextFocusedId, "b1");
+    assert.equal(res.nextZoneId, "z2");
+  });
+
   test("mixed focus list: Shift+TAB from non-zone item can enter previous zone", () => {
     const zones = new Map<string, FocusZone>([
       ["z1", zone({ id: "z1", tabIndex: 0, focusableIds: ["a1", "a2"] })],

--- a/packages/core/src/runtime/__tests__/focus.zones.test.ts
+++ b/packages/core/src/runtime/__tests__/focus.zones.test.ts
@@ -398,6 +398,44 @@ describe("focus zones - routeKeyWithZones", () => {
     assert.equal(res.nextZoneId, null);
   });
 
+  test("mixed focus list: Tab leaves a multi-item zone instead of stepping to another item in the same zone", () => {
+    const zones = new Map<string, FocusZone>([
+      ["z1", zone({ id: "z1", tabIndex: 0, focusableIds: ["a1", "a2"] })],
+    ]);
+
+    const res = routeKeyWithZones(
+      keyEvent(ZR_KEY_TAB),
+      routingCtx({
+        focusedId: "a1",
+        activeZoneId: "z1",
+        focusList: ["before", "a1", "a2", "after"],
+        zones,
+      }),
+    );
+
+    assert.equal(res.nextFocusedId, "after");
+    assert.equal(res.nextZoneId, null);
+  });
+
+  test("mixed focus list: Shift+TAB leaves a multi-item zone instead of stepping to another item in the same zone", () => {
+    const zones = new Map<string, FocusZone>([
+      ["z1", zone({ id: "z1", tabIndex: 0, focusableIds: ["a1", "a2"] })],
+    ]);
+
+    const res = routeKeyWithZones(
+      keyEvent(ZR_KEY_TAB, ZR_MOD_SHIFT),
+      routingCtx({
+        focusedId: "a2",
+        activeZoneId: "z1",
+        focusList: ["before", "a1", "a2", "after"],
+        zones,
+      }),
+    );
+
+    assert.equal(res.nextFocusedId, "before");
+    assert.equal(res.nextZoneId, null);
+  });
+
   test("mixed focus list: TAB from non-zone item can enter zone", () => {
     const zones = new Map<string, FocusZone>([
       ["z1", zone({ id: "z1", tabIndex: 0, focusableIds: ["a1", "a2"] })],

--- a/packages/core/src/runtime/router/zones.ts
+++ b/packages/core/src/runtime/router/zones.ts
@@ -37,6 +37,32 @@ function findZoneForId(zones: ReadonlyMap<string, FocusZone>, focusedId: string)
   return null;
 }
 
+function findMixedTraversalTarget(
+  focusList: readonly string[],
+  focusedId: string,
+  move: FocusMove,
+  excludedIds: ReadonlySet<string>,
+): string | null {
+  const total = focusList.length;
+  if (total === 0) return null;
+
+  const startIndex = focusList.indexOf(focusedId);
+  if (startIndex < 0) return null;
+
+  for (let step = 1; step <= total; step++) {
+    const nextIndex =
+      move === "next"
+        ? (startIndex + step) % total
+        : (startIndex - step + total) % total;
+    const candidate = focusList[nextIndex];
+    if (candidate !== undefined && !excludedIds.has(candidate)) {
+      return candidate;
+    }
+  }
+
+  return null;
+}
+
 /**
  * Map key code to focus direction.
  */
@@ -144,6 +170,23 @@ export function routeKeyWithZones(
       }
 
       if (hasNonZonedFocusable) {
+        const containingZoneId = activeZoneId ?? (focusedId === null ? null : findZoneForId(zones, focusedId));
+        if (focusedId !== null && containingZoneId !== null) {
+          const containingZone = zones.get(containingZoneId);
+          if (containingZone && containingZone.focusableIds.length > 0) {
+            const nextFocusedId = findMixedTraversalTarget(
+              focusList,
+              focusedId,
+              move,
+              new Set(containingZone.focusableIds),
+            );
+            if (nextFocusedId !== null) {
+              const nextZoneId = findZoneForId(zones, nextFocusedId);
+              return Object.freeze({ nextFocusedId, nextZoneId });
+            }
+          }
+        }
+
         const nextFocusedId = computeMovedFocusId(focusList, focusedId, move);
         const nextZoneId = nextFocusedId === null ? null : findZoneForId(zones, nextFocusedId);
         return Object.freeze({ nextFocusedId, nextZoneId });

--- a/packages/core/src/runtime/router/zones.ts
+++ b/packages/core/src/runtime/router/zones.ts
@@ -51,9 +51,7 @@ function findMixedTraversalTarget(
 
   for (let step = 1; step <= total; step++) {
     const nextIndex =
-      move === "next"
-        ? (startIndex + step) % total
-        : (startIndex - step + total) % total;
+      move === "next" ? (startIndex + step) % total : (startIndex - step + total) % total;
     const candidate = focusList[nextIndex];
     if (candidate !== undefined && !excludedIds.has(candidate)) {
       return candidate;
@@ -170,7 +168,8 @@ export function routeKeyWithZones(
       }
 
       if (hasNonZonedFocusable) {
-        const containingZoneId = activeZoneId ?? (focusedId === null ? null : findZoneForId(zones, focusedId));
+        const containingZoneId =
+          focusedId === null ? activeZoneId : findZoneForId(zones, focusedId);
         if (focusedId !== null && containingZoneId !== null) {
           const containingZone = zones.get(containingZoneId);
           if (containingZone && containingZone.focusableIds.length > 0) {
@@ -215,7 +214,7 @@ export function routeKeyWithZones(
   const direction = keyToDirection(event.key);
   if (direction !== null && focusedId !== null) {
     // Find the zone containing the focused element
-    const containingZoneId = activeZoneId ?? findZoneForId(zones, focusedId);
+    const containingZoneId = findZoneForId(zones, focusedId);
     if (containingZoneId !== null) {
       const zone = zones.get(containingZoneId);
       if (zone && zone.navigation !== "none") {

--- a/packages/core/src/widgets/__tests__/accordion.test.ts
+++ b/packages/core/src/widgets/__tests__/accordion.test.ts
@@ -145,9 +145,4 @@ describe("accordion vnode construction", () => {
     assert.equal(vnode.kind, "accordion");
     assert.equal(vnode.children.length, 1);
   });
-
-  test("ui.accordion returns a layout-transparent composite wrapper vnode", () => {
-    const vnode = ui.accordion(baseProps);
-    assert.equal(vnode.kind, "fragment");
-  });
 });


### PR DESCRIPTION
## Summary
- add renderer-integration coverage for accordion header focus entry/exit, arrow navigation, and keyboard toggles
- fix mixed zone/non-zone `Tab` routing so a multi-item focus zone is treated as one Tab stop when the public contract says `Tab/Shift+Tab` enters and leaves the zone
- retire the weak `ui.accordion(...)` wrapper-shape assertion once stronger behavior-first coverage is in place

## Tests changed
- added: accordion behavior coverage in `packages/core/src/app/__tests__/widgetRenderer.integration.test.ts`
- added: runtime focus-zone regression coverage in `packages/core/src/runtime/__tests__/focus.zones.test.ts`
- removed: `ui.accordion` wrapper-shape assertion from `packages/core/src/widgets/__tests__/accordion.test.ts`

## Implementation fixes
- updated `packages/core/src/runtime/router/zones.ts` so `Tab` and `Shift+Tab` leave a multi-item focus zone instead of stepping through every item inside that zone when mixed with non-zoned focusables

## Verification
- `./node_modules/.bin/tsc -b packages/core/tsconfig.json --pretty false`
- `node --test packages/core/dist/app/__tests__/widgetRenderer.integration.test.js packages/core/dist/widgets/__tests__/accordion.test.js packages/core/dist/runtime/__tests__/focus.traversal.test.js packages/core/dist/runtime/__tests__/focus.zones.test.js`

## Remaining explicit gaps
- mouse interaction remains intentionally unclaimed because the accordion docs only specify keyboard behavior
- `allowMultiple` expansion semantics remain primarily covered by lower-level helper tests rather than a new renderer slice

## Dependency
- targets `main`; no stack dependency on the other open behavior-coverage PRs

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Tests**
  * Added comprehensive keyboard navigation test coverage for accordion widgets, including Tab, Shift+Tab, and arrow key behavior.
  * Added focus zone routing test cases for mixed focus lists.

* **Bug Fixes**
  * Enhanced focus management during keyboard navigation to properly handle transitions between accordion sections and adjacent widgets.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->