### PR TITLE
Fix widget callback isolation

### DIFF
--- a/packages/core/src/app/__tests__/widgetBehavior.contracts.test.ts
+++ b/packages/core/src/app/__tests__/widgetBehavior.contracts.test.ts
@@ -68,6 +68,19 @@ function mouseEvent(
   };
 }
 
+function captureWarnings<T>(fn: () => T): Readonly<{ result: T; warnings: readonly string[] }> {
+  const originalWarn = console.warn;
+  const warnings: string[] = [];
+  console.warn = (message?: unknown) => {
+    warnings.push(String(message));
+  };
+  try {
+    return Object.freeze({ result: fn(), warnings: Object.freeze(warnings.slice()) });
+  } finally {
+    console.warn = originalWarn;
+  }
+}
+
 function submit(
   renderer: WidgetRenderer<void>,
   view: () => VNode,
@@ -218,6 +231,70 @@ describe("input and textarea behavior contracts", () => {
 
     assert.equal(renderer.getFocusedId(), "next");
     assert.equal(blurCount, 1);
+  });
+});
+
+describe("widget callback isolation contracts", () => {
+  test("button callback exceptions do not escape mouse routing", () => {
+    const renderer = new WidgetRenderer<void>({
+      backend: createNoopBackend(),
+      requestRender: () => {},
+    });
+
+    const view = () =>
+      ui.button({
+        id: "danger",
+        label: "Run",
+        onPress: () => {
+          throw new Error("button failed");
+        },
+      });
+
+    submit(renderer, view);
+
+    const center = centerOf(renderer, "danger");
+    renderer.routeEngineEvent(mouseEvent(center.x, center.y, 3, { buttons: 1 }));
+    const { result, warnings } = captureWarnings(() =>
+      renderer.routeEngineEvent(mouseEvent(center.x, center.y, 4)),
+    );
+
+    assert.deepEqual(result.action, { id: "danger", action: "press" });
+    assert.equal(renderer.getFocusedId(), "danger");
+    assert.equal(
+      warnings.some((entry) => entry.includes("button.onPress callback threw: button failed")),
+      true,
+    );
+  });
+
+  test("checkbox callback exceptions do not escape keyboard routing", () => {
+    const renderer = new WidgetRenderer<void>({
+      backend: createNoopBackend(),
+      requestRender: () => {},
+    });
+
+    const view = () =>
+      ui.checkbox({
+        id: "accept",
+        label: "Accept",
+        checked: false,
+        onChange: () => {
+          throw new Error("checkbox failed");
+        },
+      });
+
+    submit(renderer, view);
+    renderer.routeEngineEvent(keyEvent(ZR_KEY_TAB));
+    assert.equal(renderer.getFocusedId(), "accept");
+
+    const { result, warnings } = captureWarnings(() =>
+      renderer.routeEngineEvent(keyEvent(ZR_KEY_SPACE)),
+    );
+
+    assert.deepEqual(result.action, { id: "accept", action: "toggle", checked: true });
+    assert.equal(
+      warnings.some((entry) => entry.includes("checkbox.onChange callback threw: checkbox failed")),
+      true,
+    );
   });
 });
 

--- a/packages/core/src/app/widgetRenderer/codeEditorRouting.ts
+++ b/packages/core/src/app/widgetRenderer/codeEditorRouting.ts
@@ -30,6 +30,7 @@ import {
   normalizeSelection,
 } from "../../widgets/codeEditor.js";
 import type { CodeEditorProps } from "../../widgets/types.js";
+import { invokeCallbackSafely } from "./safeCallback.js";
 
 export type CodeEditorRoutingResult = Readonly<{ needsRender: boolean }>;
 
@@ -67,10 +68,13 @@ export function routeCodeEditorKeyDown(
         })
       : null;
 
-    if (isShift) editor.onSelectionChange(nextSelection);
-    else if (editor.selection !== null) editor.onSelectionChange(null);
+    if (isShift) {
+      invokeCallbackSafely("codeEditor.onSelectionChange", editor.onSelectionChange, nextSelection);
+    } else if (editor.selection !== null) {
+      invokeCallbackSafely("codeEditor.onSelectionChange", editor.onSelectionChange, null);
+    }
 
-    editor.onChange(editor.lines, nextCursor);
+    invokeCallbackSafely("codeEditor.onChange", editor.onChange, editor.lines, nextCursor);
 
     let nextScrollTop = editor.scrollTop;
     nextScrollTop = ensureCursorVisible(nextScrollTop, nextCursor, viewportHeight);
