### PR TITLE
docs: publish testing policy and fix docs build

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -2,13 +2,17 @@
 
 <!-- What does this change do, and why? -->
 
+## Testing Notes
+
+- Contract source:
+- Chosen test fidelity:
+- Degraded or failure-path coverage, if relevant:
+
 ## Checklist
 
 - [ ] `npm run lint` passes
 - [ ] `npm run typecheck` passes
 - [ ] `npm test` passes (or change is docs/CI-only)
-- [ ] Behavior-first test review done:
-  contract source is named, observable outcome is asserted, test fidelity matches user-visible behavior, failure/degraded-path expectation is covered, and the test still makes sense after a refactor
 - [ ] Docs updated (`README.md` and/or `docs/`)
 - [ ] `npm run docs:build` passes (docs changes)
 - [ ] Module boundaries preserved (`packages/core` has no Node APIs)

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -25,6 +25,16 @@ Treat it as a merge checklist for:
 - runtime/layout/reconciliation invariants
 - callback safety and async cancellation
 
+## Mandatory Testing Policy
+
+All behavior changes must follow `docs/dev/testing.md`.
+Treat it as the canonical testing policy for:
+- behavior-first test design
+- contract evidence
+- fidelity selection
+- degraded-capability and failure-path coverage
+- deciding whether an existing test should be kept, rewritten, promoted, or removed
+
 ## Exploration Protocol
 
 ### Before Writing Any Code
@@ -33,7 +43,8 @@ Run this checklist first:
 
 1. Read this file fully.
 2. Read `CLAUDE.md` sections relevant to the task.
-3. Read the target file and adjacent tests before changing behavior.
+3. Read `docs/dev/testing.md` before changing behavior or tests.
+4. Read the target file and adjacent tests before changing behavior.
 
 ### Exploration Order
 
@@ -171,35 +182,41 @@ See `CLAUDE.md` § Drawlist Codegen Protocol.
 
 ## Testing Protocol
 
+Behavior changes must follow the canonical policy in `docs/dev/testing.md`.
+
+Non-negotiable rules:
+- tests must assert expected behavior, not current implementation shape
+- choose the lowest fidelity that can prove the contract, but no lower
+- use terminal-real PTY evidence when semantic or replay tests cannot prove terminal-visible behavior safely
+- if a valid behavior-first test fails, keep the test and fix the implementation unless the contract is actually under-specified
+- do not weaken a valid expectation just to keep the code unchanged
+
+Quick commands:
+
 ```bash
-# Run all tests
-node scripts/run-tests.mjs
+# Full deterministic suite
+npm test
 
-# Run one test file
-node --test packages/core/src/widgets/__tests__/basicWidgets.test.ts
+# Package tests only
+npm run test:packages
 
-# Run filtered suite
-node scripts/run-tests.mjs --filter "widget"
+# Script tests only
+npm run test:scripts
+
+# End-to-end suites
+npm run test:e2e
+npm run test:e2e:reduced
 ```
 
-### Test Location Index
-
-| Category | Path |
-|----------|------|
-| Unit | `packages/core/src/**/__tests__/*.test.ts` |
-| Integration | `packages/core/src/__tests__/integration/` |
-| Stress/Fuzz | `packages/core/src/__tests__/stress/` |
-| Template tests | `packages/create-rezi/templates/*/src/__tests__/` |
-
-### Required Execution Order
-
-1. Run nearest unit tests first.
-2. If runtime/layout/renderer changed, run integration tests.
-3. Run full suite before commit.
+Execution order:
+1. Run the nearest credible test slice first.
+2. If runtime, layout, renderer, backend, or terminal behavior changed, run the relevant integration or scenario coverage too.
+3. If terminal-visible behavior changed, include PTY evidence when required by `docs/dev/testing.md`.
+4. Run the full suite before final commit when the risk warrants it.
 
 ### Mandatory Live PTY Validation for UI Regressions
 
-For rendering/layout/theme regressions, include a live PTY pass and frame-audit evidence.
+For rendering, layout, theme, capability, or terminal-integration regressions, include a live PTY pass and frame-audit evidence.
 
 Canonical runbook:
 - `docs/dev/live-pty-debugging.md`
@@ -209,7 +226,7 @@ Minimum checks:
 2. Exercise relevant routes and key paths.
 3. Capture `REZI_FRAME_AUDIT` logs.
 4. Analyze logs with `node scripts/frame-audit-report.mjs ... --latest-pid`.
-5. Include concrete evidence (hash deltas, route/key summaries) in your report.
+5. Include concrete evidence in your report.
 
 ## Verification Protocol (Two-Agent Verification)
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -2,14 +2,19 @@
 
 Thanks for contributing to Rezi.
 
-Rezi is a **code-first terminal UI framework** for Node.js built on the Zireael C engine. The core design constraints (determinism, safety, and strict module boundaries) are deliberate; please read the docs before making behavior changes.
+Rezi is a code-first terminal UI framework for Node.js built on the Zireael C
+engine. The core design constraints are deliberate: deterministic behavior,
+strict module boundaries, and safe binary handling.
 
-## Quickstart (dev)
+Before changing behavior, read:
+- [Canonical testing policy](docs/dev/testing.md)
+- [Code standards](docs/dev/code-standards.md)
+
+## Quickstart
 
 Prerequisites:
-
 - Node.js 18+ (18.18+ recommended)
-- Rust (stable toolchain) for the native addon
+- Rust stable toolchain for the native addon
 - Git submodules enabled
 
 Clone and bootstrap:
@@ -31,7 +36,7 @@ npm run build
 npm test
 ```
 
-Native addon (host build + smoke):
+Native addon:
 
 ```bash
 npm run build:native
@@ -40,57 +45,67 @@ npm run test:native:smoke
 
 ## Repository layout
 
