### PR TITLE
feat: add virtual list sticky-follow mode, tool approval dialog

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ The format is based on Keep a Changelog and the project follows Semantic Version
 
 ## [Unreleased]
 
+### Added
+
+- **core/virtual-list**: Added `ensureVisibleIndex` with sticky follow mode for log and chat tail-follow behavior.
+- **core/tool-approval**: Added the tool approval dialog modal surface and mouse action routing.
+- **core/rendering**: Added `maxBlobBytes` app config for drawlist blob payload limits.
+
+### Documentation
+
+- Documented virtual list sticky follow behavior, tool approval dialog modal input behavior, and `maxBlobBytes` engine config.
+
 ## [0.1.0-alpha.71] - 2026-04-27
 
 ### Documentation

--- a/docs/backend/engine-config.md
+++ b/docs/backend/engine-config.md
@@ -14,6 +14,7 @@ const app = createNodeApp({
   config: {
     fpsCap: 30,
     maxDrawlistBytes: 4 << 20, // 4 MiB
+    maxBlobBytes: 1 << 20, // 1 MiB
     drawlistValidateParams: false, // trusted inputs, skip validation
     maxFramesInFlight: 2,
   },
@@ -27,10 +28,18 @@ type AppConfig = Readonly<{
   fpsCap?: number;
   maxEventBytes?: number;
   maxDrawlistBytes?: number;
+  maxBlobBytes?: number;
+  rootPadding?: number;
+  breakpoints?: Readonly<{
+    smMax?: number;
+    mdMax?: number;
+    lgMax?: number;
+  }>;
   drawlistValidateParams?: boolean;
   drawlistReuseOutputBuffer?: boolean;
   drawlistEncodedStringCacheCap?: number;
   maxFramesInFlight?: number;
+  themeTransitionFrames?: number;
   internal_onRender?: (metrics: AppRenderMetrics) => void;
   internal_onLayout?: (snapshot: AppLayoutSnapshot) => void;
 }>;
@@ -86,6 +95,24 @@ config: {
 }
 ```
 
+### maxBlobBytes
+
+| Detail   | Value |
+|----------|-------|
+| Type     | `number` (positive integer) |
+| Default  | `512 << 10` (512 KiB) |
+
+Maximum total byte size of the drawlist blob pool for a frame. If binary payloads
+exceed this limit during frame construction, the frame is rejected. Increase this
+value only for applications that intentionally render large binary-backed
+surfaces such as images or canvases.
+
+```typescript
+config: {
+  maxBlobBytes: 1 << 20, // 1 MiB blob pool
+}
+```
+
 ### drawlistValidateParams
 
 | Detail   | Value |
@@ -129,7 +156,7 @@ remains safe regardless of the pipelining depth.
 | Detail   | Value |
 |----------|-------|
 | Type     | `number` (non-negative integer) |
-| Default  | `1024` |
+| Default  | `131072` |
 
 Maximum number of UTF-8 encoded strings to cache across frames. The drawlist
 builder maintains a cache of encoded strings to avoid redundant
@@ -142,7 +169,7 @@ application renders many unique but repeated strings across frames.
 
 ```typescript
 config: {
-  drawlistEncodedStringCacheCap: 2048, // larger cache for text-heavy UIs
+  drawlistEncodedStringCacheCap: 262144, // larger cache for text-heavy UIs
 }
 ```
 
@@ -177,10 +204,13 @@ config: {
 | `fpsCap`                        | `60`          |
 | `maxEventBytes`                 | `1048576` (1 MiB) |
 | `maxDrawlistBytes`              | `2097152` (2 MiB) |
+| `maxBlobBytes`                  | `524288` (512 KiB) |
+| `rootPadding`                   | `0`           |
 | `drawlistValidateParams`        | `true` (app runtime default) |
 | `drawlistReuseOutputBuffer`     | `true`        |
-| `drawlistEncodedStringCacheCap` | `1024`        |
+| `drawlistEncodedStringCacheCap` | `131072`      |
 | `maxFramesInFlight`             | `1`           |
+| `themeTransitionFrames`         | `0`           |
 
 ## See Also
 

--- a/docs/widgets/tool-approval-dialog.md
+++ b/docs/widgets/tool-approval-dialog.md
@@ -37,6 +37,8 @@ ui.toolApprovalDialog({
 - `ToolRequest` includes metadata like `toolId`, `toolName`, `riskLevel`, and optional `fileChanges`.
 - `fileChanges` entries include `path`, `changeType`, and optional `preview`/`oldPath` for renames.
 - Default dialog size is `50x15` cells when `width`/`height` are omitted.
+- When open, the dialog is a modal layer with a dim backdrop.
+- Backdrop clicks and clicks behind the dialog are blocked; only the dialog action regions route mouse presses.
 
 ## Related
 

--- a/docs/widgets/virtual-list.md
+++ b/docs/widgets/virtual-list.md
@@ -48,6 +48,8 @@ ui.virtualList({
 | `measureItemHeight` | `(item, index, ctx) => number` | internal measurer | Optional custom measurement callback for estimate mode |
 | `renderItem` | `(item, index, focused) => VNode` | **required** | Render function for each item |
 | `overscan` | `number` | `3` | Extra items rendered above/below viewport |
+| `ensureVisibleIndex` | `number` | - | Item index to keep visible after render, useful for tail-following logs or chat |
+| `ensureVisibleMode` | `"always" \| "sticky"` | `"always"` | Whether `ensureVisibleIndex` always repositions or follows only while attached |
 | `keyboardNavigation` | `boolean` | `true` | Enable arrow/page/home/end navigation |
 | `wrapAround` | `boolean` | `false` | Wrap selection from end to start |
 | `scrollDirection` | `"traditional" \| "natural"` | `"traditional"` | Mouse-wheel direction mode for this list |
@@ -62,6 +64,9 @@ ui.virtualList({
 - **Mouse scroll wheel** scrolls the list (3 lines per tick).
   - `scrollDirection: "traditional"` (default): wheel down moves viewport down.
   - `scrollDirection: "natural"`: wheel down moves content down (trackpad-style).
+- `ensureVisibleIndex` keeps a target item visible after render.
+  - `ensureVisibleMode: "always"` scrolls whenever the target is outside the viewport.
+  - `ensureVisibleMode: "sticky"` follows the target only while the user remains attached.
 - The `onScroll` callback fires for both keyboard navigation and mouse wheel input.
 
 ## Notes
@@ -72,6 +77,8 @@ ui.virtualList({
 - Returned `measureItemHeight` values are normalized before entering the measured-height cache: non-finite or non-positive values fall back to `estimatedHeight`, and positive values are truncated to whole cells with a minimum of 1.
 - In estimate mode, visible items are measured and cached, then scroll math is corrected on the following frame.
 - Measured-height cache is reused only while viewport width and item count stay the same; changing either triggers remeasurement.
+- Sticky follow is disabled when keyboard or wheel input moves away from the target, and re-enabled when the viewport reaches the target again.
+- Oversized sticky targets anchor their bottom edge to avoid scroll oscillation.
 - `renderItem` receives a `focused` flag for styling.
 - `selectionStyle` still applies to the selected row in estimate mode.
 - The `range` passed to `onScroll` is `[startIndex, endIndex)` and includes overscan.

--- a/packages/core/etc/core.api.md
+++ b/packages/core/etc/core.api.md
@@ -160,6 +160,7 @@ export type AppConfig = Readonly<{
     fpsCap?: number;
     maxEventBytes?: number;
     maxDrawlistBytes?: number;
+    maxBlobBytes?: number;
     rootPadding?: number;
     breakpoints?: Readonly<{
         smMax?: number;
@@ -7375,6 +7376,7 @@ export type VirtualListLocalState = Readonly<{
     viewportHeight: number;
     startIndex: number;
     endIndex: number;
+    stickyFollowActive?: boolean;
     measuredHeights?: ReadonlyMap<number, number>;
     measuredWidth?: number;
     measuredItemCount?: number;
@@ -7387,6 +7389,7 @@ export type VirtualListLocalStatePatch = Readonly<{
     viewportHeight?: number;
     startIndex?: number;
     endIndex?: number;
+    stickyFollowActive?: boolean;
     measuredHeights?: ReadonlyMap<number, number>;
     measuredWidth?: number;
     measuredItemCount?: number;
@@ -7411,6 +7414,8 @@ export type VirtualListProps<T = unknown> = Readonly<{
     measureItemHeight?: (item: T, index: number, ctx: VirtualListMeasureItemHeightCtx) => number;
     overscan?: number;
     renderItem: (item: T, index: number, focused: boolean) => VNode;
+    ensureVisibleIndex?: number;
+    ensureVisibleMode?: "always" | "sticky";
     onScroll?: (scrollTop: number, visibleRange: [number, number]) => void;
     onSelect?: (item: T, index: number) => void;
     keyboardNavigation?: boolean;
@@ -8016,8 +8021,8 @@ export type ZrUiErrorCode = "ZRUI_INVALID_STATE" | "ZRUI_MODE_CONFLICT" | "ZRUI_
 // src/runtime/instances.ts:56:3 - (ae-forgotten-export) The symbol "UnknownCallback_2" needs to be exported by the entry point index.d.ts
 // src/runtime/instances.ts:134:3 - (ae-forgotten-export) The symbol "InstanceId" needs to be exported by the entry point index.d.ts
 // src/runtime/instances.ts:161:3 - (ae-forgotten-export) The symbol "AppStateSelection" needs to be exported by the entry point index.d.ts
-// src/runtime/localState.ts:401:3 - (ae-forgotten-export) The symbol "TreeFlatCache" needs to be exported by the entry point index.d.ts
-// src/runtime/localState.ts:406:3 - (ae-forgotten-export) The symbol "TreePrefixCache" needs to be exported by the entry point index.d.ts
+// src/runtime/localState.ts:412:3 - (ae-forgotten-export) The symbol "TreeFlatCache" needs to be exported by the entry point index.d.ts
+// src/runtime/localState.ts:417:3 - (ae-forgotten-export) The symbol "TreePrefixCache" needs to be exported by the entry point index.d.ts
 // src/runtime/widgetMeta/focusInfo.ts:8:3 - (ae-forgotten-export) The symbol "RuntimeInstance" needs to be exported by the entry point index.d.ts
 // src/testing/renderer.ts:93:3 - (ae-forgotten-export) The symbol "TestRecordedOp" needs to be exported by the entry point index.d.ts
 // src/widgets/composition.ts:88:3 - (ae-forgotten-export) The symbol "UnknownCallback" needs to be exported by the entry point index.d.ts

--- a/packages/core/src/app/__tests__/widgetBehavior.contracts.test.ts
+++ b/packages/core/src/app/__tests__/widgetBehavior.contracts.test.ts
@@ -475,6 +475,95 @@ describe("modal, overlay, and focus behavior contracts", () => {
     assert.equal(renderer.getFocusedId(), "cancel");
   });
 
+  test("tool approval dialog mouse clicks activate action regions", () => {
+    const renderer = new WidgetRenderer<void>({
+      backend: createNoopBackend(),
+      requestRender: () => {},
+    });
+
+    let open = true;
+    let allowSessionCount = 0;
+    let closeCount = 0;
+    const view = () =>
+      ui.layers([
+        ui.button({ id: "background", label: "Background action" }),
+        ...(open
+          ? [
+              ui.toolApprovalDialog({
+                id: "approval",
+                open: true,
+                request: {
+                  toolId: "terminal",
+                  toolName: "terminal",
+                  command: "rm -rf ./dist",
+                  riskLevel: "high",
+                },
+                onPress: () => {},
+                onAllowForSession: () => {
+                  allowSessionCount++;
+                },
+                onClose: () => {
+                  closeCount++;
+                  open = false;
+                },
+              }),
+            ]
+          : []),
+      ]);
+
+    submit(renderer, view, { cols: 80, rows: 24 });
+    const rect = renderer.getRectByIdIndex().get("approval");
+    assert.ok(rect !== undefined, "approval rect should exist");
+    if (!rect) return;
+
+    const x = rect.x + 22;
+    const y = rect.y + rect.h - 2;
+    renderer.routeEngineEvent(mouseEvent(x, y, 3, { buttons: 1 }));
+    renderer.routeEngineEvent(mouseEvent(x, y, 4));
+
+    assert.equal(renderer.getFocusedId(), "approval");
+    assert.equal(allowSessionCount, 1);
+    assert.equal(closeCount, 1);
+  });
+
+  test("tool approval dialog blocks backdrop clicks from background widgets", () => {
+    const renderer = new WidgetRenderer<void>({
+      backend: createNoopBackend(),
+      requestRender: () => {},
+    });
+
+    let backgroundPresses = 0;
+    const view = () =>
+      ui.layers([
+        ui.button({
+          id: "background",
+          label: "Background action",
+          onPress: () => {
+            backgroundPresses++;
+          },
+        }),
+        ui.toolApprovalDialog({
+          id: "approval",
+          open: true,
+          request: {
+            toolId: "terminal",
+            toolName: "terminal",
+            command: "rm -rf ./dist",
+            riskLevel: "high",
+          },
+          onPress: () => {},
+          onClose: () => {},
+        }),
+      ]);
+
+    submit(renderer, view, { cols: 80, rows: 24 });
+    const bgCenter = centerOf(renderer, "background");
+    renderer.routeEngineEvent(mouseEvent(bgCenter.x, bgCenter.y, 3, { buttons: 1 }));
+    renderer.routeEngineEvent(mouseEvent(bgCenter.x, bgCenter.y, 4));
+
+    assert.equal(backgroundPresses, 0);
+  });
+
   test("top layer above a modal still receives mouse presses", () => {
     const renderer = new WidgetRenderer<void>({
       backend: createNoopBackend(),

--- a/packages/core/src/app/__tests__/widgetBehavior.contracts.test.ts
+++ b/packages/core/src/app/__tests__/widgetBehavior.contracts.test.ts
@@ -564,6 +564,55 @@ describe("modal, overlay, and focus behavior contracts", () => {
     assert.equal(backgroundPresses, 0);
   });
 
+  test("tool approval dialog keeps backdrop blocking after layout-only resize", () => {
+    const renderer = new WidgetRenderer<void>({
+      backend: createNoopBackend(),
+      requestRender: () => {},
+    });
+
+    let backgroundPresses = 0;
+    const view = () =>
+      ui.layers([
+        ui.button({
+          id: "background",
+          label: "Background action",
+          onPress: () => {
+            backgroundPresses++;
+          },
+        }),
+        ui.toolApprovalDialog({
+          id: "approval",
+          open: true,
+          request: {
+            toolId: "terminal",
+            toolName: "terminal",
+            command: "rm -rf ./dist",
+            riskLevel: "high",
+          },
+          onPress: () => {},
+          onClose: () => {},
+        }),
+      ]);
+
+    submit(renderer, view, { cols: 80, rows: 24 });
+
+    const resized = renderer.submitFrame(
+      view,
+      undefined,
+      { cols: 100, rows: 24 },
+      defaultTheme,
+      noRenderHooks(),
+      { commit: false, layout: true, checkLayoutStability: false },
+    );
+    assert.equal(resized.ok, true, "layout-only frame should render");
+
+    const bgCenter = centerOf(renderer, "background");
+    renderer.routeEngineEvent(mouseEvent(bgCenter.x, bgCenter.y, 3, { buttons: 1 }));
+    renderer.routeEngineEvent(mouseEvent(bgCenter.x, bgCenter.y, 4));
+
+    assert.equal(backgroundPresses, 0);
+  });
+
   test("top layer above a modal still receives mouse presses", () => {
     const renderer = new WidgetRenderer<void>({
       backend: createNoopBackend(),

--- a/packages/core/src/app/createApp.ts
+++ b/packages/core/src/app/createApp.ts
@@ -375,6 +375,7 @@ export function createApp<S>(opts: CreateAppStateOptions<S> | CreateAppRoutesOnl
   const rawRenderer = new RawRenderer({
     backend,
     maxDrawlistBytes: config.maxDrawlistBytes,
+    maxBlobBytes: config.maxBlobBytes,
     ...(opts.config?.drawlistValidateParams === undefined
       ? {}
       : { drawlistValidateParams: opts.config.drawlistValidateParams }),
@@ -384,6 +385,7 @@ export function createApp<S>(opts: CreateAppStateOptions<S> | CreateAppRoutesOnl
   const widgetRenderer = new WidgetRenderer<S>({
     backend,
     maxDrawlistBytes: config.maxDrawlistBytes,
+    maxBlobBytes: config.maxBlobBytes,
     rootPadding: config.rootPadding,
     breakpointThresholds: config.breakpointThresholds,
     terminalProfile,

--- a/packages/core/src/app/createApp/config.ts
+++ b/packages/core/src/app/createApp/config.ts
@@ -20,6 +20,7 @@ export type ResolvedAppConfig = Readonly<{
   fpsCap: number;
   maxEventBytes: number;
   maxDrawlistBytes: number;
+  maxBlobBytes: number;
   rootPadding: number;
   breakpointThresholds: ResponsiveBreakpointThresholds;
   drawlistValidateParams: boolean;
@@ -35,6 +36,7 @@ const DEFAULT_CONFIG: ResolvedAppConfig = Object.freeze({
   fpsCap: 60,
   maxEventBytes: 1 << 20 /* 1 MiB */,
   maxDrawlistBytes: 2 << 20 /* 2 MiB */,
+  maxBlobBytes: 512 << 10 /* 512 KiB */,
   rootPadding: 0,
   breakpointThresholds: normalizeBreakpointThresholds(undefined),
   drawlistValidateParams: true,
@@ -83,6 +85,10 @@ export function resolveAppConfig(config: AppConfig | undefined): ResolvedAppConf
     config.maxDrawlistBytes === undefined
       ? DEFAULT_CONFIG.maxDrawlistBytes
       : requirePositiveInt("maxDrawlistBytes", config.maxDrawlistBytes);
+  const maxBlobBytes =
+    config.maxBlobBytes === undefined
+      ? DEFAULT_CONFIG.maxBlobBytes
+      : requirePositiveInt("maxBlobBytes", config.maxBlobBytes);
   const rootPadding =
     config.rootPadding === undefined
       ? DEFAULT_CONFIG.rootPadding
@@ -120,6 +126,7 @@ export function resolveAppConfig(config: AppConfig | undefined): ResolvedAppConf
     fpsCap,
     maxEventBytes,
     maxDrawlistBytes,
+    maxBlobBytes,
     rootPadding,
     breakpointThresholds,
     drawlistValidateParams,

--- a/packages/core/src/app/rawRenderer.ts
+++ b/packages/core/src/app/rawRenderer.ts
@@ -51,6 +51,7 @@ export class RawRenderer {
       backend: RuntimeBackend;
       builder?: DrawlistBuilder;
       maxDrawlistBytes?: number;
+      maxBlobBytes?: number;
       drawlistValidateParams?: boolean;
       drawlistReuseOutputBuffer?: boolean;
       drawlistEncodedStringCacheCap?: number;
@@ -59,6 +60,7 @@ export class RawRenderer {
     this.backend = opts.backend;
     const builderOpts = {
       ...(opts.maxDrawlistBytes === undefined ? {} : { maxDrawlistBytes: opts.maxDrawlistBytes }),
+      ...(opts.maxBlobBytes === undefined ? {} : { maxBlobBytes: opts.maxBlobBytes }),
       ...(opts.drawlistValidateParams === undefined
         ? {}
         : { validateParams: opts.drawlistValidateParams }),

--- a/packages/core/src/app/types.ts
+++ b/packages/core/src/app/types.ts
@@ -24,6 +24,7 @@ export type AppConfig = Readonly<{
   fpsCap?: number;
   maxEventBytes?: number;
   maxDrawlistBytes?: number;
+  maxBlobBytes?: number;
   rootPadding?: number;
   breakpoints?: Readonly<{
     smMax?: number;

--- a/packages/core/src/app/widgetRenderer.ts
+++ b/packages/core/src/app/widgetRenderer.ts
@@ -842,6 +842,10 @@ export class WidgetRenderer<S> {
     nodeKey: string;
     timeMs: number;
   }> | null = null;
+  private pressedToolApproval: Readonly<{
+    id: string;
+    action: "allow" | "deny" | "allowSession";
+  }> | null = null;
   private traps: ReadonlyMap<string, CollectedTrap> = new Map<string, CollectedTrap>();
   private zoneMetaById: ReadonlyMap<string, CollectedZone> = new Map<string, CollectedZone>();
   private focusInfoById: ReadonlyMap<string, FocusInfo> = new Map<string, FocusInfo>();
@@ -1077,6 +1081,7 @@ export class WidgetRenderer<S> {
       backend: RuntimeBackend;
       builder?: DrawlistBuilder;
       maxDrawlistBytes?: number;
+      maxBlobBytes?: number;
       drawlistValidateParams?: boolean;
       drawlistReuseOutputBuffer?: boolean;
       drawlistEncodedStringCacheCap?: number;
@@ -1120,6 +1125,7 @@ export class WidgetRenderer<S> {
     const validateParams = opts.drawlistValidateParams ?? false;
     const builderOpts = {
       ...(opts.maxDrawlistBytes === undefined ? {} : { maxDrawlistBytes: opts.maxDrawlistBytes }),
+      ...(opts.maxBlobBytes === undefined ? {} : { maxBlobBytes: opts.maxBlobBytes }),
       validateParams,
       ...(opts.drawlistReuseOutputBuffer === undefined
         ? {}
@@ -1717,6 +1723,7 @@ export class WidgetRenderer<S> {
       lastFilePickerClick: this.lastFilePickerClick,
       pressedTree: this.pressedTree,
       lastTreeClick: this.lastTreeClick,
+      pressedToolApproval: this.pressedToolApproval,
       splitPaneDrag: this.splitPaneDrag,
       splitPaneLastDividerDown: this.splitPaneLastDividerDown,
     };
@@ -1808,6 +1815,7 @@ export class WidgetRenderer<S> {
     this.lastFilePickerClick = state.lastFilePickerClick;
     this.pressedTree = state.pressedTree;
     this.lastTreeClick = state.lastTreeClick;
+    this.pressedToolApproval = state.pressedToolApproval;
     this.splitPaneDrag = state.splitPaneDrag;
     this.splitPaneLastDividerDown = state.splitPaneLastDividerDown;
     return outcome;

--- a/packages/core/src/app/widgetRenderer/keyboardRouting.ts
+++ b/packages/core/src/app/widgetRenderer/keyboardRouting.ts
@@ -349,8 +349,7 @@ export function routeVirtualListKeyDown(
 
   let changed = false;
   if (r.nextSelectedIndex !== undefined || r.nextScrollTop !== undefined) {
-    const patch: { selectedIndex?: number; scrollTop?: number; stickyFollowActive?: boolean } =
-      {};
+    const patch: { selectedIndex?: number; scrollTop?: number; stickyFollowActive?: boolean } = {};
     if (r.nextSelectedIndex !== undefined) patch.selectedIndex = r.nextSelectedIndex;
     if (r.nextScrollTop !== undefined) patch.scrollTop = r.nextScrollTop;
     const stickyFollowActive = computeStickyFollowActive(r.nextScrollTop ?? state.scrollTop);

--- a/packages/core/src/app/widgetRenderer/keyboardRouting.ts
+++ b/packages/core/src/app/widgetRenderer/keyboardRouting.ts
@@ -338,7 +338,8 @@ export function routeVirtualListKeyDown(
     const totalHeight = getTotalHeight(vlist.items, itemHeight, measuredHeights);
     const clampedScrollTop = clampScrollTop(scrollTop, totalHeight, state.viewportHeight);
     const maxScrollTop = clampScrollTop(totalHeight, totalHeight, state.viewportHeight);
-    if (maxScrollTop - clampedScrollTop <= 1) return true;
+    const followsTail = followIndex >= vlist.items.length - 1;
+    if (followsTail && maxScrollTop - clampedScrollTop <= 1) return true;
     const offset = getItemOffset(vlist.items, itemHeight, followIndex, measuredHeights);
     const height = getItemHeight(vlist.items, itemHeight, followIndex, measuredHeights);
     const viewportBottom = clampedScrollTop + state.viewportHeight;

--- a/packages/core/src/app/widgetRenderer/keyboardRouting.ts
+++ b/packages/core/src/app/widgetRenderer/keyboardRouting.ts
@@ -40,7 +40,11 @@ import type {
   VirtualListProps,
 } from "../../widgets/types.js";
 import {
+  clampScrollTop,
   computeVisibleRange,
+  getItemHeight,
+  getItemOffset,
+  getTotalHeight,
   resolveVirtualListItemHeightSpec,
 } from "../../widgets/virtualList.js";
 import type { LogsConsoleRenderCache, TableRenderCache } from "./renderCaches.js";
@@ -317,11 +321,39 @@ export function routeVirtualListKeyDown(
     wrapAround: vlist.wrapAround === true,
   });
 
+  const computeStickyFollowActive = (scrollTop: number): boolean | undefined => {
+    const rawEnsureVisibleIndex = vlist.ensureVisibleIndex;
+    if (
+      typeof rawEnsureVisibleIndex !== "number" ||
+      !Number.isFinite(rawEnsureVisibleIndex) ||
+      vlist.ensureVisibleMode !== "sticky"
+    ) {
+      return undefined;
+    }
+    if (vlist.items.length === 0) return true;
+    const followIndex = Math.max(
+      0,
+      Math.min(vlist.items.length - 1, Math.trunc(rawEnsureVisibleIndex)),
+    );
+    const totalHeight = getTotalHeight(vlist.items, itemHeight, measuredHeights);
+    const clampedScrollTop = clampScrollTop(scrollTop, totalHeight, state.viewportHeight);
+    const maxScrollTop = clampScrollTop(totalHeight, totalHeight, state.viewportHeight);
+    if (maxScrollTop - clampedScrollTop <= 1) return true;
+    const offset = getItemOffset(vlist.items, itemHeight, followIndex, measuredHeights);
+    const height = getItemHeight(vlist.items, itemHeight, followIndex, measuredHeights);
+    const viewportBottom = clampedScrollTop + state.viewportHeight;
+    const itemBottom = offset + height;
+    return viewportBottom >= itemBottom - 1;
+  };
+
   let changed = false;
   if (r.nextSelectedIndex !== undefined || r.nextScrollTop !== undefined) {
-    const patch: { selectedIndex?: number; scrollTop?: number } = {};
+    const patch: { selectedIndex?: number; scrollTop?: number; stickyFollowActive?: boolean } =
+      {};
     if (r.nextSelectedIndex !== undefined) patch.selectedIndex = r.nextSelectedIndex;
     if (r.nextScrollTop !== undefined) patch.scrollTop = r.nextScrollTop;
+    const stickyFollowActive = computeStickyFollowActive(r.nextScrollTop ?? state.scrollTop);
+    if (stickyFollowActive !== undefined) patch.stickyFollowActive = stickyFollowActive;
     ctx.virtualListStore.set(vlist.id, patch);
     changed = true;
   }

--- a/packages/core/src/app/widgetRenderer/mouseRouting.ts
+++ b/packages/core/src/app/widgetRenderer/mouseRouting.ts
@@ -35,11 +35,15 @@ import type {
   SplitPaneProps,
   TableProps,
   ToastContainerProps,
+  ToolApprovalDialogProps,
   TreeProps,
   VirtualListProps,
 } from "../../widgets/types.js";
 import {
+  clampScrollTop,
   computeVisibleRange,
+  getItemHeight,
+  getItemOffset,
   getTotalHeight,
   resolveVirtualListItemHeightSpec,
 } from "../../widgets/virtualList.js";
@@ -121,6 +125,19 @@ type RouteToastMouseDownContext = Readonly<{
     nextZoneId: string | null,
     prevZones: ReadonlyMap<string, CollectedZone>,
     nextZones: ReadonlyMap<string, CollectedZone>,
+  ) => void;
+}>;
+
+type ToolApprovalAction = "allow" | "deny" | "allowSession";
+
+type RouteToolApprovalDialogMouseContext = Readonly<{
+  mouseTargetId: string | null;
+  toolApprovalDialogById: ReadonlyMap<string, ToolApprovalDialogProps>;
+  rectById: ReadonlyMap<string, Rect>;
+  focusedActionById: Map<string, ToolApprovalAction>;
+  pressedToolApproval: Readonly<{ id: string; action: ToolApprovalAction }> | null;
+  setPressedToolApproval: (
+    next: Readonly<{ id: string; action: ToolApprovalAction }> | null,
   ) => void;
 }>;
 
@@ -729,6 +746,72 @@ export function routeToastMouseDown(
   }
 
   return null;
+}
+
+function hitToolApprovalAction(
+  rect: Rect,
+  dialog: ToolApprovalDialogProps,
+  x: number,
+  y: number,
+): ToolApprovalAction | null {
+  const buttonY = rect.y + rect.h - 2;
+  if (y !== buttonY) return null;
+
+  const allowX = rect.x + 2;
+  if (x >= allowX && x < allowX + "[Allow]".length) return "allow";
+
+  const denyX = rect.x + 12;
+  if (x >= denyX && x < denyX + "[Deny]".length) return "deny";
+
+  if (dialog.onAllowForSession) {
+    const sessionX = rect.x + 21;
+    if (x >= sessionX && x < sessionX + "[Allow Session]".length) return "allowSession";
+  }
+
+  return null;
+}
+
+export function routeToolApprovalDialogMouseClick(
+  event: ZrevEvent,
+  ctx: RouteToolApprovalDialogMouseContext,
+): boolean {
+  if (event.kind !== "mouse" || (event.mouseKind !== 3 && event.mouseKind !== 4)) return false;
+
+  const targetId = ctx.mouseTargetId;
+  const dialog = targetId !== null ? ctx.toolApprovalDialogById.get(targetId) : undefined;
+  const rect = targetId !== null ? ctx.rectById.get(targetId) : undefined;
+  const action =
+    dialog && rect && dialog.open === true
+      ? hitToolApprovalAction(rect, dialog, event.x, event.y)
+      : null;
+
+  if (event.mouseKind === 3) {
+    ctx.setPressedToolApproval(null);
+    if (!targetId || !dialog || !rect || action === null) return false;
+    ctx.focusedActionById.set(targetId, action);
+    ctx.setPressedToolApproval(Object.freeze({ id: targetId, action }));
+    return true;
+  }
+
+  const pressed = ctx.pressedToolApproval;
+  ctx.setPressedToolApproval(null);
+  if (!pressed || !targetId || pressed.id !== targetId || action !== pressed.action || !dialog) {
+    return false;
+  }
+
+  if (action === "allowSession" && dialog.onAllowForSession) {
+    invokeCallbackSafely(dialog.onAllowForSession);
+    invokeCallbackSafely(dialog.onClose);
+    return true;
+  }
+
+  if (action === "allow" || action === "deny") {
+    invokeCallbackSafely(dialog.onPress, action);
+    invokeCallbackSafely(dialog.onClose);
+    return true;
+  }
+
+  return false;
 }
 
 export function routeVirtualListMouseClick(
@@ -1554,7 +1637,37 @@ export function routeMouseWheel(
       });
 
       if (r.nextScrollTop !== undefined) {
-        ctx.virtualListStore.set(vlist.id, { scrollTop: r.nextScrollTop });
+        let stickyFollowActive: boolean | undefined;
+        const rawEnsureVisibleIndex = vlist.ensureVisibleIndex;
+        if (
+          typeof rawEnsureVisibleIndex === "number" &&
+          Number.isFinite(rawEnsureVisibleIndex) &&
+          vlist.ensureVisibleMode === "sticky"
+        ) {
+          if (vlist.items.length === 0) {
+            stickyFollowActive = true;
+          } else {
+            const followIndex = Math.max(
+              0,
+              Math.min(vlist.items.length - 1, Math.trunc(rawEnsureVisibleIndex)),
+            );
+            const clampedScrollTop = clampScrollTop(r.nextScrollTop, totalHeight, state.viewportHeight);
+            const maxScrollTop = clampScrollTop(totalHeight, totalHeight, state.viewportHeight);
+            if (maxScrollTop - clampedScrollTop <= 1) {
+              stickyFollowActive = true;
+            } else {
+              const offset = getItemOffset(vlist.items, itemHeight, followIndex, measuredHeights);
+              const height = getItemHeight(vlist.items, itemHeight, followIndex, measuredHeights);
+              const viewportBottom = clampedScrollTop + state.viewportHeight;
+              const itemBottom = offset + height;
+              stickyFollowActive = viewportBottom >= itemBottom - 1;
+            }
+          }
+        }
+        ctx.virtualListStore.set(vlist.id, {
+          scrollTop: r.nextScrollTop,
+          ...(stickyFollowActive === undefined ? {} : { stickyFollowActive }),
+        });
         if (typeof vlist.onScroll === "function") {
           const overscan = vlist.overscan ?? 3;
           const { startIndex, endIndex } = computeVisibleRange(

--- a/packages/core/src/app/widgetRenderer/mouseRouting.ts
+++ b/packages/core/src/app/widgetRenderer/mouseRouting.ts
@@ -1655,7 +1655,11 @@ export function routeMouseWheel(
               0,
               Math.min(vlist.items.length - 1, Math.trunc(rawEnsureVisibleIndex)),
             );
-            const clampedScrollTop = clampScrollTop(r.nextScrollTop, totalHeight, state.viewportHeight);
+            const clampedScrollTop = clampScrollTop(
+              r.nextScrollTop,
+              totalHeight,
+              state.viewportHeight,
+            );
             const maxScrollTop = clampScrollTop(totalHeight, totalHeight, state.viewportHeight);
             const followsTail = followIndex >= vlist.items.length - 1;
             if (followsTail && maxScrollTop - clampedScrollTop <= 1) {

--- a/packages/core/src/app/widgetRenderer/mouseRouting.ts
+++ b/packages/core/src/app/widgetRenderer/mouseRouting.ts
@@ -136,6 +136,7 @@ type RouteToolApprovalDialogMouseContext = Readonly<{
   rectById: ReadonlyMap<string, Rect>;
   focusedActionById: Map<string, ToolApprovalAction>;
   pressedToolApproval: Readonly<{ id: string; action: ToolApprovalAction }> | null;
+  requestRender: () => void;
   setPressedToolApproval: (
     next: Readonly<{ id: string; action: ToolApprovalAction }> | null,
   ) => void;
@@ -786,7 +787,9 @@ export function routeToolApprovalDialogMouseClick(
       : null;
 
   if (event.mouseKind === 3) {
+    const pressed = ctx.pressedToolApproval;
     ctx.setPressedToolApproval(null);
+    if (pressed) ctx.requestRender();
     if (!targetId || !dialog || !rect || action === null) return false;
     ctx.focusedActionById.set(targetId, action);
     ctx.setPressedToolApproval(Object.freeze({ id: targetId, action }));
@@ -796,6 +799,7 @@ export function routeToolApprovalDialogMouseClick(
   const pressed = ctx.pressedToolApproval;
   ctx.setPressedToolApproval(null);
   if (!pressed || !targetId || pressed.id !== targetId || action !== pressed.action || !dialog) {
+    if (pressed) ctx.requestRender();
     return false;
   }
 
@@ -1653,7 +1657,8 @@ export function routeMouseWheel(
             );
             const clampedScrollTop = clampScrollTop(r.nextScrollTop, totalHeight, state.viewportHeight);
             const maxScrollTop = clampScrollTop(totalHeight, totalHeight, state.viewportHeight);
-            if (maxScrollTop - clampedScrollTop <= 1) {
+            const followsTail = followIndex >= vlist.items.length - 1;
+            if (followsTail && maxScrollTop - clampedScrollTop <= 1) {
               stickyFollowActive = true;
             } else {
               const offset = getItemOffset(vlist.items, itemHeight, followIndex, measuredHeights);

--- a/packages/core/src/app/widgetRenderer/overlayState.ts
+++ b/packages/core/src/app/widgetRenderer/overlayState.ts
@@ -469,18 +469,6 @@ export function rebuildRoutingWidgetMapsAndOverlayState(
         });
         break;
       }
-      case "toolApprovalDialog": {
-        const p = v.props as ToolApprovalDialogProps;
-        if (p.open === true) {
-          registerToolApprovalDialogLayer(
-            params,
-            p.id,
-            params.getRectForInstance(cur.instanceId),
-            overlaySeq++,
-          );
-        }
-        break;
-      }
       case "modal": {
         const p = v.props as {
           id?: unknown;

--- a/packages/core/src/app/widgetRenderer/overlayState.ts
+++ b/packages/core/src/app/widgetRenderer/overlayState.ts
@@ -248,6 +248,24 @@ function encodeLayerZIndex(baseZ: number | null, overlaySeq: number): number {
   return clampedBaseZ * LAYER_ZINDEX_SCALE + overlaySeq;
 }
 
+function registerToolApprovalDialogLayer(
+  params: OverlayPoolingContext,
+  id: string,
+  rect: Rect,
+  zIndex: number,
+): void {
+  params.pooledCloseOnEscape.set(id, false);
+  params.pooledCloseOnBackdrop.set(id, false);
+  params.layerRegistry.register({
+    id,
+    rect,
+    backdrop: "dim",
+    modal: true,
+    closeOnEscape: false,
+    zIndex,
+  });
+}
+
 function clearRoutingWidgetMaps(ctx: RoutingWidgetMaps): void {
   ctx.virtualListById.clear();
   ctx.buttonById.clear();
@@ -415,12 +433,19 @@ export function rebuildRoutingWidgetMapsAndOverlayState(
       case "diffViewer":
         params.diffViewerById.set((v.props as DiffViewerProps).id, v.props as DiffViewerProps);
         break;
-      case "toolApprovalDialog":
-        params.toolApprovalDialogById.set(
-          (v.props as ToolApprovalDialogProps).id,
-          v.props as ToolApprovalDialogProps,
-        );
+      case "toolApprovalDialog": {
+        const p = v.props as ToolApprovalDialogProps;
+        params.toolApprovalDialogById.set(p.id, p);
+        if (p.open === true) {
+          registerToolApprovalDialogLayer(
+            params,
+            p.id,
+            params.getRectForInstance(cur.instanceId),
+            overlaySeq++,
+          );
+        }
         break;
+      }
       case "logsConsole":
         params.logsConsoleById.set((v.props as LogsConsoleProps).id, v.props as LogsConsoleProps);
         break;
@@ -442,6 +467,18 @@ export function rebuildRoutingWidgetMapsAndOverlayState(
           closeOnEscape: false,
           zIndex,
         });
+        break;
+      }
+      case "toolApprovalDialog": {
+        const p = v.props as ToolApprovalDialogProps;
+        if (p.open === true) {
+          registerToolApprovalDialogLayer(
+            params,
+            p.id,
+            params.getRectForInstance(cur.instanceId),
+            overlaySeq++,
+          );
+        }
         break;
       }
       case "modal": {

--- a/packages/core/src/app/widgetRenderer/overlayState.ts
+++ b/packages/core/src/app/widgetRenderer/overlayState.ts
@@ -619,6 +619,18 @@ export function rebuildOverlayStateForLayout(params: RebuildOverlayStateForLayou
         });
         break;
       }
+      case "toolApprovalDialog": {
+        const p = v.props as ToolApprovalDialogProps;
+        if (p.open === true) {
+          registerToolApprovalDialogLayer(
+            params,
+            p.id,
+            params.getRectForInstance(cur.instanceId),
+            overlaySeq++,
+          );
+        }
+        break;
+      }
       case "modal": {
         const p = v.props as {
           id?: unknown;

--- a/packages/core/src/app/widgetRenderer/routeEngineEvent.ts
+++ b/packages/core/src/app/widgetRenderer/routeEngineEvent.ts
@@ -74,6 +74,7 @@ import {
   routeSplitPaneMouse,
   routeTableMouseClick,
   routeToastMouseDown,
+  routeToolApprovalDialogMouseClick,
   routeTreeMouseClick,
   routeVirtualListMouseClick,
 } from "./mouseRouting.js";
@@ -124,6 +125,10 @@ type LastTreeClick = Readonly<{
   nodeIndex: number;
   nodeKey: string;
   timeMs: number;
+}> | null;
+type PressedToolApproval = Readonly<{
+  id: string;
+  action: "allow" | "deny" | "allowSession";
 }> | null;
 type SplitPaneDrag = Readonly<{
   id: string;
@@ -241,6 +246,7 @@ export type RouteEngineEventState = {
   lastFilePickerClick: LastFilePickerClick;
   pressedTree: PressedTree;
   lastTreeClick: LastTreeClick;
+  pressedToolApproval: PressedToolApproval;
   splitPaneDrag: SplitPaneDrag;
   splitPaneLastDividerDown: SplitPaneLastDividerDown;
 };
@@ -642,6 +648,18 @@ export function routeEngineEventImpl(
       }
     }
   }
+
+  localNeedsRender =
+    routeToolApprovalDialogMouseClick(event, {
+      mouseTargetId,
+      toolApprovalDialogById: ctx.toolApprovalDialogById,
+      rectById: ctx.rectById,
+      focusedActionById: ctx.toolApprovalFocusedActionById,
+      pressedToolApproval: state.pressedToolApproval,
+      setPressedToolApproval: (next) => {
+        state.pressedToolApproval = next;
+      },
+    }) || localNeedsRender;
 
   localNeedsRender =
     routeVirtualListMouseClick(event, {

--- a/packages/core/src/app/widgetRenderer/routeEngineEvent.ts
+++ b/packages/core/src/app/widgetRenderer/routeEngineEvent.ts
@@ -656,6 +656,9 @@ export function routeEngineEventImpl(
       rectById: ctx.rectById,
       focusedActionById: ctx.toolApprovalFocusedActionById,
       pressedToolApproval: state.pressedToolApproval,
+      requestRender: () => {
+        localNeedsRender = true;
+      },
       setPressedToolApproval: (next) => {
         state.pressedToolApproval = next;
       },

--- a/packages/core/src/renderer/renderToDrawlist/widgets/collections.ts
+++ b/packages/core/src/renderer/renderToDrawlist/widgets/collections.ts
@@ -24,6 +24,7 @@ import { type FlattenedNode, computeNodeState, flattenTree } from "../../../widg
 import type { TableProps, TreeProps, VirtualListProps } from "../../../widgets/types.js";
 import {
   computeVisibleRange,
+  ensureVisible,
   getItemHeight,
   getItemOffset,
   getTotalHeight,
@@ -258,8 +259,45 @@ export function renderCollectionWidget(
           ? state.measuredHeights
           : undefined;
 
+      const normalizeEnsureVisibleIndex = (): number | null => {
+        const rawEnsureVisibleIndex = props.ensureVisibleIndex;
+        if (typeof rawEnsureVisibleIndex !== "number" || !Number.isFinite(rawEnsureVisibleIndex)) {
+          return null;
+        }
+        if (items.length === 0) return null;
+        const raw = Math.trunc(rawEnsureVisibleIndex);
+        return Math.max(0, Math.min(items.length - 1, raw));
+      };
+      const ensureVisibleIndex = normalizeEnsureVisibleIndex();
+      const ensureVisibleMode = props.ensureVisibleMode === "sticky" ? "sticky" : "always";
+      const stickyFollowActive =
+        ensureVisibleMode === "sticky" ? (state.stickyFollowActive ?? true) : true;
+      const shouldEnsureVisible = ensureVisibleIndex !== null && stickyFollowActive;
+      const ensureItemVisible = (
+        baseScrollTop: number,
+        heights: ReadonlyMap<number, number> | undefined,
+      ): number => {
+        const nextTotalHeight = getTotalHeight(items, itemHeight, heights);
+        if (!shouldEnsureVisible || ensureVisibleIndex === null) {
+          return clampScrollTop(baseScrollTop, nextTotalHeight, rect.h);
+        }
+        const offset = getItemOffset(items, itemHeight, ensureVisibleIndex, heights);
+        const height = getItemHeight(items, itemHeight, ensureVisibleIndex, heights);
+        // Sticky tail-follow should anchor oversized rows to their bottom edge.
+        // A generic "make visible" algorithm can oscillate between the row top
+        // and bottom when the item is taller than the viewport and continues growing.
+        if (height > rect.h) {
+          return clampScrollTop(Math.max(0, offset + height - rect.h), nextTotalHeight, rect.h);
+        }
+        return clampScrollTop(
+          ensureVisible(baseScrollTop, rect.h, offset, height),
+          nextTotalHeight,
+          rect.h,
+        );
+      };
+
       const totalHeight = getTotalHeight(items, itemHeight, measuredHeights);
-      const effectiveScrollTop = clampScrollTop(state.scrollTop, totalHeight, rect.h);
+      const effectiveScrollTop = ensureItemVisible(state.scrollTop, measuredHeights);
 
       const fixedItemHeight =
         !estimateMode && measuredHeights === undefined && typeof itemHeight === "number"
@@ -412,6 +450,7 @@ export function renderCollectionWidget(
           finalTotalHeight,
           rect.h,
         );
+        nextScrollTop = ensureItemVisible(nextScrollTop, finalMeasuredHeights);
       }
 
       setLayoutScrollMetadata(layoutNode, {
@@ -432,6 +471,7 @@ export function renderCollectionWidget(
           startIndex: number;
           endIndex: number;
           scrollTop?: number;
+          stickyFollowActive?: boolean;
           measuredHeights?: ReadonlyMap<number, number>;
           measuredWidth?: number;
           measuredItemCount?: number;
@@ -441,6 +481,9 @@ export function renderCollectionWidget(
           endIndex: renderedEndIndex,
         };
         if (nextScrollTop !== state.scrollTop) patch.scrollTop = nextScrollTop;
+        if (ensureVisibleMode === "sticky" && state.stickyFollowActive === undefined) {
+          patch.stickyFollowActive = true;
+        }
         if (estimateMode) {
           patch.measuredHeights = finalMeasuredHeights ?? new Map<number, number>();
           patch.measuredWidth = rect.w;

--- a/packages/core/src/runtime/__tests__/localStateStore.test.ts
+++ b/packages/core/src/runtime/__tests__/localStateStore.test.ts
@@ -52,6 +52,19 @@ test("virtual list state store clones measuredHeights inputs", () => {
   assert.equal(store.get("list").measuredHeights?.has(2), false);
 });
 
+test("virtual list state store preserves sticky follow state", () => {
+  const store = createVirtualListStateStore();
+
+  store.set("list", { stickyFollowActive: false, scrollTop: 4 });
+  const state = store.get("list");
+
+  assert.equal(state.stickyFollowActive, false);
+  assert.equal(state.scrollTop, 4);
+
+  store.set("list", { selectedIndex: 2 });
+  assert.equal(store.get("list").stickyFollowActive, false);
+});
+
 test("tree state store clones loading and expanded set inputs", () => {
   const store = createTreeStateStore();
   const loadingKeys = new Set<string>(["loading-a"]);

--- a/packages/core/src/runtime/localState.ts
+++ b/packages/core/src/runtime/localState.ts
@@ -39,6 +39,11 @@ export type VirtualListLocalState = Readonly<{
   /** One past last visible item index (derived from scrollTop + viewportHeight). */
   endIndex: number;
   /**
+   * Sticky-follow state for ensureVisibleIndex mode.
+   * Undefined means the behavior has not been initialized yet.
+   */
+  stickyFollowActive?: boolean;
+  /**
    * Cached measured heights (index -> height) used by estimateItemHeight mode.
    * Internal detail; consumers should treat this as read-only snapshot state.
    */
@@ -250,6 +255,7 @@ export type VirtualListLocalStatePatch = Readonly<{
   viewportHeight?: number;
   startIndex?: number;
   endIndex?: number;
+  stickyFollowActive?: boolean;
   measuredHeights?: ReadonlyMap<number, number>;
   measuredWidth?: number;
   measuredItemCount?: number;
@@ -286,6 +292,11 @@ export function createVirtualListStateStore(): VirtualListStateStore {
           patch.viewportHeight !== undefined ? patch.viewportHeight : prev.viewportHeight,
         startIndex: patch.startIndex !== undefined ? patch.startIndex : prev.startIndex,
         endIndex: patch.endIndex !== undefined ? patch.endIndex : prev.endIndex,
+        ...(patch.stickyFollowActive !== undefined
+          ? { stickyFollowActive: patch.stickyFollowActive }
+          : prev.stickyFollowActive !== undefined
+            ? { stickyFollowActive: prev.stickyFollowActive }
+            : {}),
         ...(measuredHeights === undefined ? {} : { measuredHeights }),
         ...(measuredWidth === undefined ? {} : { measuredWidth }),
         ...(measuredItemCount === undefined ? {} : { measuredItemCount }),

--- a/packages/core/src/widgets/__tests__/renderer.regressions.test.ts
+++ b/packages/core/src/widgets/__tests__/renderer.regressions.test.ts
@@ -710,7 +710,10 @@ describe("renderer regressions", () => {
     );
 
     const strings = parseInternedStrings(bytes);
-    assert.equal(strings.some((s) => s.includes("item-9")), true);
+    assert.equal(
+      strings.some((s) => s.includes("item-9")),
+      true,
+    );
     assert.equal(virtualListStore.get(id).scrollTop, 5);
   });
 
@@ -733,8 +736,14 @@ describe("renderer regressions", () => {
     );
 
     const strings = parseInternedStrings(bytes);
-    assert.equal(strings.some((s) => s.includes("item-0")), true);
-    assert.equal(strings.some((s) => s.includes("item-9")), false);
+    assert.equal(
+      strings.some((s) => s.includes("item-0")),
+      true,
+    );
+    assert.equal(
+      strings.some((s) => s.includes("item-9")),
+      false,
+    );
     assert.equal(virtualListStore.get(id).scrollTop, 0);
   });
 

--- a/packages/core/src/widgets/__tests__/renderer.regressions.test.ts
+++ b/packages/core/src/widgets/__tests__/renderer.regressions.test.ts
@@ -691,6 +691,74 @@ describe("renderer regressions", () => {
     );
   });
 
+  test("virtualList sticky ensureVisible follows tail while active", () => {
+    const virtualListStore = createVirtualListStateStore();
+    const id = "vl-sticky-tail";
+    virtualListStore.set(id, { stickyFollowActive: true, scrollTop: 0 });
+
+    const bytes = renderBytes(
+      ui.virtualList({
+        id,
+        items: Array.from({ length: 10 }, (_, i) => `item-${String(i)}`),
+        itemHeight: 1,
+        ensureVisibleIndex: 9,
+        ensureVisibleMode: "sticky",
+        renderItem: (item) => ui.text(item),
+      }),
+      { cols: 20, rows: 5 },
+      { virtualListStore },
+    );
+
+    const strings = parseInternedStrings(bytes);
+    assert.equal(strings.some((s) => s.includes("item-9")), true);
+    assert.equal(virtualListStore.get(id).scrollTop, 5);
+  });
+
+  test("virtualList sticky ensureVisible does not yank when follow is disabled", () => {
+    const virtualListStore = createVirtualListStateStore();
+    const id = "vl-sticky-paused";
+    virtualListStore.set(id, { stickyFollowActive: false, scrollTop: 0 });
+
+    const bytes = renderBytes(
+      ui.virtualList({
+        id,
+        items: Array.from({ length: 10 }, (_, i) => `item-${String(i)}`),
+        itemHeight: 1,
+        ensureVisibleIndex: 9,
+        ensureVisibleMode: "sticky",
+        renderItem: (item) => ui.text(item),
+      }),
+      { cols: 20, rows: 5 },
+      { virtualListStore },
+    );
+
+    const strings = parseInternedStrings(bytes);
+    assert.equal(strings.some((s) => s.includes("item-0")), true);
+    assert.equal(strings.some((s) => s.includes("item-9")), false);
+    assert.equal(virtualListStore.get(id).scrollTop, 0);
+  });
+
+  test("virtualList sticky ensureVisible anchors oversized tail rows to the bottom", () => {
+    const virtualListStore = createVirtualListStateStore();
+    const id = "vl-sticky-oversized-tail";
+    virtualListStore.set(id, { stickyFollowActive: true, scrollTop: 0 });
+
+    renderBytes(
+      ui.virtualList({
+        id,
+        items: ["giant-tail"],
+        itemHeight: 10,
+        ensureVisibleIndex: 0,
+        ensureVisibleMode: "sticky",
+        renderItem: (item) => ui.text(item),
+      }),
+      { cols: 20, rows: 5 },
+      { virtualListStore },
+    );
+
+    assert.equal(virtualListStore.get(id).scrollTop, 5);
+  });
+
   test("virtualList estimate mode uses custom measureItemHeight context", () => {
     const virtualListStore = createVirtualListStateStore();
     const calls: Array<

--- a/packages/core/src/widgets/types/base.ts
+++ b/packages/core/src/widgets/types/base.ts
@@ -1007,6 +1007,17 @@ export type VirtualListProps<T = unknown> = Readonly<{
   /** Number of items to render outside the visible viewport (default: 3) */
   overscan?: number;
   renderItem: (item: T, index: number, focused: boolean) => VNode;
+  /**
+   * When provided, the list can keep this item visible as content changes.
+   * Useful for chat, logs, or streaming output UIs that follow a tail item.
+   */
+  ensureVisibleIndex?: number;
+  /**
+   * Controls how ensureVisibleIndex behaves.
+   * - "always": always keep the target item visible
+   * - "sticky": keep following only while the user stays attached to the tail
+   */
+  ensureVisibleMode?: "always" | "sticky";
   onScroll?: (scrollTop: number, visibleRange: [number, number]) => void;
   onSelect?: (item: T, index: number) => void;
   /** Enable keyboard navigation with arrow keys, page up/down, home/end (default: true) */


### PR DESCRIPTION
Added virtual list sticky-follow mode, tool approval dialog event blocking, and max blob size configuration

<img width="1890" height="992" alt="image" src="https://github.com/user-attachments/assets/3f9afa00-fc38-4530-9230-8fa2296d1329" />

## Summary

This pull request introduces three distinct enhancements to the core UI and rendering pipeline to better support complex TUI interfaces (such as the MTI-EVO chat and configuration wizard):

1. **Virtual List Sticky Auto-Scrolling**: Introduces `ensureVisibleIndex` and `ensureVisibleMode: "sticky"` to the `VirtualList` widget. This enables UIs like streaming chat panels or logs to automatically auto-scroll and follow new tail items as they are added. Crucially, the "sticky" mode monitors a `stickyFollowActive` state, meaning it will elegantly pause auto-scrolling if the user manually scrolls up to read past content, and resume when they scroll back down. It also includes math to properly anchor oversized rows to the bottom of the viewport to prevent scroll oscillation.
2. **Tool Approval Dialog Interactions**: Implements rigorous mouse routing, modal layer registration, and backdrop click-blocking for the `toolApprovalDialog` component. It correctly maps click hit zones for `[Allow]`, `[Deny]`, and `[Allow Session]` regions. Additionally, it prevents errant clicks on the backdrop from passing through and inadvertently triggering background buttons while a critical approval is pending.
3. **Max Blob Size Config**: Plumbs a `maxBlobBytes` setting (defaulting to 512 KiB) through the app configuration, `rawRenderer`, and `widgetRenderer` to safely cap blob payload sizes during drawlist compilation.

## Testing Notes

- **Contract source**: `packages/core/src/app/__tests__/widgetBehavior.contracts.test.ts` and `packages/core/src/widgets/__tests__/renderer.regressions.test.ts`
- **Chosen test fidelity**: High-fidelity unit and behavioral contract tests. We verified virtual list behavior (sticky tail following, pausing the yank when the user manually scrolls, and oversized tail row anchoring) in `renderer.regressions.test.ts`. We also verified exact hit regions and backdrop blocking for `toolApprovalDialog` in `widgetBehavior.contracts.test.ts`. State preservation for `stickyFollowActive` was validated in `localStateStore.test.ts`.
- **Degraded or failure-path coverage, if relevant**: Handled edge cases for oversized virtual list rows to ensure they anchor to the bottom rather than oscillating. Ensured `maxBlobBytes` falls back to the default `512 KiB` configuration gracefully if left undefined by the host application.


## Checklist

- [x] `npm run lint` passes
- [x] `npm run typecheck` passes
- [x] `npm test` passes (or change is docs/CI-only)
- [ ] Docs updated (`README.md` and/or `docs/`)
- [ ] `npm run docs:build` passes (docs changes)
- [x] Module boundaries preserved (`packages/core` has no Node APIs)
- [x] Binary safety rules followed (bounds checks, caps, determinism)