@@ -82,21 +86,21 @@ export function routeCodeEditorKeyDown(
     }
 
     if (nextScrollTop !== editor.scrollTop || nextScrollLeft !== editor.scrollLeft) {
-      editor.onScroll(nextScrollTop, nextScrollLeft);
+      invokeCallbackSafely("codeEditor.onScroll", editor.onScroll, nextScrollTop, nextScrollLeft);
     }
   };
 
   // Undo/redo shortcuts
   if (isCtrl && event.key === 90 /* Z */) {
     if (isShift) {
-      editor.onRedo?.();
+      invokeCallbackSafely("codeEditor.onRedo", editor.onRedo);
     } else {
-      editor.onUndo?.();
+      invokeCallbackSafely("codeEditor.onUndo", editor.onUndo);
     }
     return Object.freeze({ needsRender: true });
   }
   if (isCtrl && event.key === 89 /* Y */) {
-    editor.onRedo?.();
+    invokeCallbackSafely("codeEditor.onRedo", editor.onRedo);
     return Object.freeze({ needsRender: true });
   }
 
@@ -104,14 +108,23 @@ export function routeCodeEditorKeyDown(
   if (isCtrl && event.key === 65 /* A */) {
     const lastLine = Math.max(0, editor.lines.length - 1);
     const endCol = (editor.lines[lastLine] ?? "").length;
-    editor.onSelectionChange(
+    invokeCallbackSafely(
+      "codeEditor.onSelectionChange",
+      editor.onSelectionChange,
       Object.freeze({
         anchor: Object.freeze({ line: 0, column: 0 }),
         active: Object.freeze({ line: lastLine, column: endCol }),
       }),
     );
-    editor.onChange(editor.lines, Object.freeze({ line: lastLine, column: endCol }));
-    editor.onScroll(
+    invokeCallbackSafely(
+      "codeEditor.onChange",
+      editor.onChange,
+      editor.lines,
+      Object.freeze({ line: lastLine, column: endCol }),
+    );
+    invokeCallbackSafely(
+      "codeEditor.onScroll",
+      editor.onScroll,
       ensureCursorVisible(editor.scrollTop, { line: lastLine, column: endCol }, viewportHeight),
       editor.scrollLeft,
     );
@@ -124,7 +137,12 @@ export function routeCodeEditorKeyDown(
     const maxScroll = Math.max(0, editor.lines.length - viewportHeight);
     const nextScrollTop = Math.max(0, Math.min(maxScroll, editor.scrollTop + dir * viewportHeight));
     if (nextScrollTop !== editor.scrollTop) {
-      editor.onScroll(nextScrollTop, editor.scrollLeft);
+      invokeCallbackSafely(
+        "codeEditor.onScroll",
+        editor.onScroll,
+        nextScrollTop,
+        editor.scrollLeft,
+      );
       return Object.freeze({ needsRender: true });
     }
     return Object.freeze({ needsRender: false });
@@ -143,8 +161,13 @@ export function routeCodeEditorKeyDown(
       const nextLines = isShift
         ? dedentLines(editor.lines, Object.freeze([startLine, endLine]), tabSize)
         : indentLines(editor.lines, Object.freeze([startLine, endLine]), tabSize, insertSpaces);
-      editor.onSelectionChange(null);
-      editor.onChange(nextLines, clampCursor(editor.cursor));
+      invokeCallbackSafely("codeEditor.onSelectionChange", editor.onSelectionChange, null);
+      invokeCallbackSafely(
+        "codeEditor.onChange",
+        editor.onChange,
+        nextLines,
+        clampCursor(editor.cursor),
+      );
       return Object.freeze({ needsRender: true });
     }
 
@@ -167,7 +190,12 @@ export function routeCodeEditorKeyDown(
           line: editor.cursor.line,
           column: Math.max(0, editor.cursor.column - Math.min(editor.cursor.column, removed)),
         });
-        editor.onChange(nextLines, clampCursor(nextCursor));
+        invokeCallbackSafely(
+          "codeEditor.onChange",
+          editor.onChange,
+          nextLines,
+          clampCursor(nextCursor),
+        );
         return Object.freeze({ needsRender: true });
       }
       return Object.freeze({ needsRender: false });
@@ -180,8 +208,10 @@ export function routeCodeEditorKeyDown(
       base ? base.cursor : editor.cursor,
       indent,
     );
-    if (editor.selection !== null) editor.onSelectionChange(null);
-    editor.onChange(next.lines, next.cursor);
+    if (editor.selection !== null) {
+      invokeCallbackSafely("codeEditor.onSelectionChange", editor.onSelectionChange, null);
+    }
+    invokeCallbackSafely("codeEditor.onChange", editor.onChange, next.lines, next.cursor);
     return Object.freeze({ needsRender: true });
   }
 
@@ -192,8 +222,10 @@ export function routeCodeEditorKeyDown(
       : event.key === ZR_KEY_BACKSPACE
         ? deleteCharBefore(editor.lines, editor.cursor)
         : deleteCharAfter(editor.lines, editor.cursor);
-    if (editor.selection !== null) editor.onSelectionChange(null);
-    editor.onChange(next.lines, next.cursor);
+    if (editor.selection !== null) {
+      invokeCallbackSafely("codeEditor.onSelectionChange", editor.onSelectionChange, null);
+    }
+    invokeCallbackSafely("codeEditor.onChange", editor.onChange, next.lines, next.cursor);
     return Object.freeze({ needsRender: true });
   }
 
@@ -204,8 +236,10 @@ export function routeCodeEditorKeyDown(
     const cursor = base ? base.cursor : editor.cursor;
     const indent = computeAutoIndent(lines, cursor, tabSize);
     const next = insertText(lines, cursor, `\n${indent}`);
-    if (editor.selection !== null) editor.onSelectionChange(null);
-    editor.onChange(next.lines, next.cursor);
+    if (editor.selection !== null) {
+      invokeCallbackSafely("codeEditor.onSelectionChange", editor.onSelectionChange, null);
+    }
+    invokeCallbackSafely("codeEditor.onChange", editor.onChange, next.lines, next.cursor);
     return Object.freeze({ needsRender: true });
   }
 

--- a/packages/core/src/app/widgetRenderer/commandPaletteRouting.ts
+++ b/packages/core/src/app/widgetRenderer/commandPaletteRouting.ts
@@ -10,6 +10,7 @@ import {
 } from "../../keybindings/keyCodes.js";
 import { getFilteredItems } from "../../widgets/commandPalette.js";
 import type { CommandItem, CommandPaletteProps } from "../../widgets/types.js";
+import { invokeCallbackSafely } from "./safeCallback.js";
 
 function popLastCodePoint(s: string): string {
   if (s.length === 0) return s;
@@ -33,7 +34,7 @@ export function routeCommandPaletteKeyDown(
   if (palette.open !== true) return false;
 
   if (event.key === ZR_KEY_ESCAPE) {
-    palette.onClose();
+    invokeCallbackSafely("commandPalette.onClose", palette.onClose);
     return true;
   }
 
@@ -68,7 +69,9 @@ export function routeCommandPaletteKeyDown(
         (keyDown ? findNextEnabledIndex(palette.selectedIndex, 1) : null) ??
         findFirstEnabledIndex() ??
         0;
-      if (next !== palette.selectedIndex) palette.onSelectionChange(next);
+      if (next !== palette.selectedIndex) {
+        invokeCallbackSafely("commandPalette.onSelectionChange", palette.onSelectionChange, next);
+      }
     }
     return true;
   }
@@ -95,8 +98,8 @@ export function routeCommandPaletteKeyDown(
         prefixes[(idx + 1 + prefixes.length) % prefixes.length] ?? prefixes[0] ?? "";
       const nextQuery = bare.length > 0 ? `${nextPrefix} ${bare}` : nextPrefix;
 
-      palette.onChange(nextQuery);
-      if (palette.onSelectionChange) palette.onSelectionChange(0);
+      invokeCallbackSafely("commandPalette.onChange", palette.onChange, nextQuery);
+      invokeCallbackSafely("commandPalette.onSelectionChange", palette.onSelectionChange, 0);
       return true;
     }
   }
@@ -113,15 +116,19 @@ export function routeCommandPaletteKeyDown(
           ? items[fallback]
           : null;
     if (item && item.disabled !== true) {
-      palette.onSelect(item);
-      palette.onClose();
+      invokeCallbackSafely("commandPalette.onSelect", palette.onSelect, item);
+      invokeCallbackSafely("commandPalette.onClose", palette.onClose);
     }
     return true;
   }
 
   if (event.key === ZR_KEY_BACKSPACE && palette.query.length > 0) {
-    palette.onChange(popLastCodePoint(palette.query));
-    if (palette.onSelectionChange) palette.onSelectionChange(0);
+    invokeCallbackSafely(
+      "commandPalette.onChange",
+      palette.onChange,
+      popLastCodePoint(palette.query),
+    );
+    invokeCallbackSafely("commandPalette.onSelectionChange", palette.onSelectionChange, 0);
     return true;
   }
 

--- a/packages/core/src/app/widgetRenderer/filePickerRouting.ts
+++ b/packages/core/src/app/widgetRenderer/filePickerRouting.ts
@@ -14,6 +14,7 @@ import {
   readFileNodeFlatCache,
   readFilePickerFlatCache,
 } from "./fileNodeCache.js";
+import { invokeCallbackSafely } from "./safeCallback.js";
 
 const EMPTY_STRING_ARRAY: readonly string[] = Object.freeze([]);
 
@@ -145,12 +146,12 @@ export function routeFileTreeExplorerKeyDown(
 
   if (r.nodeToSelect) {
     const found = flatNodes.find((n) => n.key === r.nodeToSelect);
-    if (found) fte.onSelect(found.node);
+    if (found) invokeCallbackSafely("fileTreeExplorer.onSelect", fte.onSelect, found.node);
   }
 
   if (r.nodeToActivate) {
     const found = flatNodes.find((n) => n.key === r.nodeToActivate);
-    if (found) fte.onPress(found.node);
+    if (found) invokeCallbackSafely("fileTreeExplorer.onPress", fte.onPress, found.node);
   }
 
   if (r.nextExpanded !== undefined) {
@@ -162,7 +163,9 @@ export function routeFileTreeExplorerKeyDown(
 
     for (const k of diffs) {
       const found = flatNodes.find((n) => n.key === k);
-      if (found) fte.onChange(found.node, next.has(k));
+      if (found) {
+        invokeCallbackSafely("fileTreeExplorer.onChange", fte.onChange, found.node, next.has(k));
+      }
     }
   }
 
@@ -220,7 +223,11 @@ export function routeFilePickerKeyDown(
     fp.onSelectionChange
   ) {
     const nextSelection = toggleFilePickerSelection(fp.selection, focusedKey);
-    fp.onSelectionChange(nextSelection.selection);
+    invokeCallbackSafely(
+      "filePicker.onSelectionChange",
+      fp.onSelectionChange,
+      nextSelection.selection,
+    );
     return true;
   }
 
@@ -242,7 +249,7 @@ export function routeFilePickerKeyDown(
   }
 
   if (r.nodeToSelect) {
-    fp.onSelect(r.nodeToSelect);
+    invokeCallbackSafely("filePicker.onSelect", fp.onSelect, r.nodeToSelect);
   }
 
   if (r.nodeToActivate) {
@@ -250,9 +257,9 @@ export function routeFilePickerKeyDown(
     if (found) {
       if (found.hasChildren) {
         const isExpanded = fp.expandedPaths.includes(found.key);
-        fp.onChange(found.key, !isExpanded);
+        invokeCallbackSafely("filePicker.onChange", fp.onChange, found.key, !isExpanded);
       } else if (found.node.type !== "directory") {
-        fp.onPress(found.key);
+        invokeCallbackSafely("filePicker.onPress", fp.onPress, found.key);
       }
     }
   }
@@ -264,7 +271,7 @@ export function routeFilePickerKeyDown(
     for (const k of next) if (!prev.has(k)) diffs.push(k);
     for (const k of prev) if (!next.has(k)) diffs.push(k);
     for (const k of diffs) {
-      fp.onChange(k, next.has(k));
+      invokeCallbackSafely("filePicker.onChange", fp.onChange, k, next.has(k));
     }
   }
 

--- a/packages/core/src/app/widgetRenderer/keyboardRouting.ts
+++ b/packages/core/src/app/widgetRenderer/keyboardRouting.ts
@@ -44,6 +44,7 @@ import {
   resolveVirtualListItemHeightSpec,
 } from "../../widgets/virtualList.js";
 import type { LogsConsoleRenderCache, TableRenderCache } from "./renderCaches.js";
+import { invokeCallbackSafely } from "./safeCallback.js";
 
 export type KeyboardRoutingOutcome = Readonly<{
   needsRender: boolean;
@@ -133,7 +134,7 @@ export function routeToastActionKeyDown(
   ) {
     const cb = ctx.toastActionByFocusId.get(focusedId);
     if (cb) {
-      cb();
+      invokeCallbackSafely("toast action", cb);
       return ROUTE_RENDER;
     }
   }
@@ -173,7 +174,7 @@ export function routeLogsConsoleKeyDown(
     const delta = isUp ? -1 : 1;
     const nextScrollTop = Math.max(0, Math.min(maxScroll, logs.scrollTop + delta));
     if (nextScrollTop !== logs.scrollTop) {
-      logs.onScroll(nextScrollTop);
+      invokeCallbackSafely("logsConsole.onScroll", logs.onScroll, nextScrollTop);
       return ROUTE_RENDER;
     }
     return ROUTE_NO_RENDER;
@@ -182,7 +183,7 @@ export function routeLogsConsoleKeyDown(
   if (key === 71 /* G */) {
     if (isShift) {
       if (logs.scrollTop !== maxScroll) {
-        logs.onScroll(maxScroll);
+        invokeCallbackSafely("logsConsole.onScroll", logs.onScroll, maxScroll);
         return ROUTE_RENDER;
       }
       return ROUTE_NO_RENDER;
@@ -193,7 +194,7 @@ export function routeLogsConsoleKeyDown(
     if (prevG !== undefined && event.timeMs - prevG <= 500) {
       ctx.logsConsoleLastGTimeById.delete(logs.id);
       if (logs.scrollTop !== 0) {
-        logs.onScroll(0);
+        invokeCallbackSafely("logsConsole.onScroll", logs.onScroll, 0);
         return ROUTE_RENDER;
       }
       return ROUTE_NO_RENDER;
@@ -202,7 +203,7 @@ export function routeLogsConsoleKeyDown(
   }
 
   if (!isShift && key === 67 /* C */ && logs.onPress) {
-    logs.onPress();
+    invokeCallbackSafely("logsConsole.onPress", logs.onPress);
     return ROUTE_RENDER;
   }
 
@@ -211,7 +212,7 @@ export function routeLogsConsoleKeyDown(
     const entry = filtered[idx];
     if (entry) {
       const expanded = logs.expandedEntries?.includes(entry.id) ?? false;
-      logs.onChange(entry.id, !expanded);
+      invokeCallbackSafely("logsConsole.onChange", logs.onChange, entry.id, !expanded);
       return ROUTE_RENDER;
     }
     return ROUTE_NO_RENDER;
@@ -245,7 +246,11 @@ export function routeDiffViewerKeyDown(
   if (isNext || isPrev) {
     const nextFocused = navigateHunk(focusedHunk, isNext ? "next" : "prev", hunkCount);
     ctx.diffViewerFocusedHunkById.set(diff.id, nextFocused);
-    diff.onScroll(getHunkScrollPosition(nextFocused, diff.diff.hunks));
+    invokeCallbackSafely(
+      "diffViewer.onScroll",
+      diff.onScroll,
+      getHunkScrollPosition(nextFocused, diff.diff.hunks),
+    );
     return ROUTE_RENDER;
   }
 
@@ -257,24 +262,24 @@ export function routeDiffViewerKeyDown(
     if (expanded) next.delete(focusedHunk);
     else next.add(focusedHunk);
     ctx.diffViewerExpandedHunksById.set(diff.id, next);
-    diff.onHunkToggle?.(focusedHunk, !expanded);
+    invokeCallbackSafely("diffViewer.onHunkToggle", diff.onHunkToggle, focusedHunk, !expanded);
     return ROUTE_RENDER;
   }
 
   if (!isShift && key === 83 /* S */ && diff.onStageHunk) {
-    diff.onStageHunk(focusedHunk);
+    invokeCallbackSafely("diffViewer.onStageHunk", diff.onStageHunk, focusedHunk);
     return ROUTE_RENDER;
   }
   if (!isShift && key === 85 /* U */ && diff.onUnstageHunk) {
-    diff.onUnstageHunk(focusedHunk);
+    invokeCallbackSafely("diffViewer.onUnstageHunk", diff.onUnstageHunk, focusedHunk);
     return ROUTE_RENDER;
   }
   if (!isShift && key === 65 /* A */ && diff.onApplyHunk) {
-    diff.onApplyHunk(focusedHunk);
+    invokeCallbackSafely("diffViewer.onApplyHunk", diff.onApplyHunk, focusedHunk);
     return ROUTE_RENDER;
   }
   if (!isShift && key === 82 /* R */ && diff.onRevertHunk) {
-    diff.onRevertHunk(focusedHunk);
+    invokeCallbackSafely("diffViewer.onRevertHunk", diff.onRevertHunk, focusedHunk);
     return ROUTE_RENDER;
   }
 
@@ -335,13 +340,18 @@ export function routeVirtualListKeyDown(
       overscan,
       measuredHeights,
     );
-    vlist.onScroll(r.nextScrollTop, [startIndex, endIndex]);
+    invokeCallbackSafely("virtualList.onScroll", vlist.onScroll, r.nextScrollTop, [
+      startIndex,
+      endIndex,
+    ]);
   }
 
   let routedAction: RoutedAction | undefined;
   if (r.action) {
     const item = vlist.items[r.action.index];
-    if (item !== undefined && vlist.onSelect) vlist.onSelect(item, r.action.index);
+    if (item !== undefined && vlist.onSelect) {
+      invokeCallbackSafely("virtualList.onSelect", vlist.onSelect, item, r.action.index);
+    }
     routedAction = Object.freeze({
       id: r.action.id,
       action: "select",
@@ -440,7 +450,7 @@ export function routeTableKeyDown(
         if (col && col.sortable === true && typeof table.onSort === "function") {
           const nextDirection: "asc" | "desc" =
             table.sortColumn === col.key && table.sortDirection === "asc" ? "desc" : "asc";
-          table.onSort(col.key, nextDirection);
+          invokeCallbackSafely("table.onSort", table.onSort, col.key, nextDirection);
           return ROUTE_RENDER;
         }
         return ROUTE_NO_RENDER;
@@ -487,13 +497,15 @@ export function routeTableKeyDown(
       }
 
       if (r.nextSelection !== undefined && table.onSelectionChange) {
-        table.onSelectionChange(r.nextSelection);
+        invokeCallbackSafely("table.onSelectionChange", table.onSelectionChange, r.nextSelection);
       }
 
       let routedAction: RoutedAction | undefined;
       if (r.action) {
         const row = table.data[r.action.rowIndex];
-        if (row !== undefined && table.onRowPress) table.onRowPress(row, r.action.rowIndex);
+        if (row !== undefined && table.onRowPress) {
+          invokeCallbackSafely("table.onRowPress", table.onRowPress, row, r.action.rowIndex);
+        }
         routedAction = Object.freeze({
           id: r.action.id,
           action: "rowPress",
@@ -600,14 +612,16 @@ export function routeTreeKeyDown(
 
   if (r.nodeToSelect && tree.onSelect) {
     const found = flatNodes.find((n) => n.key === r.nodeToSelect);
-    if (found) tree.onSelect(found.node as unknown);
+    if (found) invokeCallbackSafely("tree.onSelect", tree.onSelect, found.node as unknown);
   }
 
   let routedAction: RoutedAction | undefined;
 
   if (r.nodeToActivate) {
     const found = flatNodes.find((n) => n.key === r.nodeToActivate);
-    if (found && tree.onPress) tree.onPress(found.node as unknown);
+    if (found && tree.onPress) {
+      invokeCallbackSafely("tree.onPress", tree.onPress, found.node as unknown);
+    }
     routedAction = Object.freeze({
       id: tree.id,
       action: "activate",
@@ -659,7 +673,9 @@ export function routeTreeKeyDown(
 
     for (const k of diffs) {
       const found = flatNodes.find((n) => n.key === k);
-      if (found) tree.onChange(found.node as unknown, next.has(k));
+      if (found) {
+        invokeCallbackSafely("tree.onChange", tree.onChange, found.node as unknown, next.has(k));
+      }
     }
   }
 
@@ -705,7 +721,7 @@ export function routeSliderKeyDown(
   });
   const nextValue = adjustSliderValue(normalized.value, normalized, adjustment);
   if (nextValue !== normalized.value) {
-    slider.onChange(nextValue);
+    invokeCallbackSafely("slider.onChange", slider.onChange, nextValue);
     return ROUTE_RENDER;
   }
   return ROUTE_NO_RENDER;
@@ -740,7 +756,7 @@ export function routeSelectKeyDown(
     const nextIdx = idx < 0 ? 0 : (idx + dir + opts.length) % opts.length;
     const next = opts[nextIdx];
     if (next && next.value !== select.value) {
-      select.onChange(next.value);
+      invokeCallbackSafely("select.onChange", select.onChange, next.value);
       return ROUTE_RENDER;
     }
   }
@@ -763,7 +779,7 @@ export function routeCheckboxKeyDown(
   if (event.key !== ZR_KEY_ENTER && event.key !== ZR_KEY_SPACE) return null;
 
   const nextChecked = !checkbox.checked;
-  checkbox.onChange(nextChecked);
+  invokeCallbackSafely("checkbox.onChange", checkbox.onChange, nextChecked);
   const action: RoutedAction = Object.freeze({
     id: focusedId,
     action: "toggle",
@@ -800,7 +816,7 @@ export function routeRadioGroupKeyDown(
     const nextIdx = idx < 0 ? 0 : (idx + dir + opts.length) % opts.length;
     const next = opts[nextIdx];
     if (next && next.value !== radio.value) {
-      radio.onChange(next.value);
+      invokeCallbackSafely("radioGroup.onChange", radio.onChange, next.value);
       const action: RoutedAction = Object.freeze({
         id: focusedId,
         action: "change",

--- a/packages/core/src/app/widgetRenderer/mouseRouting.ts
+++ b/packages/core/src/app/widgetRenderer/mouseRouting.ts
@@ -485,7 +485,7 @@ export function routeSplitPaneMouse(
         );
         const nextSizes =
           drag.sizeMode === "percent" ? sizesToPercentages(nextCellSizes) : nextCellSizes;
-        pane.onChange(Object.freeze(nextSizes.slice()));
+        invokeCallbackSafely(pane.onChange, Object.freeze(nextSizes.slice()));
         return ROUTE_RENDER;
       }
 
@@ -547,11 +547,7 @@ export function routeSplitPaneMouse(
 
               const targetIndex = event.x < x0 ? i : event.x >= x0 + dividerSize ? i + 1 : i;
               const isCollapsed = pane.collapsed?.includes(targetIndex) ?? false;
-              try {
-                pane.onCollapse(targetIndex, !isCollapsed);
-              } catch {
-                // Swallow collapse callback errors to preserve routing determinism.
-              }
+              invokeCallbackSafely(pane.onCollapse, targetIndex, !isCollapsed);
               return ROUTE_RENDER;
             }
 
@@ -615,11 +611,7 @@ export function routeSplitPaneMouse(
 
               const targetIndex = event.y < y0 ? i : event.y >= y0 + dividerSize ? i + 1 : i;
               const isCollapsed = pane.collapsed?.includes(targetIndex) ?? false;
-              try {
-                pane.onCollapse(targetIndex, !isCollapsed);
-              } catch {
-                // Swallow collapse callback errors to preserve routing determinism.
-              }
+              invokeCallbackSafely(pane.onCollapse, targetIndex, !isCollapsed);
               return ROUTE_RENDER;
             }
 
@@ -1573,7 +1565,7 @@ export function routeMouseWheel(
             overscan,
             measuredHeights,
           );
-          vlist.onScroll(r.nextScrollTop, [startIndex, endIndex]);
+          invokeCallbackSafely(vlist.onScroll, r.nextScrollTop, [startIndex, endIndex]);
         }
         return ROUTE_RENDER;
       }
@@ -1677,7 +1669,11 @@ export function routeMouseWheel(
       });
 
       if (r.nextScrollY !== undefined || r.nextScrollX !== undefined) {
-        editor.onScroll(r.nextScrollY ?? editor.scrollTop, r.nextScrollX ?? editor.scrollLeft);
+        invokeCallbackSafely(
+          editor.onScroll,
+          r.nextScrollY ?? editor.scrollTop,
+          r.nextScrollX ?? editor.scrollLeft,
+        );
         return ROUTE_RENDER;
       }
       break;
@@ -1701,7 +1697,7 @@ export function routeMouseWheel(
         viewportHeight,
       });
       if (r.nextScrollY !== undefined) {
-        logs.onScroll(r.nextScrollY);
+        invokeCallbackSafely(logs.onScroll, r.nextScrollY);
         return ROUTE_RENDER;
       }
       break;
@@ -1726,7 +1722,7 @@ export function routeMouseWheel(
         viewportHeight,
       });
       if (r.nextScrollY !== undefined) {
-        diff.onScroll(r.nextScrollY);
+        invokeCallbackSafely(diff.onScroll, r.nextScrollY);
         return ROUTE_RENDER;
       }
       break;

--- a/packages/core/src/app/widgetRenderer/routeEngineEvent.ts
+++ b/packages/core/src/app/widgetRenderer/routeEngineEvent.ts
@@ -84,6 +84,7 @@ import type {
   TableRenderCache,
 } from "./renderCaches.js";
 import { routeToolApprovalDialogKeyDown } from "./toolApprovalRouting.js";
+import { invokeCallbackSafely } from "./safeCallback.js";
 
 const UTF8_DECODER = new TextDecoder();
 const EMPTY_ROUTING: RoutingResult = Object.freeze({});
@@ -443,8 +444,8 @@ export function routeEngineEventImpl(
         if (isCut && editor.readOnly !== true) {
           const cut = selection ? deleteRange(editor.lines, selection) : null;
           if (!cut) return ROUTE_NO_RENDER_CONSUMED;
-          editor.onSelectionChange(null);
-          editor.onChange(cut.lines, cut.cursor);
+          invokeCallbackSafely("codeEditor.onSelectionChange", editor.onSelectionChange, null);
+          invokeCallbackSafely("codeEditor.onChange", editor.onChange, cut.lines, cut.cursor);
           return ROUTE_RENDER;
         }
         return ROUTE_NO_RENDER_CONSUMED;
@@ -560,8 +561,8 @@ export function routeEngineEventImpl(
             : ""
           : UTF8_DECODER.decode(event.bytes);
       if (append.length > 0) {
-        palette.onChange(palette.query + append);
-        palette.onSelectionChange?.(0);
+        invokeCallbackSafely("commandPalette.onChange", palette.onChange, palette.query + append);
+        invokeCallbackSafely("commandPalette.onSelectionChange", palette.onSelectionChange, 0);
         return ROUTE_RENDER;
       }
     }
@@ -581,8 +582,10 @@ export function routeEngineEventImpl(
           base ? base.cursor : editor.cursor,
           insert,
         );
-        if (editor.selection !== null) editor.onSelectionChange(null);
-        editor.onChange(next.lines, next.cursor);
+        if (editor.selection !== null) {
+          invokeCallbackSafely("codeEditor.onSelectionChange", editor.onSelectionChange, null);
+        }
+        invokeCallbackSafely("codeEditor.onChange", editor.onChange, next.lines, next.cursor);
         return ROUTE_RENDER;
       }
     }
@@ -771,7 +774,7 @@ export function routeEngineEventImpl(
       const checkbox = ctx.checkboxById.get(res.action.id);
       if (checkbox && typeof checkbox.onChange === "function" && checkbox.disabled !== true) {
         const nextChecked = !checkbox.checked;
-        checkbox.onChange(nextChecked);
+        invokeCallbackSafely("checkbox.onChange", checkbox.onChange, nextChecked);
         return Object.freeze({
           needsRender,
           action: Object.freeze({
@@ -783,9 +786,9 @@ export function routeEngineEventImpl(
       }
 
       const btn = ctx.buttonById.get(res.action.id);
-      if (btn?.onPress) btn.onPress();
+      if (btn?.onPress) invokeCallbackSafely("button.onPress", btn.onPress);
       const link = ctx.linkById.get(res.action.id);
-      if (link?.onPress) link.onPress();
+      if (link?.onPress) invokeCallbackSafely("link.onPress", link.onPress);
     }
     return Object.freeze({ needsRender, action: res.action });
   }

--- a/packages/core/src/app/widgetRenderer/safeCallback.ts
+++ b/packages/core/src/app/widgetRenderer/safeCallback.ts
@@ -1,0 +1,35 @@
+const NODE_ENV =
+  (globalThis as { process?: { env?: { NODE_ENV?: string } } }).process?.env?.NODE_ENV ??
+  "development";
+const DEV_MODE = NODE_ENV !== "production";
+
+function warnDev(message: string): void {
+  if (!DEV_MODE) return;
+  const c = (globalThis as { console?: { warn?: (msg: string) => void } }).console;
+  c?.warn?.(message);
+}
+
+function describeThrown(v: unknown): string {
+  if (v instanceof Error) return v.message;
+  try {
+    return String(v);
+  } catch {
+    return "[unstringifiable thrown value]";
+  }
+}
+
+export function invokeCallbackSafely<TArgs extends readonly unknown[]>(
+  name: string,
+  callback: ((...args: TArgs) => void) | undefined,
+  ...args: TArgs
+): boolean {
+  if (typeof callback !== "function") return false;
+  try {
+    callback(...args);
+    return true;
+  } catch (e) {
+    const message = describeThrown(e);
+    warnDev(`[rezi] ${name} callback threw: ${message}`);
+    return false;
+  }
+}

--- a/packages/core/src/app/widgetRenderer/toolApprovalRouting.ts
+++ b/packages/core/src/app/widgetRenderer/toolApprovalRouting.ts
@@ -6,6 +6,7 @@ import {
   ZR_MOD_SHIFT,
 } from "../../keybindings/keyCodes.js";
 import type { ToolApprovalDialogProps } from "../../widgets/types.js";
+import { invokeCallbackSafely } from "./safeCallback.js";
 
 export type ToolApprovalAction = "allow" | "deny" | "allowSession";
 
@@ -30,8 +31,8 @@ export function routeToolApprovalDialogKeyDown(
     focusedActionById.get(toolDialog.id) ?? toolDialog.focusedAction ?? actions[0] ?? "allow";
 
   if (keyCode === ZR_KEY_ESCAPE) {
-    toolDialog.onPress("deny");
-    toolDialog.onClose();
+    invokeCallbackSafely("toolApprovalDialog.onPress", toolDialog.onPress, "deny");
+    invokeCallbackSafely("toolApprovalDialog.onClose", toolDialog.onClose);
     return true;
   }
 
@@ -46,26 +47,29 @@ export function routeToolApprovalDialogKeyDown(
   }
 
   if (keyCode === Y) {
-    toolDialog.onPress("allow");
-    toolDialog.onClose();
+    invokeCallbackSafely("toolApprovalDialog.onPress", toolDialog.onPress, "allow");
+    invokeCallbackSafely("toolApprovalDialog.onClose", toolDialog.onClose);
     return true;
   }
   if (keyCode === N) {
-    toolDialog.onPress("deny");
-    toolDialog.onClose();
+    invokeCallbackSafely("toolApprovalDialog.onPress", toolDialog.onPress, "deny");
+    invokeCallbackSafely("toolApprovalDialog.onClose", toolDialog.onClose);
     return true;
   }
   if (keyCode === S && toolDialog.onAllowForSession) {
-    toolDialog.onAllowForSession();
-    toolDialog.onClose();
+    invokeCallbackSafely("toolApprovalDialog.onAllowForSession", toolDialog.onAllowForSession);
+    invokeCallbackSafely("toolApprovalDialog.onClose", toolDialog.onClose);
     return true;
   }
   if (keyCode === ZR_KEY_ENTER) {
-    if (focusedAction === "deny") toolDialog.onPress("deny");
-    else if (focusedAction === "allowSession" && toolDialog.onAllowForSession)
-      toolDialog.onAllowForSession();
-    else toolDialog.onPress("allow");
-    toolDialog.onClose();
+    if (focusedAction === "deny") {
+      invokeCallbackSafely("toolApprovalDialog.onPress", toolDialog.onPress, "deny");
+    } else if (focusedAction === "allowSession" && toolDialog.onAllowForSession) {
+      invokeCallbackSafely("toolApprovalDialog.onAllowForSession", toolDialog.onAllowForSession);
+    } else {
+      invokeCallbackSafely("toolApprovalDialog.onPress", toolDialog.onPress, "allow");
+    }
+    invokeCallbackSafely("toolApprovalDialog.onClose", toolDialog.onClose);
     return true;
   }
 


### PR DESCRIPTION
## Summary

- Add guarded callback invocation for widget routing paths that were still calling user handlers directly.
- Cover mouse button presses and keyboard checkbox changes with regression tests for thrown callbacks.

## Rationale

A user callback should not be able to crash the renderer's routing path. These routes now preserve the routed action/render result and report the callback failure in development builds.

## Validation

- `npm run build`
- `node scripts/run-tests.mjs --filter widgetBehavior.contracts`
- `npm run typecheck -- --pretty false`