-- `packages/core` — runtime-agnostic TypeScript core (no Node APIs)
-- `packages/node` — Node.js backend (worker-thread ownership, IO, buffers)
-- `packages/native` — Rust + N-API addon bundling the Zireael engine
-- `packages/testkit` — test utilities and fixtures
-- `packages/jsx` — JSX runtime
-- `packages/bench` — benchmark harness (not published)
-- `examples/*` — runnable examples
-- `docs/` — GitHub Pages documentation site (MkDocs)
+- `packages/core` - runtime-agnostic TypeScript core
+- `packages/node` - Node.js backend
+- `packages/native` - Rust + N-API addon
+- `packages/testkit` - test utilities and fixtures
+- `packages/jsx` - JSX runtime
+- `packages/bench` - benchmark harness
+- `examples/*` - runnable examples
+- `docs/` - documentation site
 
-## Project constraints (read before changing)
+## Project constraints
 
 - `packages/core` must not import `node:*`, use `Buffer`, or depend on Node runtime semantics.
-- Binary parsing/building must follow the safety rules in the docs (bounded reads, alignment checks, deterministic failure).
-- Public APIs should be documented and stable within a release line.
-- Streaming hooks in `packages/core` must use runtime adapters/factories for environment-specific sources (`EventSource`, `WebSocket`, file tailing) and include cleanup + stale-update guards.
-- Animation hooks (`useTransition`, `useSpring`, `useSequence`, `useStagger`) and `ui.box` transition behavior must remain deterministic and be documented in docs + templates when user-visible behavior changes.
+- Binary parsing and building must remain bounded, deterministic, and explicit about failure.
+- Public APIs should remain documented and stable within a release line.
+- Streaming hooks in `packages/core` must use runtime adapters or factories for environment-specific sources and include cleanup plus stale-update guards.
+- Animation hooks and transition behavior must remain deterministic and be documented when user-visible behavior changes.
+
+## Testing requirements
+
+Behavior changes must follow the canonical testing policy in [docs/dev/testing.md](docs/dev/testing.md).
+
+Short version:
+- tests must assert expected behavior, not current implementation shape
+- choose the lowest fidelity that can prove the contract, but no lower
+- use terminal-real PTY evidence when terminal-visible behavior cannot be proven safely by semantic or replay tests
+- cover degraded-capability and failure paths when the contract depends on them
+- do not weaken a valid failing test to preserve current behavior; fix the implementation or make the contract gap explicit
 
 ## Pull requests
 
 PRs should include:
-
-- A clear problem statement and intended behavior
-- Tests for any behavior change (unit tests or golden fixtures where appropriate)
-- Docs updates for user-facing changes (manual and/or API docs)
+- a clear problem statement and intended behavior
+- tests for the behavior change at the right fidelity
+- contract source and degraded or failure-path coverage when relevant
+- docs updates for user-facing changes
 
 PRs may be rejected if they:
-
-- Blur module boundaries (Node code in `core`)
-- Add implicit behavior or non-determinism
-- Expand unsafe binary surface area without tight validation
+- blur module boundaries
+- add implicit behavior or non-determinism
+- expand unsafe binary surface area without tight validation
+- rely on implementation-shaped tests instead of behavioral coverage
 
 ## Style and tooling
 
 - Formatting and linting: Biome (`npm run fmt`, `npm run lint`)
 - TypeScript: strict mode (`npm run typecheck`)
-- Tests: `npm test` (keep tests deterministic and fast)
-- Hook changes: add/adjust hook docs (`docs/guide/hooks-reference.md`) and include race/cleanup tests.
-- Animation changes: update `docs/guide/animation.md` and `docs/widgets/box.md`, and add/adjust transition/hook tests.
+- Tests: `npm test`
+- Hook changes: update `docs/guide/hooks-reference.md` and include race or cleanup tests
+- Animation changes: update `docs/guide/animation.md` and `docs/widgets/box.md`, and add transition or hook tests
 
 ## Interaction guidelines
 
 - Interactive widgets with an `id` should be keyboard reachable via `Tab` unless there is a deliberate opt-out (`focusable: false`).
-- For complex table flows, prefer `useTable(...)` over manually wiring selection/sort state in each widget.
-- For stacked modal flows, prefer `useModalStack(...)` to keep push/pop behavior and focus restoration deterministic.
+- For complex table flows, prefer `useTable(...)` over manually wiring selection or sort state.
+- For stacked modal flows, prefer `useModalStack(...)` so push/pop behavior and focus restoration stay deterministic.
 - In composite widgets, use `ctx.useMemo(...)` and `ctx.useCallback(...)` when dependency-driven memoization is needed.
-- For hot state-preserving reload workflows (`app.replaceView` / `app.replaceRoutes` / `createHotStateReload`), keep widget ids/keys stable so local state and focus survive edits.
-- Use `npm run hsr:demo:widget` / `npm run hsr:demo:router` for manual HSR validation, and `npm run hsr:record:widget` / `npm run hsr:record:router` for GIF capture.
-- In widget demo validation, edit the `self-edit-code` snippet and save with `Enter` or `F6` to confirm hot-swap without terminal restart.
-- For code-editor syntax changes, keep tokenization deterministic and line-based; use `syntaxLanguage` presets or `tokenizeLine` + `tokenizeCodeEditorLine(...)`, then add/adjust tests in `codeEditor.syntax` suites.
+- For hot state-preserving reload workflows, keep widget ids and keys stable so local state and focus survive edits.
+- For code-editor syntax changes, keep tokenization deterministic and line-based, then add or adjust `codeEditor.syntax` coverage.
 
-## Widget and Design System guardrails
+## Widget and design-system guardrails
 
-- New widget kinds must be registered in `packages/core/src/widgets/protocol.ts`. Do not add new hardcoded kind lists in `packages/core/src/runtime/commit.ts`, `packages/core/src/layout/hitTest.ts`, or `packages/core/src/runtime/widgetMeta.ts`.
-- When adding interactive widgets, wire the matching recipe function and validate both legacy `Theme` and `ThemeDefinition` paths. Recipe output should provide the default style, and manual widget `style` overrides should merge on top.
+- New widget kinds must be registered in `packages/core/src/widgets/protocol.ts`. Do not add new hardcoded kind lists elsewhere in the runtime or layout path.
+- When adding interactive widgets, wire the matching recipe function and validate both legacy `Theme` and `ThemeDefinition` paths.
+- Recipe output should provide the default style, and manual widget `style` overrides should merge on top.

