### PR TITLE
fix(create-rezi): harden windows scaffold installs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,11 @@ The format is based on Keep a Changelog and the project follows Semantic Version
 
 ## [Unreleased]
 
+### Bug Fixes
+
+- **create-rezi/cli**: Fixed Windows nested installs by switching `create-rezi` to the standard `cross-spawn` process launcher and by resolving npm installs through the active npm entrypoint instead of relying on Git Bash shell resolution.
+- **create-rezi/minimal**: Replaced the invalid bare `+` keybinding in the minimal template with Windows-safe `=` / `shift+=` bindings while keeping `+` as an accepted command alias.
+
 ## [0.1.0-alpha.68] - 2026-04-15
 
 ### CI / Tooling

--- a/package-lock.json
+++ b/package-lock.json
@@ -1777,6 +1777,16 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/@types/cross-spawn": {
+      "version": "6.0.6",
+      "resolved": "https://registry.npmjs.org/@types/cross-spawn/-/cross-spawn-6.0.6.tgz",
+      "integrity": "sha512-fXRhhUkG4H3TQk5dBhQ7m/JDdSNHKwR2BBia62lhwEIq9xGiQKLxd6LymNhn47SjXhsUEPmxi+PKw2OkW4LLjA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/node": "*"
+      }
+    },
     "node_modules/@types/hast": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/@types/hast/-/hast-3.0.4.tgz",
@@ -2182,6 +2192,20 @@
     "node_modules/create-rezi": {
       "resolved": "packages/create-rezi",
       "link": true
+    },
+    "node_modules/cross-spawn": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-7.0.6.tgz",
+      "integrity": "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA==",
+      "license": "MIT",
+      "dependencies": {
+        "path-key": "^3.1.0",
+        "shebang-command": "^2.0.0",
+        "which": "^2.0.1"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
     },
     "node_modules/csstype": {
       "version": "3.2.3",
@@ -2754,6 +2778,12 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/isexe": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/isexe/-/isexe-2.0.0.tgz",
+      "integrity": "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw==",
+      "license": "ISC"
+    },
     "node_modules/jimp": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/jimp/-/jimp-1.6.0.tgz",
@@ -3201,6 +3231,15 @@
         "xml2js": "^0.5.0"
       }
     },
+    "node_modules/path-key": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/path-key/-/path-key-3.1.1.tgz",
+      "integrity": "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/path-parse": {
       "version": "1.0.7",
       "resolved": "https://registry.npmjs.org/path-parse/-/path-parse-1.0.7.tgz",
@@ -3604,6 +3643,27 @@
         "node": ">=16.13.0"
       }
     },
+    "node_modules/shebang-command": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-2.0.0.tgz",
+      "integrity": "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA==",
+      "license": "MIT",
+      "dependencies": {
+        "shebang-regex": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/shebang-regex": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/shebang-regex/-/shebang-regex-3.0.0.tgz",
+      "integrity": "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/shell-quote": {
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.8.3.tgz",
@@ -3662,17 +3722,6 @@
       "integrity": "sha512-D9cPgkvLlV3t3IzL0D0YLvGA9Ahk4PcvVwUbN0dSGr1aP0Nrt4AEnTUbuGvquEC0mA64Gqt1fzirlRs5ibXx8g==",
       "dev": true,
       "license": "BSD-3-Clause"
-    },
-    "node_modules/stage-js": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/stage-js/-/stage-js-1.0.1.tgz",
-      "integrity": "sha512-cz14aPp/wY0s3bkb/B93BPP5ZAEhgBbRmAT3CCDqert8eCAqIpQ0RB2zpK8Ksxf+Pisl5oTzvPHtL4CVzzeHcw==",
-      "license": "MIT",
-      "optional": true,
-      "peer": true,
-      "engines": {
-        "node": ">=18.0"
-      }
     },
     "node_modules/string_decoder": {
       "version": "1.3.0",
@@ -4080,6 +4129,21 @@
         }
       }
     },
