### PR TITLE
testing: cover feedback widget behavior

### DIFF
--- a/packages/core/src/widgets/__tests__/infoWidgets.test.ts
+++ b/packages/core/src/widgets/__tests__/infoWidgets.test.ts
@@ -1,47 +1,85 @@
 import { assert, describe, test } from "@rezi-ui/testkit";
+import { createTestRenderer } from "../../testing/index.js";
 import { ui } from "../ui.js";
 
-describe("informational widgets - edge cases", () => {
-  test("empty preserves action and accepts empty strings", () => {
-    const action = ui.button({ id: "retry", label: "Retry" });
-    const vnode = ui.empty("", {
-      icon: "status.info",
-      description: "",
-      action,
-    });
+describe("informational widgets - visible behavior", () => {
+  test("empty renders title, description, and action affordance", () => {
+    const output = createTestRenderer({ viewport: { cols: 40, rows: 10 } })
+      .render(
+        ui.empty("No results", {
+          description: "Try changing your filters.",
+          action: ui.button({ id: "retry", label: "Retry" }),
+        }),
+      )
+      .toText();
 
-    assert.equal(vnode.kind, "empty");
-    assert.deepEqual(vnode.props, {
-      title: "",
-      icon: "status.info",
-      description: "",
-      action,
-    });
+    assert.equal(output.includes("No results"), true);
+    assert.equal(output.includes("Try changing your filters."), true);
+    assert.equal(output.includes("[Retry]"), true);
   });
 
-  test("errorDisplay preserves stack/retry callbacks", () => {
-    const onRetry = () => undefined;
-    const vnode = ui.errorDisplay("failure", {
-      title: "Oops",
-      stack: "line1\nline2",
-      showStack: true,
-      onRetry,
-    });
+  test("empty with empty title and description still shows its action affordance", () => {
+    const output = createTestRenderer({ viewport: { cols: 40, rows: 10 } })
+      .render(
+        ui.empty("", {
+          description: "",
+          action: ui.button({ id: "retry", label: "Retry" }),
+        }),
+      )
+      .toText();
 
-    assert.equal(vnode.kind, "errorDisplay");
-    assert.equal(vnode.props.message, "failure");
-    assert.equal(vnode.props.stack, "line1\nline2");
-    assert.equal(vnode.props.showStack, true);
-    assert.equal(vnode.props.onRetry, onRetry);
+    assert.equal(output.trim(), "[Retry]");
   });
 
-  test("callout supports all variant values", () => {
-    const variants = ["info", "success", "warning", "error"] as const;
-    for (const variant of variants) {
-      const vnode = ui.callout("message", { variant, title: "title", icon: "status.info" });
-      assert.equal(vnode.kind, "callout");
-      assert.equal(vnode.props.variant, variant);
-      assert.equal(vnode.props.message, "message");
-    }
+  test("errorDisplay renders title, message, stack, and retry affordance when enabled", () => {
+    const output = createTestRenderer({ viewport: { cols: 40, rows: 10 } })
+      .render(
+        ui.errorDisplay("Build failed", {
+          title: "Build error",
+          stack: "line1\nline2",
+          showStack: true,
+          onRetry: () => undefined,
+        }),
+      )
+      .toText();
+
+    assert.equal(output.includes("✗ Build error"), true);
+    assert.equal(output.includes("Build failed"), true);
+    assert.equal(output.includes("line1"), true);
+    assert.equal(output.includes("line2"), true);
+    assert.equal(output.includes("[Retry]"), true);
+  });
+
+  test("errorDisplay omits stack rows when showStack is true but stack is empty", () => {
+    const output = createTestRenderer({ viewport: { cols: 40, rows: 10 } })
+      .render(
+        ui.errorDisplay("boom", {
+          title: "Oops",
+          showStack: true,
+        }),
+      )
+      .toText();
+
+    const visibleLines = output
+      .split("\n")
+      .map((line) => line.trim())
+      .filter((line) => line.length > 0);
+
+    assert.deepEqual(visibleLines, ["✗ Oops", "boom"]);
+  });
+
+  test("callout renders the override icon, title, and message", () => {
+    const output = createTestRenderer({ viewport: { cols: 40, rows: 10 } })
+      .render(
+        ui.callout("Saved successfully", {
+          title: "Done",
+          icon: "status.info",
+        }),
+      )
+      .toText();
+
+    assert.equal(output.includes("[i]"), true);
+    assert.equal(output.includes("Done"), true);
+    assert.equal(output.includes("Saved successfully"), true);
   });
 });


### PR DESCRIPTION
## Summary
- rewrite the weak `infoWidgets` tests around visible behavior for public feedback widgets
- cover `empty`, `errorDisplay`, and `callout` at widget-render fidelity instead of prop-shape assertions
- keep exact centering, border geometry, and theme-detail styling out of scope because they are not tightly specified public contracts

## Families and systems covered
- feedback widgets: `empty`, `errorDisplay`, and `callout`

## Tests added, rewritten, removed
- rewrote `packages/core/src/widgets/__tests__/infoWidgets.test.ts` from prop-shape checks to visible-output behavior assertions
- retained existing factory, drawlist, and app-level resilience tests that still protect distinct lower-level or broader contracts

## Implementation bugs fixed
- none

## Validation
- `./node_modules/.bin/tsc -b packages/core/tsconfig.json --pretty false`
- `node --test packages/core/dist/widgets/__tests__/infoWidgets.test.js packages/core/dist/widgets/__tests__/basicWidgets.render.test.js packages/core/dist/app/__tests__/resilience.test.js`

## Explicit gaps left out
- exact centering, truncation, and border geometry remain renderer details rather than public widget contracts
- `callout` default icon and tone mapping remain intentionally unclaimed
- `errorBoundary` recovery behavior stays covered by the existing app-level resilience suite rather than this widget-render slice

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Tests**
  * Enhanced test coverage for info widget components to verify rendered output and visible behavior (including titles, descriptions, icons, and action affordances) rather than internal implementation details.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->