--- a/docs/dev/contributing.md
+++ b/docs/dev/contributing.md
@@ -1,9 +1,12 @@
 # Contributing
 
-Rezi welcomes issues and pull requests. This page summarizes the local workflow; see the linked guides for details.
+Rezi welcomes issues and pull requests. This page summarizes the local workflow.
+For behavior changes, the canonical testing policy is:
+- [Testing Policy](testing.md)
 
-Before starting implementation, review the mandatory
-[Code Standards](code-standards.md) checklist.
+Before starting implementation, review the mandatory guides:
+- [Code Standards](code-standards.md)
+- [Testing Policy](testing.md)
 
 ## Prerequisites
 
@@ -28,7 +31,16 @@ npm test
 npm run docs:build
 ```
 
-## Hook/API changes
+## Testing requirements
+
+When you change behavior:
+- test expected behavior, not current implementation shape
+- use the lowest fidelity that proves the contract, but no lower
+- include PTY evidence when terminal-visible behavior cannot be proven safely by semantic or replay tests
+- cover degraded-capability and failure paths when the contract depends on them
+- fix the implementation when a valid behavior-first test fails, unless the contract is genuinely under-specified
+
+## Hook and API changes
 
 - For public hook changes, update `docs/guide/hooks-reference.md` and `docs/guide/composition.md` in the same PR.
 - For animation hook changes (`useTransition`, `useSpring`, `useSequence`, `useStagger`) or `ui.box` transition behavior, also update `docs/guide/animation.md` and `docs/widgets/box.md`.
@@ -43,19 +55,19 @@ node --test packages/core/src/layout/__tests__/layout.overflow-scroll.test.ts
 node --test packages/core/src/app/__tests__/widgetRenderer.integration.test.ts
 ```
 
-## HSR Change Checklist
+## HSR change checklist
 
 If your change touches `app.view`, route integration, reconciliation identity, `createNodeApp({ hotReload })`, or `createHotStateReload`:
 
 - add app runtime tests for `app.replaceView(...)` / `app.replaceRoutes(...)` behavior
-- verify widget local state survives reload with stable ids/keys
-- verify failure paths keep the previous working view/routes
-- update user docs when API/limitations change
+- verify widget local state survives reload with stable ids or keys
+- verify failure paths keep the previous working view or routes
+- update user docs when API or limitations change
 - manually run `npm run hsr:demo:widget` once and confirm in-app code-editor save (`self-edit-code` + F6/Ctrl+O or save button + Enter) triggers reload without process restart
 
 If your change touches code-editor syntax behavior (`syntaxLanguage`, tokenizer exports, or renderer token painting):
 
-- add/extend unit tests for built-in language presets and custom tokenizer override paths
+- add or extend unit tests for built-in language presets and custom tokenizer override paths
 - verify fallback behavior for unsupported language names (`plain`)
 - update [widgets/code-editor](../widgets/code-editor.md) and [packages/core](../packages/core.md) API docs
 

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -1,67 +1,345 @@
-# Testing
+# Testing Policy
 
-Rezi uses the built-in `node:test` runner via a deterministic test discovery
-script. The test suite currently contains **873+ tests** across multiple
-categories.
+This document is the canonical testing policy for Rezi framework changes.
 
-## Running Tests
+Use it when you:
+- add or change widget behavior
+- change routing, focus, layout, rendering, or terminal integration
+- rewrite or remove existing tests
+- review whether a test actually proves the behavior it claims to prove
 