+    "node_modules/which": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
+      "integrity": "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA==",
+      "license": "ISC",
+      "dependencies": {
+        "isexe": "^2.0.0"
+      },
+      "bin": {
+        "node-which": "bin/node-which"
+      },
+      "engines": {
+        "node": ">= 8"
+      }
+    },
     "node_modules/ws": {
       "version": "8.19.0",
       "resolved": "https://registry.npmjs.org/ws/-/ws-8.19.0.tgz",
@@ -4432,11 +4496,15 @@
     "packages/create-rezi": {
       "version": "0.1.0-alpha.61",
       "license": "Apache-2.0",
+      "dependencies": {
+        "cross-spawn": "^7.0.6"
+      },
       "bin": {
         "create-rezi": "dist/index.js"
       },
       "devDependencies": {
-        "@rezi-ui/testkit": "0.1.0-alpha.61"
+        "@rezi-ui/testkit": "0.1.0-alpha.61",
+        "@types/cross-spawn": "^6.0.6"
       },
       "engines": {
         "bun": ">=1.3.0",

--- a/packages/create-rezi/package.json
+++ b/packages/create-rezi/package.json
@@ -22,6 +22,10 @@
     "bun": ">=1.3.0"
   },
   "devDependencies": {
-    "@rezi-ui/testkit": "0.1.0-alpha.61"
+    "@rezi-ui/testkit": "0.1.0-alpha.61",
+    "@types/cross-spawn": "^6.0.6"
+  },
+  "dependencies": {
+    "cross-spawn": "^7.0.6"
   }
 }

--- a/packages/create-rezi/src/__tests__/index.test.ts
+++ b/packages/create-rezi/src/__tests__/index.test.ts
@@ -74,6 +74,21 @@ test("resolveInstallInvocation prefers npm_execpath and falls back to node-adjac
 
   assert.deepEqual(
     resolveInstallInvocation("npm", {
+      env: {
+        npm_execpath:
+          "C:\\Users\\example\\AppData\\Roaming\\npm\\node_modules\\pnpm\\bin\\pnpm.cjs",
+      },
+      platform: "win32",
+      nodeExecPath: "C:\\Program Files\\nodejs\\node.exe",
+    }),
+    {
+      command: "C:\\Program Files\\nodejs\\npm.cmd",
+      args: ["install"],
+    },
+  );
+
+  assert.deepEqual(
+    resolveInstallInvocation("npm", {
       env: {},
       platform: "win32",
       nodeExecPath: "C:\\Program Files\\nodejs\\node.exe",

--- a/packages/create-rezi/src/__tests__/index.test.ts
+++ b/packages/create-rezi/src/__tests__/index.test.ts
@@ -1,6 +1,6 @@
 import { resolve } from "node:path";
 import { assert, test } from "@rezi-ui/testkit";
-import { createInstallEnv, resolveInstallCwd } from "../index.js";
+import { createInstallEnv, resolveInstallCwd, resolveInstallInvocation } from "../index.js";
 
 test("resolveInstallCwd resolves targetDir against the current base directory", () => {
   assert.equal(
@@ -52,4 +52,47 @@ test("createInstallEnv strips parent npm lifecycle metadata but preserves useful
   assert.equal(childEnv.npm_config_local_prefix, undefined);
   assert.equal(childEnv.npm_package_name, undefined);
   assert.equal(childEnv.npm_package_json, undefined);
+});
+
+test("resolveInstallInvocation prefers npm_execpath and falls back to node-adjacent npm.cmd on Windows", () => {
+  assert.deepEqual(
+    resolveInstallInvocation("npm", {
+      env: {
+        npm_execpath: "C:\\Users\\k3nig\\AppData\\Roaming\\npm\\node_modules\\npm\\bin\\npm-cli.js",
+      },
+      platform: "win32",
+      nodeExecPath: "C:\\Program Files\\nodejs\\node.exe",
+    }),
+    {
+      command: "C:\\Program Files\\nodejs\\node.exe",
+      args: [
+        "C:\\Users\\k3nig\\AppData\\Roaming\\npm\\node_modules\\npm\\bin\\npm-cli.js",
+        "install",
+      ],
+    },
+  );
+
+  assert.deepEqual(
+    resolveInstallInvocation("npm", {
+      env: {},
+      platform: "win32",
+      nodeExecPath: "C:\\Program Files\\nodejs\\node.exe",
+    }),
+    {
+      command: "C:\\Program Files\\nodejs\\npm.cmd",
+      args: ["install"],
+    },
+  );
+
+  assert.deepEqual(
+    resolveInstallInvocation("pnpm", {
+      env: {},
+      platform: "win32",
+      nodeExecPath: "C:\\Program Files\\nodejs\\node.exe",
+    }),
+    {
+      command: "pnpm",
+      args: ["install"],
+    },
+  );
 });

--- a/packages/create-rezi/src/__tests__/index.test.ts
+++ b/packages/create-rezi/src/__tests__/index.test.ts
@@ -2,6 +2,9 @@ import { resolve } from "node:path";
 import { assert, test } from "@rezi-ui/testkit";
 import { createInstallEnv, resolveInstallCwd, resolveInstallInvocation } from "../index.js";
 
+const WINDOWS_ROAMING_NPM_EXEC_PATH =
+  "C:\\Users\\example\\AppData\\Roaming\\npm\\node_modules\\npm\\bin\\npm-cli.js";
+
 test("resolveInstallCwd resolves targetDir against the current base directory", () => {
   assert.equal(
     resolveInstallCwd("my-app", "/tmp/rezi-parent"),
@@ -58,17 +61,14 @@ test("resolveInstallInvocation prefers npm_execpath and falls back to node-adjac
   assert.deepEqual(
     resolveInstallInvocation("npm", {
       env: {
-        npm_execpath: "C:\\Users\\k3nig\\AppData\\Roaming\\npm\\node_modules\\npm\\bin\\npm-cli.js",
+        npm_execpath: WINDOWS_ROAMING_NPM_EXEC_PATH,
       },
       platform: "win32",
       nodeExecPath: "C:\\Program Files\\nodejs\\node.exe",
     }),
     {
       command: "C:\\Program Files\\nodejs\\node.exe",
-      args: [
-        "C:\\Users\\k3nig\\AppData\\Roaming\\npm\\node_modules\\npm\\bin\\npm-cli.js",
-        "install",
-      ],
+      args: [WINDOWS_ROAMING_NPM_EXEC_PATH, "install"],
     },
   );
 

--- a/packages/create-rezi/src/index.ts
+++ b/packages/create-rezi/src/index.ts
@@ -1,5 +1,5 @@
 #!/usr/bin/env node
-import { dirname, join, relative, resolve } from "node:path";
+import { dirname, join, relative, resolve, win32 } from "node:path";
 import { cwd, exit, stdin, stdout } from "node:process";
 import { createInterface } from "node:readline/promises";
 import * as crossSpawn from "cross-spawn";
@@ -184,7 +184,7 @@ export function resolveInstallInvocation(
       return { command: nodeExecPath, args: [npmExecPath, "install"] };
     }
     if (platform === "win32") {
-      return { command: join(dirname(nodeExecPath), "npm.cmd"), args: ["install"] };
+      return { command: win32.join(win32.dirname(nodeExecPath), "npm.cmd"), args: ["install"] };
     }
   }
 

--- a/packages/create-rezi/src/index.ts
+++ b/packages/create-rezi/src/index.ts
@@ -149,6 +149,15 @@ function shouldStripInstallEnvKey(key: string): boolean {
   );
 }
 
+function isNpmExecPath(execPath: string): boolean {
+  const normalized = execPath.replaceAll("\\", "/").toLowerCase();
+  return (
+    normalized.endsWith("/npm-cli.js") ||
+    normalized.endsWith("/npm-cli.mjs") ||
+    /(^|\/)npm(\.cmd|\.exe)?$/.test(normalized)
+  );
+}
+
 export function createInstallEnv(
   parentEnv: Readonly<Record<string, string | undefined>> = process.env,
 ): NodeJS.ProcessEnv {
@@ -180,7 +189,7 @@ export function resolveInstallInvocation(
   if (packageManager === "npm") {
     // biome-ignore lint/complexity/useLiteralKeys: process.env-compatible maps use index signatures in TS.
     const npmExecPath = env["npm_execpath"];
-    if (npmExecPath) {
+    if (npmExecPath && isNpmExecPath(npmExecPath)) {
       return { command: nodeExecPath, args: [npmExecPath, "install"] };
     }
     if (platform === "win32") {

--- a/packages/create-rezi/src/index.ts
+++ b/packages/create-rezi/src/index.ts
@@ -1,8 +1,8 @@
 #!/usr/bin/env node
-import { spawnSync } from "node:child_process";
-import { relative, resolve } from "node:path";
+import { dirname, join, relative, resolve } from "node:path";
 import { cwd, exit, stdin, stdout } from "node:process";
 import { createInterface } from "node:readline/promises";
+import * as crossSpawn from "cross-spawn";
 import { isMainModuleEntry } from "./mainEntry.js";
 import {
   TEMPLATE_DEFINITIONS,
@@ -165,6 +165,32 @@ export function resolveInstallCwd(targetDir: string, baseDir: string = cwd()): s
   return resolve(baseDir, targetDir);
 }
 
+export function resolveInstallInvocation(
+  packageManager: PackageManager,
+  {
+    env = process.env,
+    platform = process.platform,
+    nodeExecPath = process.execPath,
+  }: {
+    env?: Readonly<Record<string, string | undefined>>;
+    platform?: NodeJS.Platform;
+    nodeExecPath?: string;
+  } = {},
+): { command: string; args: string[] } {
+  if (packageManager === "npm") {
+    // biome-ignore lint/complexity/useLiteralKeys: process.env-compatible maps use index signatures in TS.
+    const npmExecPath = env["npm_execpath"];
+    if (npmExecPath) {
+      return { command: nodeExecPath, args: [npmExecPath, "install"] };
+    }
+    if (platform === "win32") {
+      return { command: join(dirname(nodeExecPath), "npm.cmd"), args: ["install"] };
+    }
+  }
+
+  return { command: packageManager, args: ["install"] };
+}
+
 async function promptText(
   rl: ReturnType<typeof createInterface>,
   prompt: string,
@@ -200,7 +226,8 @@ async function promptTemplate(rl: ReturnType<typeof createInterface>): Promise<s
 
 function runInstall(pm: PackageManager, targetDir: string): void {
   const installCwd = resolveInstallCwd(targetDir);
-  const res = spawnSync(pm, ["install"], {
+  const installInvocation = resolveInstallInvocation(pm);
+  const res = crossSpawn.sync(installInvocation.command, installInvocation.args, {
     cwd: installCwd,
     stdio: "inherit",
     env: createInstallEnv(),

--- a/packages/create-rezi/templates/minimal/src/__tests__/keybindings.test.ts
+++ b/packages/create-rezi/templates/minimal/src/__tests__/keybindings.test.ts
@@ -4,6 +4,7 @@ import { resolveMinimalCommand } from "../helpers/keybindings.js";
 
 test("minimal keybinding map resolves expected commands", () => {
   assert.equal(resolveMinimalCommand("q"), "quit");
+  assert.equal(resolveMinimalCommand("="), "increment");
   assert.equal(resolveMinimalCommand("+"), "increment");
   assert.equal(resolveMinimalCommand("-"), "decrement");
   assert.equal(resolveMinimalCommand("t"), "cycle-theme");

--- a/packages/create-rezi/templates/minimal/src/helpers/keybindings.ts
+++ b/packages/create-rezi/templates/minimal/src/helpers/keybindings.ts
@@ -11,6 +11,7 @@ const COMMAND_BY_KEY: Readonly<Record<string, MinimalCommand>> = Object.freeze({
   "ctrl+c": "quit",
   h: "toggle-help",
   "shift+/": "toggle-help",
+  "=": "increment",
   "+": "increment",
   "shift+=": "increment",
   "-": "decrement",

--- a/packages/create-rezi/templates/minimal/src/main.ts
+++ b/packages/create-rezi/templates/minimal/src/main.ts
@@ -125,7 +125,7 @@ app.keys({
   "ctrl+c": () => applyCommand(resolveMinimalCommand("ctrl+c")),
   h: () => applyCommand(resolveMinimalCommand("h")),
   "shift+/": () => applyCommand(resolveMinimalCommand("shift+/")),
-  "+": () => applyCommand(resolveMinimalCommand("+")),
+  "=": () => applyCommand(resolveMinimalCommand("=")),
   "shift+=": () => applyCommand(resolveMinimalCommand("shift+=")),
   "-": () => applyCommand(resolveMinimalCommand("-")),
   t: () => applyCommand(resolveMinimalCommand("t")),


### PR DESCRIPTION
## Summary
- switch create-rezi Windows installs to the standard cross-spawn launcher and resolve npm through the active npm entrypoint
- add a regression test for npm_execpath / npm.cmd install invocation resolution
- fix the minimal template plus-keybinding so generated apps do not bind an invalid bare '+' sequence

## Validation
- npm install
- npx biome check CHANGELOG.md packages/create-rezi/package.json packages/create-rezi/src/index.ts packages/create-rezi/src/__tests__/index.test.ts packages/create-rezi/templates/minimal/src/main.ts packages/create-rezi/templates/minimal/src/helpers/keybindings.ts packages/create-rezi/templates/minimal/src/__tests__/keybindings.test.ts
- npx tsc -b packages/testkit/tsconfig.json packages/create-rezi/tsconfig.json
- node scripts/run-tests.mjs --filter "create-rezi"
- npx tsx --test packages/create-rezi/templates/minimal/src/__tests__/keybindings.test.ts
- node scripts/release-set-version.mjs 0.1.0-alpha.68
- node packages/create-rezi/dist/index.js V:\temp\rezi-smoke-minimal --template minimal
- npm run start (confirmed tsx launch and cleared the original create-rezi install failure; remaining backend engine_create failure is outside this regression scope)
- node scripts/release-set-version.mjs 0.1.0-alpha.61


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved Windows nested-install issues so project creation reliably runs package installs using the active npm entrypoint instead of failing under Git Bash.
  * Improved minimal template keybindings: replaced an invalid `+` binding with `=` (and `Shift+=` on Windows) while preserving `+` as a command alias, ensuring consistent behavior across platforms.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->