### PR TITLE
Fix tail UTF-8 chunk decoding

### DIFF
--- a/packages/create-rezi/src/scaffold.ts
+++ b/packages/create-rezi/src/scaffold.ts
@@ -42,7 +42,8 @@ export const TEMPLATE_DEFINITIONS: readonly TemplateDefinition[] = [
   {
     key: "starship",
     label: "Starship Command Console",
-    description: "Larger command-console showcase for routing, animation, charts, forms, and overlays",
+    description:
+      "Larger command-console showcase for routing, animation, charts, forms, and overlays",
     safetyTag: "safe-default",
     safetyNote:
       "Feature-rich showcase template with moderate CPU usage from animation hooks and live telemetry.",

--- a/packages/node/src/__tests__/tailSource.test.ts
+++ b/packages/node/src/__tests__/tailSource.test.ts
@@ -3,7 +3,7 @@ import { appendFile, mkdtemp, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import test from "node:test";
-import { createNodeTailSource } from "../streams/tail.js";
+import { READ_CHUNK_BYTES, createNodeTailSource } from "../streams/tail.js";
 
 async function nextWithTimeout<T>(
   iterator: AsyncIterator<T>,
@@ -65,7 +65,7 @@ test("createNodeTailSource preserves UTF-8 characters split across read chunks",
   let source: ReturnType<typeof createNodeTailSource> | undefined;
 
   try {
-    const line = `${"a".repeat(64 * 1024 - 1)}😀`;
+    const line = `${"a".repeat(READ_CHUNK_BYTES - 1)}😀`;
     await writeFile(filePath, `${line}\n`, "utf8");
 
     source = createNodeTailSource(filePath, { fromEnd: false, pollMs: 10 });
@@ -74,6 +74,37 @@ test("createNodeTailSource preserves UTF-8 characters split across read chunks",
     const first = await nextWithTimeout(iterator);
     assert.equal(first.done, false);
     assert.equal(first.value, line);
+    assert.equal(first.value.includes("\uFFFD"), false);
+
+    source.close?.();
+    const done = await nextWithTimeout(iterator);
+    assert.equal(done.done, true);
+  } finally {
+    source?.close?.();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
+test("createNodeTailSource preserves UTF-8 characters split across poll reads", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "rezi-tail-"));
+  const filePath = join(dir, "utf8-poll.log");
+  let source: ReturnType<typeof createNodeTailSource> | undefined;
+
+  try {
+    await writeFile(filePath, "", "utf8");
+
+    source = createNodeTailSource(filePath, { fromEnd: false, pollMs: 10 });
+    const iterator = source[Symbol.asyncIterator]();
+    const pendingLine = nextWithTimeout(iterator);
+    const emojiBytes = Buffer.from("😀", "utf8");
+
+    await appendFile(filePath, emojiBytes.subarray(0, 2));
+    await new Promise<void>((resolve) => setTimeout(resolve, 30));
+    await appendFile(filePath, Buffer.concat([emojiBytes.subarray(2), Buffer.from("\n")]));
+
+    const first = await pendingLine;
+    assert.equal(first.done, false);
+    assert.equal(first.value, "😀");
     assert.equal(first.value.includes("\uFFFD"), false);
 
     source.close?.();

--- a/packages/node/src/__tests__/tailSource.test.ts
+++ b/packages/node/src/__tests__/tailSource.test.ts
@@ -59,6 +59,32 @@ test("createNodeTailSource yields existing + appended lines when fromEnd=false",
   }
 });
 
+test("createNodeTailSource preserves UTF-8 characters split across read chunks", async () => {
+  const dir = await mkdtemp(join(tmpdir(), "rezi-tail-"));
+  const filePath = join(dir, "utf8.log");
+  let source: ReturnType<typeof createNodeTailSource> | undefined;
+
+  try {
+    const line = `${"a".repeat(64 * 1024 - 1)}😀`;
+    await writeFile(filePath, `${line}\n`, "utf8");
+
+    source = createNodeTailSource(filePath, { fromEnd: false, pollMs: 10 });
+    const iterator = source[Symbol.asyncIterator]();
+
+    const first = await nextWithTimeout(iterator);
+    assert.equal(first.done, false);
+    assert.equal(first.value, line);
+    assert.equal(first.value.includes("\uFFFD"), false);
+
+    source.close?.();
+    const done = await nextWithTimeout(iterator);
+    assert.equal(done.done, true);
+  } finally {
+    source?.close?.();
+    await rm(dir, { recursive: true, force: true });
+  }
+});
+
 test("createNodeTailSource skips initial contents when fromEnd=true", async () => {
   const dir = await mkdtemp(join(tmpdir(), "rezi-tail-"));
   const filePath = join(dir, "events.log");

--- a/packages/node/src/streams/tail.ts
+++ b/packages/node/src/streams/tail.ts
@@ -3,7 +3,7 @@ import { StringDecoder } from "node:string_decoder";
 import type { TailSource, TailSourceFactory } from "@rezi-ui/core";
 
 const DEFAULT_POLL_MS = 200;
-const READ_CHUNK_BYTES = 64 * 1024;
+export const READ_CHUNK_BYTES = 64 * 1024;
 
 type SleepState = Readonly<{
   timer: ReturnType<typeof setTimeout> | null;
@@ -21,13 +21,17 @@ function isNodeErrorWithCode(error: unknown): error is Readonly<{ code: string }
   return typeof code === "string";
 }
 
-async function readUtf8Slice(filePath: string, start: number, end: number): Promise<string> {
+async function readUtf8Slice(
+  filePath: string,
+  start: number,
+  end: number,
+  decoder: StringDecoder,
+): Promise<string> {
   if (end <= start) return "";
 
   const handle = await open(filePath, "r");
   let offset = start;
   let output = "";
-  const decoder = new StringDecoder("utf8");
 
   try {
     while (offset < end) {
@@ -38,7 +42,7 @@ async function readUtf8Slice(filePath: string, start: number, end: number): Prom
       output += decoder.write(buffer.subarray(0, bytesRead));
       offset += bytesRead;
     }
-    return output + decoder.end();
+    return output;
   } finally {
     await handle.close();
   }
@@ -83,6 +87,7 @@ export const createNodeTailSource: TailSourceFactory<string> = (
     let initialized = false;
     let offset = 0;
     let carry = "";
+    let decoder = new StringDecoder("utf8");
 
     while (!closed) {
       let fileSize: number;
@@ -106,10 +111,11 @@ export const createNodeTailSource: TailSourceFactory<string> = (
         // File was truncated/rotated.
         offset = 0;
         carry = "";
+        decoder = new StringDecoder("utf8");
       }
 
       if (fileSize > offset) {
-        const delta = await readUtf8Slice(filePath, offset, fileSize);
+        const delta = await readUtf8Slice(filePath, offset, fileSize, decoder);
         offset = fileSize;
         const segments = `${carry}${delta}`.split(/\r?\n/);
         carry = segments.pop() ?? "";

--- a/packages/node/src/streams/tail.ts
+++ b/packages/node/src/streams/tail.ts
@@ -1,4 +1,5 @@
 import { open, stat } from "node:fs/promises";
+import { StringDecoder } from "node:string_decoder";
 import type { TailSource, TailSourceFactory } from "@rezi-ui/core";
 
 const DEFAULT_POLL_MS = 200;
@@ -26,6 +27,7 @@ async function readUtf8Slice(filePath: string, start: number, end: number): Prom
   const handle = await open(filePath, "r");
   let offset = start;
   let output = "";
+  const decoder = new StringDecoder("utf8");
 
   try {
     while (offset < end) {
@@ -33,10 +35,10 @@ async function readUtf8Slice(filePath: string, start: number, end: number): Prom
       const buffer = Buffer.allocUnsafe(bytesToRead);
       const { bytesRead } = await handle.read(buffer, 0, bytesToRead, offset);
       if (bytesRead <= 0) break;
-      output += buffer.toString("utf8", 0, bytesRead);
+      output += decoder.write(buffer.subarray(0, bytesRead));
       offset += bytesRead;
     }
-    return output;
+    return output + decoder.end();
   } finally {
     await handle.close();
   }


### PR DESCRIPTION
## Summary

- Decode tailed file slices with a streaming UTF-8 decoder.
- Add a regression for a multi-byte character split across the 64 KiB read boundary.

## Rationale

The tail source decoded each read chunk independently. If a UTF-8 character crossed the chunk boundary, Node inserted replacement characters and the yielded line was corrupted.

## Validation

- `npm run build`
- `node scripts/run-tests.mjs --filter tailSource`
- `npm run typecheck -- --pretty false`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Resolved UTF-8 character corruption in tail streaming when characters span internal read boundaries.

* **Tests**
  * Added unit tests ensuring multi-byte UTF-8 characters are preserved across read/poll chunk boundaries.

* **Chores**
  * Minor template formatting cleanup and exposed a streaming chunk-size constant for external use.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->