### PR TITLE
Fix worker exit waiter rejection

### DIFF
--- a/packages/create-rezi/src/scaffold.ts
+++ b/packages/create-rezi/src/scaffold.ts
@@ -42,7 +42,8 @@ export const TEMPLATE_DEFINITIONS: readonly TemplateDefinition[] = [
   {
     key: "starship",
     label: "Starship Command Console",
-    description: "Larger command-console showcase for routing, animation, charts, forms, and overlays",
+    description:
+      "Larger command-console showcase for routing, animation, charts, forms, and overlays",
     safetyTag: "safe-default",
     safetyNote:
       "Feature-rich showcase template with moderate CPU usage from animation hooks and live telemetry.",

--- a/packages/node/src/__tests__/worker/testShims/exitNonZeroOnDestroyNative.ts
+++ b/packages/node/src/__tests__/worker/testShims/exitNonZeroOnDestroyNative.ts
@@ -1,0 +1,9 @@
+import { native as baseNative } from "./mockNative.js";
+
+export const native = {
+  ...baseNative,
+
+  engineDestroy(_engineId: number): never {
+    process.exit(7);
+  },
+};

--- a/packages/node/src/__tests__/worker/testShims/exitZeroOnCapsNative.ts
+++ b/packages/node/src/__tests__/worker/testShims/exitZeroOnCapsNative.ts
@@ -1,0 +1,9 @@
+import { native as baseNative } from "./mockNative.js";
+
+export const native = {
+  ...baseNative,
+
+  engineGetCaps(_engineId: number): never {
+    process.exit(0);
+  },
+};

--- a/packages/node/src/__tests__/worker_integration.test.ts
+++ b/packages/node/src/__tests__/worker_integration.test.ts
@@ -593,8 +593,13 @@ test("backend: clean unexpected worker exit rejects pending waiters", async () =
 
   await backend.start();
   try {
+    let timeoutHandle: ReturnType<typeof setTimeout> | undefined;
+    const timeout = new Promise<null>((resolve) => {
+      timeoutHandle = setTimeout(() => resolve(null), 1000);
+    });
     const pending = Promise.allSettled([backend.pollEvents(), backend.getCaps()]);
-    const settled = await Promise.race([pending, delay(1000).then(() => null)]);
+    const settled = await Promise.race([pending, timeout]);
+    if (timeoutHandle !== undefined) clearTimeout(timeoutHandle);
 
     assert.ok(settled !== null, "worker exit should settle pending backend waiters");
     for (const result of settled) {
@@ -603,6 +608,27 @@ test("backend: clean unexpected worker exit rejects pending waiters", async () =
       assert.equal(result.reason.code, "ZRUI_BACKEND_ERROR");
       assert.match(result.reason.message, /worker exited unexpectedly: code=0/);
     }
+  } finally {
+    backend.dispose();
+  }
+});
+
+test("backend: non-zero worker exit during stop rejects stop", async () => {
+  const shim = new URL("./worker/testShims/exitNonZeroOnDestroyNative.js", import.meta.url).href;
+  const backend = createNodeBackendInternal({
+    config: { executionMode: "worker", fpsCap: 1000, maxEventBytes: 1024 },
+    nativeShimModule: shim,
+  });
+
+  await backend.start();
+  try {
+    await assert.rejects(
+      backend.stop(),
+      (error) =>
+        error instanceof ZrUiError &&
+        error.code === "ZRUI_BACKEND_ERROR" &&
+        /worker exited unexpectedly: code=7/.test(error.message),
+    );
   } finally {
     backend.dispose();
   }

--- a/packages/node/src/__tests__/worker_integration.test.ts
+++ b/packages/node/src/__tests__/worker_integration.test.ts
@@ -584,6 +584,30 @@ test("backend: pollEvents recovers from oversized event batch (ZR_ERR_LIMIT)", a
   backend.dispose();
 });
 
+test("backend: clean unexpected worker exit rejects pending waiters", async () => {
+  const shim = new URL("./worker/testShims/exitZeroOnCapsNative.js", import.meta.url).href;
+  const backend = createNodeBackendInternal({
+    config: { executionMode: "worker", fpsCap: 1000, maxEventBytes: 1024 },
+    nativeShimModule: shim,
+  });
+
+  await backend.start();
+  try {
+    const pending = Promise.allSettled([backend.pollEvents(), backend.getCaps()]);
+    const settled = await Promise.race([pending, delay(1000).then(() => null)]);
+
+    assert.ok(settled !== null, "worker exit should settle pending backend waiters");
+    for (const result of settled) {
+      assert.equal(result.status, "rejected");
+      assert.ok(result.reason instanceof ZrUiError);
+      assert.equal(result.reason.code, "ZRUI_BACKEND_ERROR");
+      assert.match(result.reason.message, /worker exited unexpectedly: code=0/);
+    }
+  } finally {
+    backend.dispose();
+  }
+});
+
 test("backend: maps fpsCap to native targetFps during init", async () => {
   const shim = new URL("./worker/testShims/targetFpsNative.js", import.meta.url).href;
   const backend = createNodeBackendInternal({

--- a/packages/node/src/backend/nodeBackend.ts
+++ b/packages/node/src/backend/nodeBackend.ts
@@ -563,7 +563,15 @@ export function createNodeBackendInternal(opts: NodeBackendInternalOpts = {}): N
   function handleWorkerExit(code: number | null): void {
     if (disposed) return;
     if (stopRequested) {
-      rejectPending(new Error("NodeBackend: stopped"));
+      if (code !== 0 && fatal === null) {
+        fatal = new ZrUiError(
+          "ZRUI_BACKEND_ERROR",
+          `worker exited unexpectedly: code=${String(code)}`,
+        );
+        failAll(fatal);
+      } else {
+        rejectPending(new Error("NodeBackend: stopped"));
+      }
     } else if (fatal === null) {
       const message =
         code === 0 && !started && startDef !== null && !startSettled

--- a/packages/node/src/backend/nodeBackend.ts
+++ b/packages/node/src/backend/nodeBackend.ts
@@ -564,16 +564,12 @@ export function createNodeBackendInternal(opts: NodeBackendInternalOpts = {}): N
     if (disposed) return;
     if (stopRequested) {
       rejectPending(new Error("NodeBackend: stopped"));
-    }
-    if (code !== 0 && fatal === null) {
-      fatal = new ZrUiError(
-        "ZRUI_BACKEND_ERROR",
-        `worker exited unexpectedly: code=${String(code)}`,
-      );
-      failAll(fatal);
-    }
-    if (code === 0 && !started && fatal === null && startDef !== null && !startSettled) {
-      fatal = new ZrUiError("ZRUI_BACKEND_ERROR", "worker exited before ready handshake");
+    } else if (fatal === null) {
+      const message =
+        code === 0 && !started && startDef !== null && !startSettled
+          ? "worker exited before ready handshake"
+          : `worker exited unexpectedly: code=${String(code)}`;
+      fatal = new ZrUiError("ZRUI_BACKEND_ERROR", message);
       failAll(fatal);
     }
 


### PR DESCRIPTION
## Summary

- Treat any unexpected worker exit as a backend fatal error, including clean `code=0` exits after startup.
- Add a worker-mode regression that exits cleanly while `pollEvents` and `getCaps` are pending.

## Rationale

A worker can exit without an error code after the ready handshake. The backend was not marking that as fatal, so pending waiters could stay unresolved.

## Validation

- `npm run build`
- `node scripts/run-tests.mjs --filter worker_integration`
- `npm run typecheck -- --pretty false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Tests**
  * Added integration tests covering worker process exits (both zero and non-zero) to verify pending operations and shutdown calls fail with clear backend error messages.

* **Bug Fixes**
  * Consolidated worker-exit handling so unexpected exits consistently surface as backend errors and pending waiters are failed reliably.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->