-### Full Suite
+This document is normative.
+`AGENTS.md`, `CONTRIBUTING.md`, and other testing entry points summarize it or
+link back here.
+
+## Core Rule
+
+Tests in Rezi must assert expected behavior, not current implementation shape.
+
+A test is only useful if it makes a clear claim about what Rezi should do.
+A test is weak if it only freezes what the current code happens to do.
+
+Examples of good claims:
+- an input gains focus when clicked
+- a modal blocks background interaction and restores focus on close
+- a virtual list keeps the visible viewport stable across resizes
+- a parser rejects malformed input with a structured error
+
+Examples of weak claims:
+- a cache object keeps the same identity
+- hook cell order stayed the same
+- a private method was called in the same sequence
+- a snapshot still matches even though the intended behavior is unclear
+
+## Testing Principles
+
+Every new or rewritten test should follow these rules.
+
+### Behavior-first
+
+State the behavior under test in terms of an observable outcome.
+
+Good:
+- selected item moves to the next enabled option
+- blur happens when focus leaves the widget
+- terminal-visible output changes after a theme switch
+
+Weak:
+- internal focus bookkeeping matches the current implementation
+- a private structure contains the same fields in the same order
+
+### Deterministic and Reviewable
+
+Tests must be deterministic enough for review and CI.
+Avoid timing-dependent assertions, environment-dependent randomness, and opaque
+large snapshots that reviewers cannot evaluate.
+
+### Honest About Specification Gaps
+
+If a behavior is under-specified, do not invent a strict oracle just to make a
+coverage claim.
+Leave the gap explicit and tighten the contract first.
+
+### Fix Valid Failures, Do Not Weaken Them
+
+If a behavior-first test is valid and fails, the default response is to fix the
+implementation.
+Do not weaken the expectation to keep the code unchanged.
+
+Valid failing tests may expose one of these cases:
+- product bug
+- under-specified contract
+- incorrect test oracle
+- harness defect
+- environment limitation
+
+The test should only be relaxed when the expected behavior was not actually
+supported by repo evidence.
+
+## Contract Evidence
+
+A behavior expectation must be backed by concrete repo evidence.
+
+Strong evidence:
+- public API and types
+- canonical docs
+- examples or templates when they are clearly intentional and stable
+- existing stable contract tests
+- issue or PR intent when it is specific enough to define behavior
+
+Evidence that is not strong enough by itself:
+- incidental current behavior
+- implementation structure
+- convenience snapshots with unclear intent
+- a helper returning a certain shape because that is how it happens to work now
+
+When writing or reviewing a test, ask:
+- what behavior is promised?
+- where is that promise stated or implied strongly enough to rely on it?
+- what observable outcome proves that promise?
+
+## Fidelity Ladder
+
+Use the lowest fidelity that can prove the contract, but no lower.
+
+### 1. Unit or Lower-level Contract Tests
+
+Use these for:
+- pure helpers
+- parsers and encoders
+- invariant checks
+- binary protocol contracts
+- lower-level state machines where the lower-level contract itself matters
+
+These tests should protect the real lower-level contract, not private incidental
+structure.
+
+### 2. Semantic Scenario Tests
+
+Use semantic tests when the behavior is best proven at the app or widget level,
+but a real terminal is not required.
+
+Good targets:
+- focus movement
+- action dispatch
+- selection changes
+- route transitions
+- modal blocking at the semantic layer
+- resize and interaction rules where text-mode semantic output is sufficient
+
+Important:
+- semantic helpers are not the final truth for terminal-visible behavior
+- `createTestRenderer()` is a semantic convenience helper, not the final oracle
+  for terminal correctness
+
+### 3. Replay Scenario Tests
+
+Use replay tests when the scenario model and event flow matter but a PTY is not
+required.
+
+Good targets:
+- deterministic event replays
+- scenario-level contract evaluation
+- event ordering behavior that is stronger than a pure unit test but does not
+  require terminal-real evidence
+
+### 4. Terminal-real PTY Tests
+
+Use PTY tests when the contract depends on actual terminal behavior and a
+headless semantic assertion is not enough.
+
+Good targets:
+- terminal-visible rendering or damage behavior
+- overlay, focus, and input interactions that depend on terminal integration
+- capability-dependent behavior
+- terminal byte-stream recovery behavior
+- worker/native/backend integration where the visible outcome matters
+
+## When PTY Coverage Is Mandatory
+
+PTY or equivalent terminal-real validation is required when the behavior depends
+on the real terminal path in a way that semantic or replay testing cannot prove
+safely.
+
+This includes cases such as:
+- terminal-visible rendering and redraw behavior
+- focus, overlay, or cursor interactions whose correctness depends on the real
+  backend path
+- capability-driven behavior such as mouse, focus events, bracketed paste, or
+  clipboard support
+- malformed or partial terminal input where byte-stream recovery matters
+- worker/native/backend behavior where the user-visible result is the contract
+
+For UI regressions and terminal integration work, use the live PTY runbook:
+- [Live PTY UI Testing and Frame Audit Runbook](live-pty-debugging.md)
+
+## Failure and Degraded-capability Coverage
+
+Where the contract is affected by missing terminal capabilities or by failure
+paths, tests must cover those paths explicitly.
+
+Examples:
+- `supportsMouse = false`
+- `supportsFocusEvents = false`
+- bracketed paste boundaries and incomplete paste recovery
+- malformed or incomplete escape sequences
+- resize storms
+- backend or native failure paths when the contract depends on safe recovery or
+  structured failure handling
+
+Do not add speculative failure assertions when the user-visible fallback is not
+actually specified.
+If the fallback is under-specified, document the gap and avoid over-claiming.
+
+## Acceptable and Unacceptable Oracles
+
+### Usually acceptable
+
+These generally prove real behavior:
+- visible text or screen regions
+- selected value or selected item state
+- focus transitions
+- callback or action outcomes
+- route transitions
+- modal blocking and focus restoration
+- scroll behavior and visible viewport changes
+- structured failure results
+- byte-level protocol output, but only when the protocol itself is the contract
+
+### Usually unacceptable unless they protect a justified lower-level contract
+
+These are weak by default:
+- cache identity
+- hook cell order
+- slot bookkeeping
+- private method call order
+- incidental object shape
+- snapshots that freeze current behavior without a declared contract
+
+A weak oracle is acceptable only when you can explain the actual lower-level
+contract it protects.
+
+## Existing Test Migration Rules
+
+When you touch existing coverage, classify the tests honestly.
+
+### Keep
+
+Keep a test when it still protects a meaningful contract at the right level.
+
+### Rewrite
+
+Rewrite a test when the behavior matters but the current oracle is too tied to
+implementation details.
+
+### Promote
+
+Promote a test to a higher fidelity when the current layer is too weak to prove
+the user-visible contract.
+
+Examples:
+- semantic-only coverage that should move to PTY
+- lower-level contract coverage that needs an app-level behavior assertion too
+
+### Remove or Merge
+
+Remove or merge a test only when:
+- it is redundant or invalid
+- stronger coverage now exists
+- it no longer protects a distinct lower-level contract
+
+Do not keep weak tests just because they already exist.
+Do not remove lower-level tests that still protect a real lower-level contract.
+
+## New Test Requirements
+
+Every new or rewritten behavioral test should make these points clear in the
+code or surrounding review context:
+- the behavior under test
+- the contract source
+- the chosen fidelity
+- degraded-capability or failure-path expectations when relevant
+
+This does not require boilerplate comments on every test.
+It does require that the behavior and its basis are obvious to reviewers.
+
+## Bug-regression Tests
+
+A regression test must pin the intended behavior.
+
+Do this:
+- write the behavior that should hold
+- keep the regression scope narrow and reviewable
+- fix the implementation if the expectation is valid
+
+Do not do this:
+- snapshot the bug as the new baseline
+- replace a clear behavioral expectation with a weaker incidental assertion
+- write a regression test that only proves the bug still exists
+
+## Scope Honesty
+
+Do not claim a widget family or subsystem is fully covered unless the coverage
+can be defended against the contract and the relevant state transitions.
+
+If behavior is under-specified, say so.
+If a harness cannot currently prove the behavior correctly, say so.
+If a broader redesign is required, say so.
+
+Rezi values honest boundaries over inflated coverage claims.
+
+## Practical Repo Guidance
+
+### Running tests
+
+Full deterministic suite:
 
 ```bash
 npm test
 ```
 
