### PR TITLE
Fix modal mouse isolation

### DIFF
--- a/packages/core/src/app/__tests__/widgetBehavior.contracts.test.ts
+++ b/packages/core/src/app/__tests__/widgetBehavior.contracts.test.ts
@@ -359,6 +359,45 @@ describe("modal, overlay, and focus behavior contracts", () => {
     assert.equal(renderer.getFocusedId(), "cancel");
   });
 
+  test("blank modal space does not route clicks to background widgets", () => {
+    const renderer = new WidgetRenderer<void>({
+      backend: createNoopBackend(),
+      requestRender: () => {},
+    });
+
+    let backgroundPresses = 0;
+    const view = () =>
+      ui.layers([
+        ui.column({}, [
+          ui.button({
+            id: "background",
+            label: "Background action",
+            onPress: () => {
+              backgroundPresses++;
+            },
+          }),
+        ]),
+        ui.modal({
+          id: "confirm",
+          title: "Confirm",
+          width: "full",
+          height: "full",
+          initialFocus: "cancel",
+          closeOnBackdrop: false,
+          content: ui.text("Confirm action"),
+          actions: [ui.button({ id: "cancel", label: "Cancel" })],
+        }),
+      ]);
+
+    submit(renderer, view);
+    const bgCenter = centerOf(renderer, "background");
+    renderer.routeEngineEvent(mouseEvent(bgCenter.x, bgCenter.y, 3, { buttons: 1 }));
+    renderer.routeEngineEvent(mouseEvent(bgCenter.x, bgCenter.y, 4));
+
+    assert.equal(backgroundPresses, 0);
+    assert.equal(renderer.getFocusedId(), "cancel");
+  });
+
   test("Escape closes a dialog and restores focus to returnFocusTo", () => {
     const renderer = new WidgetRenderer<void>({
       backend: createNoopBackend(),

--- a/packages/core/src/app/__tests__/widgetBehavior.contracts.test.ts
+++ b/packages/core/src/app/__tests__/widgetBehavior.contracts.test.ts
@@ -398,6 +398,60 @@ describe("modal, overlay, and focus behavior contracts", () => {
     assert.equal(renderer.getFocusedId(), "cancel");
   });
 
+  test("top layer above a modal still receives mouse presses", () => {
+    const renderer = new WidgetRenderer<void>({
+      backend: createNoopBackend(),
+      requestRender: () => {},
+    });
+
+    let backgroundPresses = 0;
+    let topLayerPresses = 0;
+    const view = () =>
+      ui.layers([
+        ui.column({}, [
+          ui.button({
+            id: "background",
+            label: "Background action",
+            onPress: () => {
+              backgroundPresses++;
+            },
+          }),
+        ]),
+        ui.modal({
+          id: "confirm",
+          title: "Confirm",
+          width: "full",
+          height: "full",
+          initialFocus: "cancel",
+          closeOnBackdrop: false,
+          content: ui.text("Confirm action"),
+          actions: [ui.button({ id: "cancel", label: "Cancel" })],
+        }),
+        ui.layer({
+          id: "top-layer",
+          zIndex: 10_000,
+          content: ui.column({}, [
+            ui.button({
+              id: "top-action",
+              label: "Top action",
+              onPress: () => {
+                topLayerPresses++;
+              },
+            }),
+          ]),
+        }),
+      ]);
+
+    submit(renderer, view);
+    const topCenter = centerOf(renderer, "top-action");
+    renderer.routeEngineEvent(mouseEvent(topCenter.x, topCenter.y, 3, { buttons: 1 }));
+    renderer.routeEngineEvent(mouseEvent(topCenter.x, topCenter.y, 4));
+
+    assert.equal(topLayerPresses, 1);
+    assert.equal(backgroundPresses, 0);
+    assert.equal(renderer.getFocusedId(), "top-action");
+  });
+
   test("Escape closes a dialog and restores focus to returnFocusTo", () => {
     const renderer = new WidgetRenderer<void>({
       backend: createNoopBackend(),

--- a/packages/core/src/app/widgetRenderer/routeEngineEvent.ts
+++ b/packages/core/src/app/widgetRenderer/routeEngineEvent.ts
@@ -327,8 +327,7 @@ export function routeEngineEventImpl(
   const prevPressedId = state.pressedId;
 
   const focusedId = state.focusState.focusedId;
-  const mouseTargets =
-    event.kind === "mouse" ? resolveMouseTargets(ctx, event.x, event.y) : null;
+  const mouseTargets = event.kind === "mouse" ? resolveMouseTargets(ctx, event.x, event.y) : null;
   const mouseTargetId = mouseTargets?.focusableId ?? null;
   const mouseTargetAnyId = mouseTargets?.anyId ?? null;
   let localNeedsRender = false;

--- a/packages/core/src/app/widgetRenderer/routeEngineEvent.ts
+++ b/packages/core/src/app/widgetRenderer/routeEngineEvent.ts
@@ -165,6 +165,54 @@ function extendMousePressableIds(
   return merged ?? pressableIds;
 }
 
+function readNodeId(layout: LayoutTree): string | null {
+  const raw = (layout.vnode.props as { id?: unknown }).id;
+  return typeof raw === "string" && raw.length > 0 ? raw : null;
+}
+
+function findLayoutNodeById(layout: LayoutTree, id: string): LayoutTree | null {
+  const stack: LayoutTree[] = [layout];
+  while (stack.length > 0) {
+    const node = stack.pop();
+    if (!node) continue;
+    if (readNodeId(node) === id) return node;
+    for (let i = node.children.length - 1; i >= 0; i--) {
+      const child = node.children[i];
+      if (child) stack.push(child);
+    }
+  }
+  return null;
+}
+
+function containsPoint(rect: Rect, x: number, y: number): boolean {
+  return x >= rect.x && x < rect.x + rect.w && y >= rect.y && y < rect.y + rect.h;
+}
+
+function resolveMouseTargets(
+  ctx: RouteEngineEventContext,
+  x: number,
+  y: number,
+): Readonly<{ focusableId: string | null; anyId: string | null }> {
+  if (!ctx.committedRoot || !ctx.layoutTree) {
+    return Object.freeze({ focusableId: null, anyId: null });
+  }
+
+  const topmostModal = ctx.layerRegistry.getTopmostModal();
+  if (topmostModal && containsPoint(topmostModal.rect, x, y)) {
+    const modalLayout = findLayoutNodeById(ctx.layoutTree, topmostModal.id);
+    if (!modalLayout) return Object.freeze({ focusableId: null, anyId: null });
+    return Object.freeze({
+      focusableId: hitTestFocusable(modalLayout.vnode, modalLayout, x, y),
+      anyId: hitTestAnyId(modalLayout, x, y),
+    });
+  }
+
+  return Object.freeze({
+    focusableId: hitTestFocusable(ctx.committedRoot.vnode, ctx.layoutTree, x, y),
+    anyId: hitTestAnyId(ctx.layoutTree, x, y),
+  });
+}
+
 export type RouteEngineEventOutcome = Readonly<{
   needsRender: boolean;
   action?: RoutedAction;
@@ -279,12 +327,10 @@ export function routeEngineEventImpl(
   const prevPressedId = state.pressedId;
 
   const focusedId = state.focusState.focusedId;
-  const mouseTargetId =
-    event.kind === "mouse"
-      ? hitTestFocusable(ctx.committedRoot.vnode, ctx.layoutTree, event.x, event.y)
-      : null;
-  const mouseTargetAnyId =
-    event.kind === "mouse" ? hitTestAnyId(ctx.layoutTree, event.x, event.y) : null;
+  const mouseTargets =
+    event.kind === "mouse" ? resolveMouseTargets(ctx, event.x, event.y) : null;
+  const mouseTargetId = mouseTargets?.focusableId ?? null;
+  const mouseTargetAnyId = mouseTargets?.anyId ?? null;
   let localNeedsRender = false;
 
   // Overlay routing: dropdown key navigation, layer/modal ESC close, and modal backdrop blocking.

--- a/packages/core/src/app/widgetRenderer/routeEngineEvent.ts
+++ b/packages/core/src/app/widgetRenderer/routeEngineEvent.ts
@@ -9,7 +9,7 @@ import type { RuntimeInstance } from "../../runtime/commit.js";
 import type { FocusManagerState } from "../../runtime/focus.js";
 import type { InputSelection, InputUndoStack } from "../../runtime/inputEditor.js";
 import type { InstanceId } from "../../runtime/instance.js";
-import type { LayerRegistry } from "../../runtime/layers.js";
+import { type LayerRegistry, hitTestLayers } from "../../runtime/layers.js";
 import type {
   TableStateStore,
   TreeStateStore,
@@ -95,6 +95,8 @@ const ROUTE_NO_RENDER_CONSUMED: RouteEngineEventOutcome = Object.freeze({
 });
 const EMPTY_STRING_ARRAY: readonly string[] = Object.freeze([]);
 const EMPTY_COMMAND_ITEMS: readonly CommandItem[] = Object.freeze([]);
+const EMPTY_MOUSE_TARGETS: Readonly<{ focusableId: string | null; anyId: string | null }> =
+  Object.freeze({ focusableId: null, anyId: null });
 
 type PressedDropdown = Readonly<{ id: string; itemId: string }> | null;
 type PressedVirtualList = Readonly<{ id: string; index: number }> | null;
@@ -194,13 +196,18 @@ function resolveMouseTargets(
   y: number,
 ): Readonly<{ focusableId: string | null; anyId: string | null }> {
   if (!ctx.committedRoot || !ctx.layoutTree) {
-    return Object.freeze({ focusableId: null, anyId: null });
+    return EMPTY_MOUSE_TARGETS;
   }
 
   const topmostModal = ctx.layerRegistry.getTopmostModal();
-  if (topmostModal && containsPoint(topmostModal.rect, x, y)) {
+  const layerHit = topmostModal ? hitTestLayers(ctx.layerRegistry, x, y) : null;
+  if (
+    topmostModal &&
+    layerHit?.layer?.id === topmostModal.id &&
+    containsPoint(topmostModal.rect, x, y)
+  ) {
     const modalLayout = findLayoutNodeById(ctx.layoutTree, topmostModal.id);
-    if (!modalLayout) return Object.freeze({ focusableId: null, anyId: null });
+    if (!modalLayout) return EMPTY_MOUSE_TARGETS;
     return Object.freeze({
       focusableId: hitTestFocusable(modalLayout.vnode, modalLayout, x, y),
       anyId: hitTestAnyId(modalLayout, x, y),

--- a/packages/create-rezi/src/scaffold.ts
+++ b/packages/create-rezi/src/scaffold.ts
@@ -42,7 +42,8 @@ export const TEMPLATE_DEFINITIONS: readonly TemplateDefinition[] = [
   {
     key: "starship",
     label: "Starship Command Console",
-    description: "Larger command-console showcase for routing, animation, charts, forms, and overlays",
+    description:
+      "Larger command-console showcase for routing, animation, charts, forms, and overlays",
     safetyTag: "safe-default",
     safetyNote:
       "Feature-rich showcase template with moderate CPU usage from animation hooks and live telemetry.",


### PR DESCRIPTION
## Summary

- Scope generic mouse hit-testing to the top modal's layout subtree when the modal is the actual top hit layer.
- Keep non-modal layers above modals reachable by mouse.
- Add regression tests for blank modal space and top-layer mouse routing.

## Rationale

Modal layers were blocking backdrop clicks, but clicks inside blank modal space still used full-tree hit-testing. That allowed widgets behind the modal to receive focus or press actions if they occupied the same screen cells.

The modal-scoped hit-test also needs to respect higher layers. If a non-modal layer sits above a modal, it must receive mouse events before the modal subtree is considered.

## Validation

- `npm run lint`
- `npm run build`
- `node scripts/run-tests.mjs --filter widgetBehavior.contracts`
- `npm run typecheck -- --pretty false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved mouse event handling for modals and overlays to ensure proper event routing based on z-ordering and backdrop interactions.

* **Tests**
  * Added contract tests for modal behavior, including backdrop interactions and layer stacking verification.

* **Chores**
  * Updated template documentation formatting.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->