### PR TITLE
testing: cover tool approval dialog surface

### DIFF
--- a/packages/core/src/widgets/__tests__/overlay.edge.test.ts
+++ b/packages/core/src/widgets/__tests__/overlay.edge.test.ts
@@ -106,6 +106,39 @@ describe("overlay.edge - layout sizing and clamping", () => {
     assert.equal(result.value.rect.y + result.value.rect.h <= 12, true);
   });
 
+  test("measureOverlays toolApprovalDialog returns zero size when closed", () => {
+    const vnode = makeVNode("toolApprovalDialog", {
+      id: "approval",
+      open: false,
+      request: { toolId: "shell", toolName: "Shell", riskLevel: "low" },
+      onPress: () => undefined,
+      onClose: () => undefined,
+    });
+    const result = measureOverlays(vnode, 80, 24, "column", measureNode);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+
+    assert.deepEqual(result.value, { w: 0, h: 0 });
+  });
+
+  test("layoutOverlays toolApprovalDialog open is clamped within viewport", () => {
+    const vnode = makeVNode("toolApprovalDialog", {
+      id: "approval",
+      open: true,
+      request: { toolId: "shell", toolName: "Shell", riskLevel: "low" },
+      onPress: () => undefined,
+      onClose: () => undefined,
+    });
+    const result = layoutOverlays(vnode, 0, 0, 30, 10, 30, 10, "column", measureNode, layoutNode);
+    assert.equal(result.ok, true);
+    if (!result.ok) return;
+
+    assert.equal(result.value.rect.x >= 0, true);
+    assert.equal(result.value.rect.y >= 0, true);
+    assert.equal(result.value.rect.x + result.value.rect.w <= 30, true);
+    assert.equal(result.value.rect.y + result.value.rect.h <= 10, true);
+  });
+
   test("layoutOverlays modal width=auto stays centered and bounded", () => {
     const content = makeVNode("text", { testW: 120, testH: 8, text: "content" });
     const actionA = makeVNode("text", { testW: 8, testH: 1, text: "ok" });

--- a/packages/core/src/widgets/__tests__/overlays.test.ts
+++ b/packages/core/src/widgets/__tests__/overlays.test.ts
@@ -1,4 +1,5 @@
 import { assert, describe, test } from "@rezi-ui/testkit";
+import { createTestRenderer } from "../../testing/index.js";
 import { ui } from "../ui.js";
 
 describe("overlay widgets - VNode construction", () => {
@@ -119,6 +120,77 @@ describe("overlay widgets - VNode construction", () => {
     assert.equal(vnode.props.request.toolId, "shell");
     assert.equal(vnode.props.request.riskLevel, "high");
     assert.equal(vnode.props.focusedAction, "deny");
+  });
+
+  test("toolApprovalDialog renders the visible review surface when open", () => {
+    const output = createTestRenderer({ viewport: { cols: 60, rows: 16 } })
+      .render(
+        ui.toolApprovalDialog({
+          id: "approval",
+          open: true,
+          request: {
+            toolId: "shell",
+            toolName: "Shell",
+            riskLevel: "high",
+            command: "rm -rf /tmp/demo",
+          },
+          onPress: () => undefined,
+          onAllowForSession: () => undefined,
+          onClose: () => undefined,
+        }),
+      )
+      .toText();
+
+    assert.equal(output.includes("Tool Approval"), true);
+    assert.equal(output.includes("Tool: Shell"), true);
+    assert.equal(output.includes("Risk: HIGH"), true);
+    assert.equal(output.includes("Command:"), true);
+    assert.equal(output.includes("rm -rf /tmp/demo"), true);
+    assert.equal(output.includes("[Allow]"), true);
+    assert.equal(output.includes("[Deny]"), true);
+    assert.equal(output.includes("[Allow Session]"), true);
+  });
+
+  test("toolApprovalDialog omits allow-session action when no session callback is provided", () => {
+    const output = createTestRenderer({ viewport: { cols: 60, rows: 16 } })
+      .render(
+        ui.toolApprovalDialog({
+          id: "approval",
+          open: true,
+          request: {
+            toolId: "shell",
+            toolName: "Shell",
+            riskLevel: "low",
+          },
+          onPress: () => undefined,
+          onClose: () => undefined,
+        }),
+      )
+      .toText();
+
+    assert.equal(output.includes("[Allow]"), true);
+    assert.equal(output.includes("[Deny]"), true);
+    assert.equal(output.includes("[Allow Session]"), false);
+  });
+
+  test("toolApprovalDialog renders nothing when closed", () => {
+    const output = createTestRenderer({ viewport: { cols: 60, rows: 16 } })
+      .render(
+        ui.toolApprovalDialog({
+          id: "approval",
+          open: false,
+          request: {
+            toolId: "shell",
+            toolName: "Shell",
+            riskLevel: "low",
+          },
+          onPress: () => undefined,
+          onClose: () => undefined,
+        }),
+      )
+      .toText();
+
+    assert.equal(output.trim(), "");
   });
 
   test("toastContainer creates VNode with edge values", () => {


### PR DESCRIPTION
## Summary
- add behavior-first coverage for the tool approval dialog's visible review surface when open
- add layout coverage for closed zero-size behavior and open viewport clamping
- keep keyboard routing and focus-order behavior out of scope because the public contract is still under-specified

## Families and systems covered
- tool approval dialog widget surface
- overlay layout for tool approval dialog open and closed states

## Tests added, rewritten, removed
- added visible render-surface tests in `packages/core/src/widgets/__tests__/overlays.test.ts`
- added closed/open layout tests in `packages/core/src/widgets/__tests__/overlay.edge.test.ts`
- removed no existing tests

## Implementation bugs fixed
- none

## Validation
- `./node_modules/.bin/tsc -b packages/core/tsconfig.json --pretty false`
- `node --test packages/core/dist/widgets/__tests__/overlays.test.js packages/core/dist/widgets/__tests__/overlay.edge.test.js packages/core/dist/widgets/__tests__/widgetRenderSmoke.test.js`

## Explicit gaps left out
- keyboard routing and focus-order behavior remain blocked by missing public contract evidence
- file-change preview presentation remains intentionally unclaimed because the docs do not specify its exact output

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for tool approval dialog overlay behavior, including dimension validation and boundary clamping scenarios.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->