-This executes `node scripts/run-tests.mjs`, which deterministically discovers
-and runs all test files. Discovery is based on sorted directory walks -- no shell
-globs or non-deterministic ordering.
-
-### Scoped Runs
-
-Run only package tests (compiled `.test.js` files under `packages/*/dist/`):
+Package tests only:
 
 ```bash
 npm run test:packages
 ```
 
-Run only script tests (`.test.mjs` files under `scripts/__tests__/`):
+Script tests only:
 
 ```bash
 npm run test:scripts
 ```
 
-Run the named release-critical package suites that the fast PR gate surfaces:
+End-to-end tests:
 
 ```bash
-npm run test:release-critical
+npm run test:e2e
+npm run test:e2e:reduced
 ```
 
-Run the named terminal-real release-critical slice after building the native addon:
-
-```bash
-npm run build:native
-npm run test:release-critical:terminal
-```
-
-Print the CI-facing testing progress summary locally:
-
-```bash
-npm run test:progress
-```
-
-### Individual Test Files
-
-Run a single test file directly with Node's test runner:
-
-```bash
-node --test packages/core/dist/runtime/__tests__/reconcile.keyed.test.js
-```
-
-Note that tests run against compiled output in `dist/`, so you must build first:
+Individual compiled test file:
 
 ```bash
 npm run build && node --test packages/core/dist/path/to/test.js
 ```
+
+### Common helpers and where they fit
+
+`createTestRenderer()`
+: Use for semantic rendering and layout assertions. Do not treat it as the
+  final oracle for terminal-real behavior.
+
+`TestEventBuilder`
+: Use to build readable deterministic event sequences instead of hand-encoding
+  batches.
+
+`matchesSnapshot(...)`
+: Use for stable text snapshots when the snapshot encodes a declared contract.
+  Do not use snapshots as a substitute for identifying the behavior under test.
+
+Shared scenario runners in `@rezi-ui/core/testing` and `@rezi-ui/node/testing`
+: Use these when scenario-level semantic, replay, or PTY execution is the right
+  fidelity for the contract.
 
 ### Drawlist codegen guardrail
 
@@ -72,400 +350,22 @@ npm run codegen
 npm run codegen:check
 ```
 
-`codegen:check` is enforced in CI and fails if
-`packages/core/src/drawlist/writers.gen.ts` is out of sync with
-`scripts/drawlist-spec.ts`.
+`codegen:check` fails if generated writers are out of sync with the drawlist
+spec.
 
-### End-to-End Tests
+## Review Checklist
 
-```bash
-npm run test:e2e
+When reviewing a test change, check these questions first:
+- what behavior is being asserted?
+- what repo evidence supports that expectation?
+- is the chosen fidelity strong enough?
+- should degraded-capability or failure behavior also be covered?
+- is the oracle observable, or is it implementation-shaped?
+- if an old test remains, what contract does it still protect?
 
