### PR TITLE
fix: isolate create-rezi nested installs on Windows

### DIFF
--- a/packages/create-rezi/src/__tests__/index.test.ts
+++ b/packages/create-rezi/src/__tests__/index.test.ts
@@ -1,0 +1,39 @@
+import { resolve } from "node:path";
+import { assert, test } from "@rezi-ui/testkit";
+import { createInstallEnv, resolveInstallCwd } from "../index.js";
+
+test("resolveInstallCwd resolves targetDir against the current base directory", () => {
+  assert.equal(resolveInstallCwd("my-app", "/tmp/rezi-parent"), resolve("/tmp/rezi-parent", "my-app"));
+});
+
+test("createInstallEnv strips parent npm lifecycle metadata but preserves useful config", () => {
+  const env = {
+    PATH: "/usr/bin",
+    HOME: "/tmp/home",
+    INIT_CWD: "V:\\rezitest2",
+    npm_command: "exec",
+    npm_execpath: "C:\\Program Files\\nodejs\\node_modules\\npm\\bin\\npm-cli.js",
+    npm_lifecycle_event: "npx",
+    npm_lifecycle_script: "create-rezi my-app",
+    npm_config_local_prefix: "V:\\rezitest2",
+    npm_package_name: "rezitest2",
+    npm_package_json: "V:\\rezitest2\\package.json",
+    npm_config_registry: "https://registry.npmjs.org/",
+    npm_config_user_agent: "npm/10.8.2 node/v20.19.5 win32 x64 workspaces/false",
+  } as const;
+
+  const childEnv = createInstallEnv(env);
+
+  assert.equal(childEnv.PATH, env.PATH);
+  assert.equal(childEnv.HOME, env.HOME);
+  assert.equal(childEnv.npm_config_registry, env.npm_config_registry);
+  assert.equal(childEnv.npm_config_user_agent, env.npm_config_user_agent);
+  assert.equal(childEnv.INIT_CWD, undefined);
+  assert.equal(childEnv.npm_command, undefined);
+  assert.equal(childEnv.npm_execpath, undefined);
+  assert.equal(childEnv.npm_lifecycle_event, undefined);
+  assert.equal(childEnv.npm_lifecycle_script, undefined);
+  assert.equal(childEnv.npm_config_local_prefix, undefined);
+  assert.equal(childEnv.npm_package_name, undefined);
+  assert.equal(childEnv.npm_package_json, undefined);
+});

--- a/packages/create-rezi/src/index.ts
+++ b/packages/create-rezi/src/index.ts
@@ -25,6 +25,17 @@ type CliOptions = {
   help: boolean;
 };
 
+const INSTALL_ENV_EXACT_BLOCKLIST = new Set([
+  "init_cwd",
+  "npm_command",
+  "npm_config_argv",
+  "npm_config_local_prefix",
+  "npm_config_prefix",
+  "npm_execpath",
+  "npm_node_execpath",
+  "npm_prefix",
+]);
+
 function parseArgs(argv: string[]): CliOptions {
   const options: CliOptions = {
     install: true,
@@ -129,6 +140,31 @@ function resolvePackageManager(value?: string): PackageManager {
   throw new Error(`Unsupported package manager: ${value}`);
 }
 
+function shouldStripInstallEnvKey(key: string): boolean {
+  const normalized = key.toLowerCase();
+  return (
+    INSTALL_ENV_EXACT_BLOCKLIST.has(normalized) ||
+    normalized.startsWith("npm_lifecycle_") ||
+    normalized.startsWith("npm_package_")
+  );
+}
+
+export function createInstallEnv(
+  parentEnv: Readonly<Record<string, string | undefined>> = process.env,
+): NodeJS.ProcessEnv {
+  const childEnv: NodeJS.ProcessEnv = { ...parentEnv };
+  for (const key of Object.keys(childEnv)) {
+    if (shouldStripInstallEnvKey(key)) {
+      delete childEnv[key];
+    }
+  }
+  return childEnv;
+}
+
+export function resolveInstallCwd(targetDir: string, baseDir: string = cwd()): string {
+  return resolve(baseDir, targetDir);
+}
+
 async function promptText(
   rl: ReturnType<typeof createInterface>,
   prompt: string,
@@ -163,10 +199,15 @@ async function promptTemplate(rl: ReturnType<typeof createInterface>): Promise<s
 }
 
 function runInstall(pm: PackageManager, targetDir: string): void {
+  const installCwd = resolveInstallCwd(targetDir);
   const res = spawnSync(pm, ["install"], {
-    cwd: targetDir,
+    cwd: installCwd,
     stdio: "inherit",
+    env: createInstallEnv(),
   });
+  if (res.error) {
+    throw res.error;
+  }
   if (res.status !== 0) {
     throw new Error(`${pm} install failed`);
   }


### PR DESCRIPTION
## Summary
- sanitize the environment passed to the nested package-manager install in `create-rezi`
- strip leaked parent npm lifecycle/package metadata such as `INIT_CWD`, `npm_lifecycle_*`, `npm_package_*`, and local prefix fields
- resolve the install `cwd` to an absolute path before spawning the child install
- add a regression test for the exact nested-`npm create` env shape seen on Windows

## Why
A Windows replay showed `npm create rezi my-app` scaffolding the app successfully but failing during the internal `npm install`. The npm error still pointed at the parent directory and outer command:
- path: parent folder
- command: `create-rezi my-app`

That indicates the child install inherited outer `npm create` lifecycle metadata and was not running as a clean install in the generated app directory.

## Validation
- direct smoke check of `createInstallEnv(...)` with the replayed npm env shape passed
- `git diff --check` passed

## Note
I could not run the full repo test/typecheck suite in the clean worktree because the worktree did not have the repo dependencies installed, but the change is narrowly scoped to `packages/create-rezi`.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Installation environment is now automatically sanitized to remove npm lifecycle-related configuration variables, reducing potential conflicts during setup.
  * Installation directory path resolution capability added for improved deployment flexibility.

* **Tests**
  * Added comprehensive test coverage for environment sanitization and directory resolution functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->