### PR TITLE
docs: refresh README overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,45 +1,25 @@
 # Rezi
 
-Rezi is a deterministic, native-backed TypeScript TUI framework for Node.js and Bun.
+Rezi is a TypeScript framework for building terminal user interfaces on Node.js and Bun. It provides a declarative widget API, deterministic input and rendering behavior, and a native-backed rendering pipeline through the Zireael engine.
 
-> **Status: pre-alpha**. Rezi is under active development. Public APIs, ABI details, and behavior may change between releases. It is not yet recommended for production workloads.
+> **Status: pre-alpha.** Rezi is under active development. Public APIs, native ABI details, and behavior may change between releases. It is not yet recommended for production workloads.
 
-Rezi is built for terminal applications that need predictable rendering, explicit input routing, and a strong testing surface. The canonical API is `ui.*`; JSX support is available through `@rezi-ui/jsx`.
+**Links:** [Website](https://rezitui.dev/) · [Docs](https://rezitui.dev/docs/) · [Quickstart](https://rezitui.dev/docs/getting-started/quickstart/) · [Widgets](https://rezitui.dev/docs/widgets/) · [Benchmarks](https://rezitui.dev/docs/benchmarks/)
 
-## Focus
+## What Rezi Is For
 
-- Deterministic rendering and input routing
-- Native-backed layout and framebuffer diffing through Zireael
-- Focus, forms, routing, themes, and testing primitives
-- A small public template set for scaffolding and examples
+Rezi is aimed at terminal applications that need more than line-oriented output: multi-panel layouts, routed screens, focusable controls, forms, tables, overlays, testing support, and predictable behavior under keyboard and mouse input.
 
-## Performance
+The canonical authoring surface is `ui.*`. JSX is available through `@rezi-ui/jsx`, but the framework does not depend on React.
 
-Rezi is built to stay fast on real terminal workloads. Benchmark methodology, results, and caveats are documented in [BENCHMARKS.md](BENCHMARKS.md) and [docs/benchmarks.md](docs/benchmarks.md).
+## What Rezi Includes
 
-## Quick Start
-
-```bash
-npm create rezi my-app
-cd my-app
-npm run start
-```
-
-Or with Bun:
-
-```bash
-bun create rezi my-app
-cd my-app
-bun run start
-```
-
-Public starter templates:
-
-- `minimal` - single-screen utility starter
-- `cli-tool` - routed multi-screen workflow starter
-- `starship` - advanced console starter with tabs, charts, overlays, and broad widget coverage
-
-See [docs/getting-started/create-rezi.md](docs/getting-started/create-rezi.md) for the public template guide.
+- Layout primitives for rows, columns, grids, panels, spacing, and layered screens
+- Interactive widgets such as buttons, inputs, selects, checkboxes, radios, sliders, tabs, tables, virtual lists, trees, dialogs, dropdowns, and toasts
+- Graphics and data-display widgets including canvas, charts, gauges, sparklines, heatmaps, and image support
+- Application primitives for focus management, keybindings, routing, theming, and controlled state updates
+- Testing utilities and deterministic rendering behavior intended to make TUI code easier to verify
+- A native-backed rendering path through Zireael for layout, framebuffer diffing, and terminal output
 
 ## Example
 
@@ -47,7 +27,9 @@ See [docs/getting-started/create-rezi.md](docs/getting-started/create-rezi.md) f
 import { ui } from "@rezi-ui/core";
 import { createNodeApp } from "@rezi-ui/node";
 
-const app = createNodeApp<{ count: number }>({ initialState: { count: 0 } });
+type State = { count: number };
+
+const app = createNodeApp<State>({ initialState: { count: 0 } });
 
 app.view((state) =>
   ui.page({
@@ -62,15 +44,15 @@ app.view((state) =>
           id: "inc",
           label: "+1",
           intent: "primary",
-          onPress: () => app.update((prev) => ({ count: prev.count + 1 })),
+          onPress: () => app.update((s) => ({ count: s.count + 1 })),
         }),
       ]),
     ]),
-  })
+  }),
 );
 
 app.keys({ q: () => app.stop() });
-await app.start();
+await app.run();
 ```
 
 Install:
@@ -79,19 +61,49 @@ Install:
 npm install @rezi-ui/core @rezi-ui/node
 ```
 
-## Architecture
+## Quick Start
 
-| Layer | Purpose |
+```bash
+npm create rezi my-app
+cd my-app
+npm run start
+```
+
+With Bun:
+
+```bash
+bun create rezi my-app
+cd my-app
+bun run start
+```
+
+## Public Templates
+
+- `minimal` - small single-screen starter
+- `cli-tool` - routed multi-screen workflow starter
+- `starship` - larger console-style starter showing tabs, charts, forms, and overlays
+
+## Packages
+
+| Package | Purpose |
 |---|---|
-| `@rezi-ui/core` | Runtime-agnostic widget API, layout, routing, focus, forms, themes, testing hooks |
-| `@rezi-ui/node` | Node.js/Bun backend, terminal I/O, scheduling, native engine integration |
+| `@rezi-ui/core` | Widget API, layout, routing, focus, forms, themes, testing hooks |
+| `@rezi-ui/node` | Node/Bun backend, terminal I/O, scheduling, native integration |
 | `@rezi-ui/native` | N-API binding to the Zireael engine |
-| `@rezi-ui/jsx` | Optional JSX runtime over the core widget API |
+| `@rezi-ui/jsx` | Optional JSX runtime over the core API |
+| `@rezi-ui/testkit` | Testing utilities |
+| `create-rezi` | Project scaffolding CLI |
 
-## Docs
+## Performance
+
+Rezi is designed to stay fast on structured terminal workloads. Benchmark methodology, caveats, and committed result snapshots are documented in [BENCHMARKS.md](BENCHMARKS.md) and [docs/benchmarks.md](docs/benchmarks.md).
+
+## Documentation
 
 - [Install](docs/getting-started/install.md)
 - [Quickstart](docs/getting-started/quickstart.md)
-- [Widget catalog](docs/widgets/index.md)
+- [Create Rezi](docs/getting-started/create-rezi.md)
+- [Widget Catalog](docs/widgets/index.md)
 - [Examples](docs/getting-started/examples.md)
+- [Architecture](docs/architecture/index.md)
 - [Benchmarks](docs/benchmarks.md)


### PR DESCRIPTION
## Summary
- rewrite the root README into a fuller, more grounded project overview
- move high-value links up and explain what Rezi is for before diving into setup
- keep the example aligned with the current `ui.*` API and `createNodeApp(...)/app.run()` convention
- replace the stripped-down tone with a serious pre-alpha framing that still explains the framework surface

## Validation
- parsed the README example directly from the markdown fence with TypeScript and got no syntax diagnostics
- checked the example and links against the current worktree exports/docs
- ran `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Documentation**
  * Improved framework description emphasizing declarative widget API and rendering pipeline.
  * Reorganized README with new sections for links, packages, and public templates.
  * Updated code examples and expanded package documentation.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->