-# Reduced profile (fewer scenarios, faster)
-npm run test:e2e:reduced
-```
-
-## CI Gates
-
-Rezi keeps the gate split tied to real repo test entrypoints instead of abstract labels.
-
-- Fast PR gate: Linux / Node 22 quality checks plus the named release-critical package suites.
-- Full PR gate: the broader Node/OS matrix, reduced/full terminal e2e, PTY scenarios, native smoke, and Bun coverage.
-- Nightly gate: the scheduled rerun of the full cross-platform stack plus the release-critical package and terminal slices.
-- Release gate: the tag workflow repeats the release-critical slices before publishing, then runs the release matrix and Bun coverage.
-
-The release-critical suites surfaced in CI are:
-
-- Input editing and focus-capture contracts
-- Table selection, sorting, viewport, and row-key behavior
-- Virtual-list visible range and navigation behavior
-- Command palette query, async fetch, selection, and close behavior
-- File picker and file-tree explorer browse, open, and select flows
-- Modal focus entry and return behavior
-- Code editor editing, selection, and scroll behavior
-- Node terminal IO and worker/native backend flow
-
-## New Test Declarations
-
-New tests should declare two things before review:
-
-- Contract source: the docs page, public API, regression, or existing contract file that defines the behavior being pinned.
-- Fidelity: the lowest test level that can still prove the user-visible behavior, for example helper-level, semantic app/render coverage, or terminal-real PTY/e2e coverage.
-
-If the contract source is not obvious from the suite name, add a short comment near the test. If the behavior depends on terminal capabilities, stream ordering, or PTY/native behavior, prefer terminal-real coverage or explain why a lower-fidelity test is still sufficient. The pull-request template repeats this check during review.
-
-## Live PTY Rendering Validation (for UI regressions)
-
-For terminal rendering/theme/layout regressions, run a live PTY session with
-frame-audit instrumentation in addition to normal tests.
-
-Use the dedicated runbook:
+## Related Documents
 
 - [Live PTY UI Testing and Frame Audit Runbook](live-pty-debugging.md)
-
-That guide includes deterministic viewport setup, worker-mode run commands,
-scripted key driving, and cross-layer telemetry analysis.
-
-## Test Categories
-
-### Unit Tests
-
-Standard unit tests for pure functions and isolated modules. These make up the
-majority of the test suite and cover:
-
-- Layout calculations
-- Text measurement
-- Theme resolution
-- Keybinding matching
-- State machine transitions
-- Update queue ordering
-
-### Golden Tests (ZRDL/ZREV Fixtures)
-
-Golden tests compare binary output byte-for-byte against committed fixture
-files. They are used where **byte-level stability** matters:
-
-- **ZRDL fixtures** -- Drawlist output. The renderer produces a ZRDL binary
-  drawlist for a given widget tree, and the test asserts it matches a committed
-  `.zrdl` fixture file exactly.
-- **ZREV fixtures** -- Event batch parsing. A committed `.zrev` binary is
-  parsed, and the result is compared against expected structured output.
-
-Golden tests catch unintentional changes to the binary protocol. When a
-legitimate protocol change is made, the fixtures must be regenerated and
-committed alongside the code change.
-
-### Fuzz-Lite Tests (Property-Based)
-
-Bounded property-based tests for binary parsers and encoders. These tests
-generate random inputs within defined bounds and verify invariants:
-
-- Parsers never throw (they return `ParseResult`).
-- Round-trip encoding/decoding produces the original value.
-- Out-of-bounds inputs produce structured error results, not crashes.
-
-Fuzz-lite tests are fast (bounded iteration count) and run as part of the
-normal test suite -- they do not require external fuzzing infrastructure.
-
-### Integration Tests
-
-End-to-end tests that exercise the full rendering pipeline from state through
-view function to drawlist output. These tests use the `@rezi-ui/testkit`
-headless backend to run without a real terminal.
-
-Integration tests cover:
-
-- Full app lifecycle (create, render, update, destroy)
-- Widget interaction sequences (focus, input, navigation)
-- Routing and navigation
-- Resize and reflow behavior
-
-### Hot State-Preserving Reload (HSR) Tests
-
-When changing `app.replaceView(...)`, `app.replaceRoutes(...)`, `createNodeApp({ hotReload })`, or `createHotStateReload(...)`, include:
-
-- successful runtime widget-view swap test (`replaceView` while `Running`)
-- successful runtime route-table swap test (`replaceRoutes` while `Running` in route mode)
-- preservation test for local widget state/focus/cursor with stable ids/keys
-- failure-path test proving previous view/routes remain active after reload import errors
-- mode guard tests (raw mode and incompatible API usage)
-
-### Code Editor Syntax Tokenizer Tests
-
-When changing `syntaxLanguage`, tokenizer exports, or code-editor token paint behavior, include:
-
-- preset coverage for mainstream language tokenization (`typescript`, `javascript`, `json`, `go`, `rust`, `c`, `cpp`/`c++`, `csharp`/`c#`, `java`, `python`, `bash`)
-- fallback coverage for unsupported languages (`plain`)
-- custom-tokenizer override coverage (`tokenizeLine` and `tokenizeCodeEditorLineWithCustom(...)`)
-- renderer integration coverage proving tokens and active cursor-cell highlighting render together safely
-
-Quick scoped run:
-
-```bash
-node scripts/run-tests.mjs --filter "codeEditor.syntax"
-```
-
-`--filter` performs a literal substring match against discovered relative test
-file paths. It does not interpret the value as a raw regular expression.
-
-### Manual HSR + GIF Workflow
-
-Use the built-in demos under `scripts/hsr/`:
-
-```bash
-npm run hsr:demo:widget
-npm run hsr:demo:router
-```
-
-Preferred widget-demo quit keys: `F10` / `Alt+Q` / `Ctrl+C` / `Ctrl+X`.
-
-Live-edit these files while each demo is running:
-
-- widget demo: `scripts/hsr/widget-view.mjs`
-- router demo: `scripts/hsr/router-routes.mjs`
-
-Widget demo shortcut:
-
-- the in-app `self-edit-code` editor is focused on startup and shows the TypeScript snippet used for the title banner
-- edit `SELF_EDIT_BANNER = "..."` and save with `F6` (fallback: `Ctrl+O`, then `Ctrl+S`; `Enter` works on the save button) to rewrite `widget-view.mjs` from inside the demo
-- save/reload status appears in a modal overlay to avoid log noise in the capture surface
-- the banner text in the header is sourced from `widget-view.mjs` `SELF_EDIT_BANNER`, so successful HSR swaps are visually obvious
-- if your terminal uses XON/XOFF flow control, prefer `F6`/`Ctrl+O` because `Ctrl+S` may be swallowed by the terminal
-
-One-command recording:
-
-```bash
-npm run hsr:record:widget
-npm run hsr:record:router
-```
-
-`hsr:record:*` uses manual capture by default so you can type/edit freely during recording.
-
-Use scripted mode for deterministic multi-scene showcase captures:
-
-```bash
-npm run hsr:record:widget:auto
-node scripts/record-hsr-gif.mjs --mode widget --scripted
-node scripts/record-hsr-gif.mjs --mode widget --scripted --scene-text "My custom headline"
-```
-
-The recorder writes an asciinema cast and attempts GIF conversion via `agg` (or
-`asciinema gif` when available).
-
-### High-level Widget Rendering Tests
-
-For widget-level tests, prefer `createTestRenderer()` from `@rezi-ui/core` so
-tests do not need manual `commitVNodeTree() -> layout() -> renderToDrawlist()`
-setup:
-
-```typescript
-import { createTestRenderer, ui } from "@rezi-ui/core";
-
-const renderer = createTestRenderer({ viewport: { cols: 80, rows: 24 } });
-const frame = renderer.render(
-  ui.column({}, [
-    ui.text("Hello"),
-    ui.button({ id: "submit", label: "Submit" }),
-  ]),
-);
-
-frame.findText("Hello");
-frame.findById("submit");
-frame.findAll("button");
-```
-
-`frame.toText()` returns a deterministic text snapshot of the rendered screen.
-
-### Fluent Event Simulation
-
-For integration tests that need input batches, use `TestEventBuilder` instead
-of hand-encoding ZREV bytes:
-
-```typescript
-import { TestEventBuilder } from "@rezi-ui/core";
-
-const events = new TestEventBuilder();
-events.pressKey("Enter").type("hello@example.com").click(10, 5).resize(120, 40);
-
-backend.pushBatch(events.buildBatch());
-```
-
-This keeps event sequences readable and protocol-safe.
-
-### Text Snapshot Assertions
-
-Use `matchesSnapshot(...)` from `@rezi-ui/testkit` to lock rendered text frames:
-
-```typescript
-import { matchesSnapshot } from "@rezi-ui/testkit";
-
-matchesSnapshot(frame.toText(), "my-widget-default");
-```
-
-Snapshots are read from:
-
-```
-<test-directory>/__snapshots__/my-widget-default.txt
-```
-
-Set `UPDATE_SNAPSHOTS=1` when intentionally updating snapshot outputs.
-
-### Stress Tests
-
-Tests designed to exercise the system under extreme conditions:
-
-- Deep widget trees (hundreds of nesting levels)
-- Wide widget trees (thousands of siblings)
-- Rapid state update sequences
-- Large text content
-
-Stress tests verify that the runtime does not crash, exceed memory bounds, or
-exhibit non-linear performance degradation.
-
-## Animation Regression Suites
-
-Animation behavior has dedicated deterministic suites and should be run for any motion-related change:
-
-- `node --test packages/core/src/widgets/__tests__/composition.animationHooks.test.ts`
-- `node --test packages/core/src/app/__tests__/widgetRenderer.transition.test.ts`
-- `node --test packages/core/src/runtime/__tests__/commit.fastReuse.regression.test.ts`
-
-These suites cover hook retargeting/timer cleanup, `ui.box` transition property filters (`position`/`size`/`opacity`), and reconciliation fast-reuse correctness with transition props.
-
-## Reconciliation Hardening Matrix
-
-Reconciliation edge-cases are covered by dedicated runtime suites:
-
-- `packages/core/src/runtime/__tests__/reconcile.keyed.test.ts`
-- `packages/core/src/runtime/__tests__/reconcile.unkeyed.test.ts`
-- `packages/core/src/runtime/__tests__/reconcile.mixed.test.ts`
-- `packages/core/src/runtime/__tests__/reconcile.composite.test.ts`
-- `packages/core/src/runtime/__tests__/reconcile.deep.test.ts`
-
-These suites lock deterministic behavior for keyed reorder/insert/remove,
-unkeyed grow/shrink, mixed keyed+unkeyed slots, `defineWidget` hook/state
-persistence, and deep-tree reconciliation.
-
-## Renderer Correctness Audit (Baseline Lock)
-
-The renderer correctness audit maintains a baseline lock to track the known-good
-state of renderer tests:
-
-```yaml
-timestamp_utc: 2026-02-18T11:07:15Z
-head: a441bba78ddc99ece4eb76965ce36c0aec9225fe
-branch: renderer-correctness-audit
-node: v20.19.5
-npm: 10.8.2
-baseline_test_count: 2488
-```
-
-Audited areas and their dedicated test suites:
-
-| Area       | Test file                                    | Tests |
-|------------|----------------------------------------------|-------|
-| Clip       | `renderer/__tests__/renderer.clip.test.ts`   | 18    |
-| Border     | `renderer/__tests__/renderer.border.test.ts` | 45    |
-| Text       | `renderer/__tests__/renderer.text.test.ts`   | 28    |
-| Damage     | `renderer/__tests__/renderer.damage.test.ts` | 17    |
-| Scrollbar  | `renderer/__tests__/renderer.scrollbar.test.ts` | 24 |
-| **Total**  |                                              | **132** |
-
-Notable bug fix captured by the audit: `overflow: "visible"` behavior for
-`row`/`column`/`grid`/`box` containers was fixed to inherit the parent clip
-instead of always creating a local content clip.
-
-## Test Discovery
-
-The `scripts/run-tests.mjs` script discovers test files deterministically:
-
-1. **Script tests:** Recursively walks `scripts/__tests__/` for `.test.mjs`
-   files.
-2. **Package tests:** For each package in `packages/*/`, recursively walks
-   `dist/` for files matching `**/__tests__/**/*.test.js`.
-3. All discovered paths are sorted lexicographically.
-4. The combined list is passed to `node --test` as explicit file arguments.
-
-This avoids shell glob non-determinism and ensures consistent test ordering
-across platforms.
-
-## Adding New Tests
-
-1. **Create the test file.** Place it in a `__tests__/` directory adjacent to
-   the module being tested:
-
-    ```
-    packages/core/src/layout/__tests__/myModule.test.ts
-    ```
-
-2. **Use `node:test` APIs.** Import `describe`, `it`, and `assert` from
-   `node:test` and `node:assert`:
-
-    ```typescript
-    import { describe, it } from "node:test";
-    import assert from "node:assert/strict";
-
-    describe("myModule", () => {
-      it("should compute the correct value", () => {
-        assert.strictEqual(myFunction(1, 2), 3);
-      });
-    });
-    ```
-
-3. **Build.** Run `npm run build` so the TypeScript test file is compiled to
-   `dist/`.
-
-4. **Run.** Execute the full suite or just your new file:
-
-    ```bash
-    npm test
-    # or
-    node --test packages/core/dist/layout/__tests__/myModule.test.js
-    ```
-
-## CI Integration
-
-Tests run automatically through the workflow split described above instead of a
-single CI flow.
-
-Pull requests and pushes use `ci.yml`:
-
-1. Fast gate:
-   `fast gate / quality` runs the blocking repo checks with `npm ci`,
-   `npm run lint`, `npm run typecheck`, `npm run build`, and the existing
-   guardrail commands.
-2. Fast gate:
-   `fast gate / release-critical suites` runs `npm run test:progress` and
-   `npm run test:release-critical`, which surfaces the named release-critical
-   package suites separately from the broader matrix.
-3. Full gate:
-   `full gate / create-rezi smoke`, `full gate / node <version> / <os>`, and
-   `full gate / bun / ubuntu-latest` run after the fast gate and cover the
-   broader matrix, replay harness, PTY/native build work, terminal e2e, native
-   smoke, and Bun coverage. These jobs also use `npm ci`.
-
-Nightly runs use `nightly.yml`:
-
-1. `nightly gate / release-critical suites` repeats the package slice and the
-   terminal slice (`npm run test:release-critical:terminal`).
-2. `nightly gate / create-rezi smoke`, the 3x3 Node/OS matrix, and Bun rerun
-   the current full stack on a schedule.
-
-Tag-based release runs use `release.yml`:
-
-1. `release gate / quality preflight` performs the blocking publish checks with
-   `npm ci`.
-2. `release gate / release-critical suites` repeats the named release-critical
-   package and terminal slices before the release matrix.
-3. `release gate / create-rezi smoke`, `release gate / node <version> / <os>`,
-   and `release gate / bun / ubuntu-latest` run the remaining release checks.
-
-The separate release-critical job is the visible mapping from the gate model to
-the named release-critical suites listed earlier in this document. Failures in
-those jobs block the downstream full or release fan-out work.
-
-## Related
-
-- [Perf Regressions](./perf-regressions.md)
-- [Repro Replay](./repro-replay.md)
-- [Build](build.md)
+- [Guide: Testing Rezi Apps](../guide/testing.md)
+- [Contributing](contributing.md)
+- [Agent Workflow Guide](https://github.com/RtlZeroMemory/Rezi/blob/main/AGENTS.md)

--- a/docs/guide/testing.md
+++ b/docs/guide/testing.md
@@ -1,6 +1,10 @@
 # Testing
 
-This guide is the entry point for testing Rezi apps and framework changes.
+This guide is the entry point for testing Rezi apps.
+
+If you are changing the Rezi framework itself, use the canonical developer
+policy instead:
+- [Developer Testing Policy](../dev/testing.md)
 
 ## Quick start
 
@@ -28,29 +32,34 @@ Filter to a subset:
 node scripts/run-tests.mjs --filter "layout"
 ```
 
-`--filter` matches a literal substring in the discovered relative test file
-paths.
+## What to test in an app
 
-## What to test
+Focus on user-visible behavior:
+- state changes and action flow
+- rendering and layout behavior
+- focus and keyboard interaction
+- mouse, wheel, and paste behavior when your app supports them
+- resize and reflow behavior
+- bug regressions
 
-- Unit behavior for pure helpers and validators.
-- Integration behavior for rendering, routing, and event flow.
-- Regression coverage for bugs (repro test first, then fix).
-- Snapshot/visual stability for renderer-facing changes.
-- Responsive behavior validation across multiple viewport sizes (`**/*.test.{ts,tsx,js,jsx}`).
+## Choosing the right test level
 
-## Renderer and widget tests
+Use the lowest level that proves the behavior.
 
-For high-level widget assertions, prefer `createTestRenderer()` so tests can use:
+- Unit tests for pure helpers and reducers.
+- Semantic rendering or scenario tests for app behavior that does not require a real terminal.
+- PTY validation for terminal-visible behavior, terminal capability behavior, or terminal input recovery that headless tests cannot prove safely.
 
-- `findById(...)`
-- `findAll(...)`
-- `findText(...)`
-- `toText()`
+`createTestRenderer()` is useful for semantic rendering assertions, but it is
+not the final oracle for terminal-real behavior.
 
-## Snapshot workflow
+## Snapshots
 
-Use the snapshot CLI:
+Use snapshots only when the snapshot encodes a clear contract.
+Do not use snapshots as a substitute for deciding what behavior the app should
+have.
+
+Snapshot CLI:
 
 ```bash
 node scripts/rezi-snap.mjs --verify
@@ -59,13 +68,13 @@ node scripts/rezi-snap.mjs --update
 
 ## UI regression validation
 
-For layout/theme/render regressions, include a live PTY run with frame-audit evidence:
-
+For layout, theme, rendering, or capability-sensitive regressions, include a
+live PTY run with frame-audit evidence:
 - [Live PTY UI Testing and Frame Audit Runbook](../dev/live-pty-debugging.md)
 
 ## Related
 
+- [Developer Testing Policy](../dev/testing.md)
 - [Hooks Reference](hooks-reference.md)
 - [Debugging](debugging.md)
-- [Dev Testing Deep Dive](../dev/testing.md)
 - [Testkit Package](../packages/testkit.md)

--- a/tsconfig.base.json
+++ b/tsconfig.base.json
@@ -3,6 +3,17 @@
     "target": "ES2022",
     "module": "ESNext",
     "moduleResolution": "Bundler",
+    "baseUrl": ".",
+    "paths": {
+      "@rezi-ui/core": ["packages/core/src/index.ts"],
+      "@rezi-ui/core/*": ["packages/core/src/*"],
+      "@rezi-ui/node": ["packages/node/src/index.ts"],
+      "@rezi-ui/node/*": ["packages/node/src/*"],
+      "@rezi-ui/testkit": ["packages/testkit/src/index.ts"],
+      "@rezi-ui/testkit/*": ["packages/testkit/src/*"],
+      "@rezi-ui/jsx": ["packages/jsx/src/index.ts"],
+      "@rezi-ui/jsx/*": ["packages/jsx/src/*"]
+    },
     "strict": true,
     "noImplicitAny": true,
     "useUnknownInCatchVariables": true,


### PR DESCRIPTION
## Summary

- make `docs/dev/testing.md` the canonical testing policy
- align `AGENTS.md`, `CONTRIBUTING.md`, and `docs/dev/contributing.md` to that policy
- keep `docs/guide/testing.md` lighter and user-facing while correcting the `createTestRenderer()` guidance
- add minimal PR template prompts for contract source, fidelity, and degraded/failure-path coverage
- fix `docs:build` on current `main` by adding workspace package subpath resolution to `tsconfig.base.json`

## Why

The repo had testing guidance in multiple places, but it did not enforce the same behavior-first standard everywhere.
The docs also overstated headless helpers relative to terminal-real validation.
On top of that, `docs:build` was broken because source builds could not resolve package subpath imports such as `@rezi-ui/core/testing`.

## Files changed

- `docs/dev/testing.md`
- `AGENTS.md`
- `CONTRIBUTING.md`
- `docs/dev/contributing.md`
- `docs/guide/testing.md`
- `.github/PULL_REQUEST_TEMPLATE.md`
- `tsconfig.base.json`

## Verification

- `npm run build`
- `npm run docs:build`
- forbidden-term search across changed repo files returned no matches
- changed links and target paths were validated directly on disk

## Notes

- `docs:build` still emits one existing Typedoc warning for `core/src.supportsCursorProtocol` and the upstream MkDocs Material warning banner, but the build completes successfully.
- No internal planning documents or gap-analysis notes were added to the repo.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Established a new Testing Policy framework with requirements for behavior-first assertions, test fidelity guidance, and failure-path coverage.
  * Updated contribution guidelines and developer documentation to reflect new testing standards.
  * Restructured PR template with updated testing checklist.

* **Chores**
  * Added TypeScript module path aliases for improved import resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->