### PR TITLE
Fix route engine import ordering

### DIFF
--- a/packages/core/src/app/widgetRenderer/routeEngineEvent.ts
+++ b/packages/core/src/app/widgetRenderer/routeEngineEvent.ts
@@ -83,8 +83,8 @@ import type {
   LogsConsoleRenderCache,
   TableRenderCache,
 } from "./renderCaches.js";
-import { routeToolApprovalDialogKeyDown } from "./toolApprovalRouting.js";
 import { invokeCallbackSafely } from "./safeCallback.js";
+import { routeToolApprovalDialogKeyDown } from "./toolApprovalRouting.js";
 
 const UTF8_DECODER = new TextDecoder();
 const EMPTY_ROUTING: RoutingResult = Object.freeze({});


### PR DESCRIPTION
## Summary

- Sort `routeEngineEvent.ts` imports in the order expected by Biome.

## Rationale

The merged main branch failed the `fast gate / quality` lint check because `safeCallback` and `toolApprovalRouting` were out of order.

## Validation

- `npm run lint`
- `git diff --check`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Internal code organization adjustments with no impact to end-user functionality.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->