### PR TITLE
test: add deterministic fuzzing framework

### DIFF
--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -28,8 +28,18 @@ Keep fuzz targets behavior-first and contract-backed:
   structured errors
 - binary readers/writers: preserve byte order, bounds checks, and failure
   atomicity
+- drawlist builders: valid public command programs produce well-formed bounded
+  ZRDL; invalid public inputs return structured build errors without throwing
+- keybinding parsers: valid public syntax round-trips through canonical strings;
+  malformed syntax returns structured parse errors
+- router paths: key, mouse, hit-test, and wheel routing only dispatch to
+  enabled intended targets and clamp scroll updates
+- widgets: disabled controls suppress interaction, enabled controls emit
+  documented payloads, and duplicate interactive ids fail deterministically
 - layout/text/render paths: never throw on valid widget trees or malformed text
   data; outputs remain bounded and deterministic
+- theme and style resolution: valid tokens resolve exactly; invalid tokens and
+  paths fail or fall back deterministically
 - app runtime and backend integration: injected backend failures produce
   structured fatal events, stop safely, and dispose when the runtime faults
 

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -8,6 +8,9 @@ Rezi fuzz tests are deterministic, bounded `node:test` suites. They should use
 - derived case seed
 - case notes such as input length, viewport, or injected fault points
 
+Seeds are unsigned 32-bit integers. Values outside `0..0xffffffff` are rejected
+instead of truncated so reproduction commands always identify one exact run.
+
 Run all package fuzz suites after a build:
 
 ```bash

--- a/docs/dev/fuzzing.md
+++ b/docs/dev/fuzzing.md
@@ -1,0 +1,38 @@
+# Fuzzing
+
+Rezi fuzz tests are deterministic, bounded `node:test` suites. They should use
+`@rezi-ui/testkit` helpers so failures report:
+
+- suite seed
+- iteration
+- derived case seed
+- case notes such as input length, viewport, or injected fault points
+
+Run all package fuzz suites after a build:
+
+```bash
+npm run test:fuzz
+```
+
+For a single built test file:
+
+```bash
+node --test packages/core/dist/protocol/__tests__/zrev_v1_fuzz_lite.test.js
+```
+
+## Coverage Targets
+
+Keep fuzz targets behavior-first and contract-backed:
+
+- parsers and binary protocols: never throw on malformed bytes; return
+  structured errors
+- binary readers/writers: preserve byte order, bounds checks, and failure
+  atomicity
+- layout/text/render paths: never throw on valid widget trees or malformed text
+  data; outputs remain bounded and deterministic
+- app runtime and backend integration: injected backend failures produce
+  structured fatal events, stop safely, and dispose when the runtime faults
+
+Do not add unbounded randomness or wall-clock-dependent fuzzing to CI. Increase
+iteration counts through explicit seeds and focused profiles, not through
+environment-dependent loops.

--- a/docs/dev/testing.md
+++ b/docs/dev/testing.md
@@ -191,6 +191,9 @@ Do not add speculative failure assertions when the user-visible fallback is not
 actually specified.
 If the fallback is under-specified, document the gap and avoid over-claiming.
 
+For deterministic fuzz-lite and failure-injection test structure, see
+[Fuzzing](fuzzing.md).
+
 ## Acceptable and Unacceptable Oracles
 
 ### Usually acceptable

--- a/docs/packages/testkit.md
+++ b/docs/packages/testkit.md
@@ -6,7 +6,8 @@ Test utilities and fixtures for Rezi applications and package-level tests.
 
 - **Fixtures** for protocol and drawlist tests (golden byte blobs)
 - **Golden helpers** (`assertBytesEqual`, `hexdump`) for stable diffs
-- **Deterministic RNG** helpers (`createRng`) for fuzz-lite tests
+- **Deterministic fuzz helpers** (`runFuzz`, `fuzzTest`, `createRng`) for
+  seeded fuzz-lite and failure-injection tests
 - **Snapshot helper** (`matchesSnapshot`) for text-frame regression tests
 - Convenience re-exports of Node’s `node:test` and `node:assert` APIs (Node-only)
 
@@ -24,6 +25,22 @@ describe("zrev parser", () => {
 
 test("snapshot rendered frame text", () => {
   matchesSnapshot("hello\nworld", "example-frame");
+});
+```
+
+Seeded fuzz tests should use `runFuzz()` or `fuzzTest()` so failures include
+the suite seed, iteration, derived case seed, and any notes needed to reproduce
+the generated input.
+
+```ts
+import { assert, randomInt, runFuzz, test } from "@rezi-ui/testkit";
+
+test("parser fuzz-lite", async () => {
+  await runFuzz({ seed: 0x5a524556, iterations: 1000, label: "parser" }, (ctx) => {
+    const bytes = ctx.rng.bytes(randomInt(ctx.rng, 0, 256));
+    ctx.note(`len=${bytes.byteLength}`);
+    assert.equal(typeof bytes.byteLength, "number");
+  });
 });
 ```
 

--- a/docs/packages/testkit.md
+++ b/docs/packages/testkit.md
@@ -30,7 +30,7 @@ test("snapshot rendered frame text", () => {
 
 Seeded fuzz tests should use `runFuzz()` or `fuzzTest()` so failures include
 the suite seed, iteration, derived case seed, and any notes needed to reproduce
-the generated input.
+the generated input. Seeds must be unsigned 32-bit integers.
 
 ```ts
 import { assert, randomInt, runFuzz, test } from "@rezi-ui/testkit";

--- a/mkdocs.yml
+++ b/mkdocs.yml
@@ -265,6 +265,7 @@ nav:
       - Repo Layout: dev/repo-layout.md
       - Build: dev/build.md
       - Testing: dev/testing.md
+      - Fuzzing: dev/fuzzing.md
       - Live PTY Debugging: dev/live-pty-debugging.md
       - Code Standards: dev/code-standards.md
       - Perf Regressions: dev/perf-regressions.md

--- a/package.json
+++ b/package.json
@@ -43,6 +43,7 @@
     "test:e2e:reduced": "node scripts/run-e2e.mjs --profile reduced",
     "test:scripts": "node scripts/run-tests.mjs --scope scripts",
     "test:packages": "node scripts/run-tests.mjs --scope packages",
+    "test:fuzz": "npm run build && node scripts/run-tests.mjs --scope packages --filter fuzz",
     "test:release-critical": "node scripts/testing-slices.mjs run release-critical-packages",
     "test:release-critical:terminal": "node scripts/testing-slices.mjs run release-critical-terminal",
     "test:progress": "node scripts/testing-slices.mjs summary",

--- a/packages/core/src/app/__tests__/failure.fuzz.test.ts
+++ b/packages/core/src/app/__tests__/failure.fuzz.test.ts
@@ -1,0 +1,126 @@
+import { assert, createFuzzFaultPlan, runFuzz, test } from "@rezi-ui/testkit";
+import { ui } from "../../widgets/ui.js";
+import { createApp } from "../createApp.js";
+import { encodeZrevBatchV1, flushMicrotasks, makeBackendBatch } from "./helpers.js";
+import { StubBackend } from "./stubBackend.js";
+
+const FAILURE_POINTS = ["start", "getCaps", "poll", "frame", "stop"] as const;
+type FailurePoint = (typeof FAILURE_POINTS)[number];
+
+async function settle(backend: StubBackend): Promise<void> {
+  if (backend.requestedFrames.length > 0) {
+    try {
+      backend.resolveNextFrame();
+    } catch {
+      // The fault plan may already have rejected the only in-flight frame.
+    }
+  }
+  await flushMicrotasks(16);
+}
+
+async function emitResize(backend: StubBackend): Promise<void> {
+  backend.pushBatch(
+    makeBackendBatch({
+      bytes: encodeZrevBatchV1({
+        events: [{ kind: "resize", timeMs: 1, cols: 60, rows: 16 }],
+      }),
+    }),
+  );
+  await flushMicrotasks(16);
+}
+
+test("createApp failure fuzz: injected backend failures produce structured lifecycle outcomes", async () => {
+  await runFuzz(
+    {
+      seed: 0xfa17_0001,
+      iterations: 256,
+      label: "createApp backend failures",
+    },
+    async (ctx) => {
+      const plan = createFuzzFaultPlan<FailurePoint>(ctx, FAILURE_POINTS, {
+        minFailures: 1,
+        maxFailures: 2,
+      });
+      ctx.note(`faults=${plan.describe()}`);
+
+      const backend = new StubBackend();
+      const app = createApp({ backend, initialState: 0 });
+      const fatals: string[] = [];
+
+      app.view((state) => appText(state));
+      app.onEvent((event) => {
+        if (event.kind === "fatal") fatals.push(`${event.code}:${event.detail}`);
+      });
+
+      if (plan.has("start")) {
+        backend.queueStartFailure(new Error("fuzz start failure"));
+        await assert.rejects(app.start(), /backend.start rejected: Error: fuzz start failure/u);
+        assert.equal(backend.startCalls, 1);
+        assert.equal(backend.requestedFrames.length, 0);
+        app.dispose();
+        return;
+      }
+
+      if (plan.has("getCaps")) backend.queueGetCapsFailure(new Error("fuzz caps failure"));
+      await app.start();
+      assert.equal(backend.startCalls, 1);
+      await emitResize(backend);
+      assert.equal(backend.requestedFrames.length >= 1, true);
+
+      if (plan.has("frame")) {
+        backend.rejectNextFrame(new Error("fuzz frame failure"));
+        await flushMicrotasks(20);
+        assert.equal(
+          fatals.some((fatal) => fatal.startsWith("ZRUI_BACKEND_ERROR:requestFrame")),
+          true,
+        );
+        assert.equal(backend.stopCalls >= 1, true);
+        assert.equal(backend.disposeCalls >= 1, true);
+        return;
+      }
+
+      await settle(backend);
+
+      if (plan.has("poll")) {
+        backend.queuePollFailure(new Error("fuzz poll failure"));
+        await flushMicrotasks(20);
+        assert.equal(
+          fatals.some((fatal) => fatal.startsWith("ZRUI_BACKEND_ERROR:pollEvents rejected:")),
+          true,
+        );
+        assert.equal(backend.stopCalls >= 1, true);
+        assert.equal(backend.disposeCalls >= 1, true);
+        return;
+      }
+
+      if (plan.has("stop")) {
+        backend.queueStopFailure(new Error("fuzz stop failure"));
+        backend.pushBatch(
+          makeBackendBatch({
+            bytes: encodeZrevBatchV1({
+              events: [{ kind: "text", timeMs: 2, codepoint: 113 }],
+            }),
+          }),
+        );
+        await flushMicrotasks(20);
+        assert.equal(
+          fatals.some((fatal) =>
+            fatal.startsWith("ZRUI_BACKEND_ERROR:stop rejected after unhandled quit input:"),
+          ),
+          true,
+        );
+        assert.equal(backend.stopCalls >= 1, true);
+        app.dispose();
+        return;
+      }
+
+      await app.stop();
+      app.dispose();
+      assert.equal(fatals.length, 0);
+    },
+  );
+});
+
+function appText(state: number) {
+  return ui.text(`state:${String(state)}`);
+}

--- a/packages/core/src/binary/__tests__/binary.fuzz.test.ts
+++ b/packages/core/src/binary/__tests__/binary.fuzz.test.ts
@@ -1,0 +1,201 @@
+import { assert, type Rng, chance, pick, randomInt, runFuzz, test } from "@rezi-ui/testkit";
+import { ZrBinaryError } from "../parseError.js";
+import { BinaryReader } from "../reader.js";
+import { BinaryWriter } from "../writer.js";
+
+type WriteOp =
+  | Readonly<{ kind: "u8"; value: number }>
+  | Readonly<{ kind: "u32"; value: number }>
+  | Readonly<{ kind: "i32"; value: number }>
+  | Readonly<{ kind: "bytes"; bytes: Uint8Array }>
+  | Readonly<{ kind: "pad4" }>;
+
+type SuccessfulRead =
+  | Readonly<{ kind: "u8"; value: number }>
+  | Readonly<{ kind: "u32"; value: number }>
+  | Readonly<{ kind: "i32"; value: number }>
+  | Readonly<{ kind: "bytes"; bytes: Uint8Array }>
+  | Readonly<{ kind: "skip"; len: number }>;
+
+function randomOp(rng: Rng): WriteOp {
+  const kind = pick(rng, ["u8", "u32", "i32", "bytes", "pad4"] as const);
+  if (kind === "u8") return { kind, value: rng.u32() };
+  if (kind === "u32") return { kind, value: rng.u32() };
+  if (kind === "i32") return { kind, value: rng.u32() | 0 };
+  if (kind === "pad4") return { kind };
+  return { kind, bytes: rng.bytes(randomInt(rng, 0, 12)) };
+}
+
+function expectedFailure(
+  op: WriteOp,
+  offset: number,
+  capacity: number,
+): "ZR_MISALIGNED" | "ZR_LIMIT" | null {
+  const size = op.kind === "u8" ? 1 : op.kind === "u32" || op.kind === "i32" ? 4 : 0;
+  if ((op.kind === "u32" || op.kind === "i32") && (offset & 3) !== 0) return "ZR_MISALIGNED";
+  if (op.kind === "bytes") return offset + op.bytes.byteLength > capacity ? "ZR_LIMIT" : null;
+  if (op.kind === "pad4") {
+    const aligned = (offset + 3) & ~3;
+    return aligned > capacity ? "ZR_LIMIT" : null;
+  }
+  return offset + size > capacity ? "ZR_LIMIT" : null;
+}
+
+function appendLeU32(out: number[], value: number): void {
+  out.push(value & 0xff, (value >>> 8) & 0xff, (value >>> 16) & 0xff, (value >>> 24) & 0xff);
+}
+
+function appendLeI32(out: number[], value: number): void {
+  appendLeU32(out, value >>> 0);
+}
+
+function applyExpected(op: WriteOp, expected: number[], reads: SuccessfulRead[]): void {
+  if (op.kind === "u8") {
+    expected.push(op.value & 0xff);
+    reads.push({ kind: "u8", value: op.value & 0xff });
+    return;
+  }
+  if (op.kind === "u32") {
+    appendLeU32(expected, op.value);
+    reads.push({ kind: "u32", value: op.value >>> 0 });
+    return;
+  }
+  if (op.kind === "i32") {
+    appendLeI32(expected, op.value);
+    reads.push({ kind: "i32", value: op.value | 0 });
+    return;
+  }
+  if (op.kind === "bytes") {
+    expected.push(...op.bytes);
+    reads.push({ kind: "bytes", bytes: op.bytes });
+    return;
+  }
+
+  const before = expected.length;
+  const aligned = (before + 3) & ~3;
+  while (expected.length < aligned) expected.push(0);
+  if (aligned > before) reads.push({ kind: "skip", len: aligned - before });
+}
+
+function applyWriter(writer: BinaryWriter, op: WriteOp): void {
+  if (op.kind === "u8") {
+    writer.writeU8(op.value);
+    return;
+  }
+  if (op.kind === "u32") {
+    writer.writeU32(op.value);
+    return;
+  }
+  if (op.kind === "i32") {
+    writer.writeI32(op.value);
+    return;
+  }
+  if (op.kind === "bytes") {
+    writer.writeBytes(op.bytes);
+    return;
+  }
+  writer.padTo4();
+}
+
+function assertBinaryError(err: unknown, code: "ZR_MISALIGNED" | "ZR_LIMIT"): boolean {
+  assert.ok(err instanceof ZrBinaryError);
+  assert.equal(err.code, code);
+  return true;
+}
+
+function assertReaderRoundTrip(bytes: Uint8Array, reads: readonly SuccessfulRead[]): void {
+  const reader = new BinaryReader(bytes);
+  for (const read of reads) {
+    if (read.kind === "u8") {
+      assert.equal(reader.readU8(), read.value);
+      continue;
+    }
+    if (read.kind === "u32") {
+      assert.equal(reader.readU32(), read.value);
+      continue;
+    }
+    if (read.kind === "i32") {
+      assert.equal(reader.readI32(), read.value);
+      continue;
+    }
+    if (read.kind === "bytes") {
+      assert.deepEqual(Array.from(reader.readBytes(read.bytes.byteLength)), Array.from(read.bytes));
+      continue;
+    }
+    reader.skip(read.len);
+  }
+  assert.equal(reader.remaining, 0);
+}
+
+function assertTruncatedReadsFail(bytes: Uint8Array, reads: readonly SuccessfulRead[]): void {
+  if (bytes.byteLength === 0) return;
+  const truncated = bytes.subarray(0, bytes.byteLength - 1);
+  const reader = new BinaryReader(truncated);
+  let sawFailure = false;
+
+  for (const read of reads) {
+    try {
+      if (read.kind === "u8") reader.readU8();
+      else if (read.kind === "u32") reader.readU32();
+      else if (read.kind === "i32") reader.readI32();
+      else if (read.kind === "bytes") reader.readBytes(read.bytes.byteLength);
+      else reader.skip(read.len);
+    } catch (err: unknown) {
+      assert.ok(err instanceof ZrBinaryError);
+      assert.equal(err.code, "ZR_TRUNCATED");
+      sawFailure = true;
+      break;
+    }
+  }
+
+  assert.equal(sawFailure, true);
+}
+
+test("BinaryReader/BinaryWriter fuzz: bounded programs preserve bytes and failure atomicity", async () => {
+  await runFuzz(
+    {
+      seed: 0xb16a_0001,
+      iterations: 2048,
+      label: "binary reader/writer",
+    },
+    (ctx) => {
+      const capacity = randomInt(ctx.rng, 0, 160);
+      const opCount = randomInt(ctx.rng, 1, 80);
+      const writer = new BinaryWriter(capacity);
+      const expected: number[] = [];
+      const reads: SuccessfulRead[] = [];
+      ctx.note(`capacity=${String(capacity)} ops=${String(opCount)}`);
+
+      for (let i = 0; i < opCount; i++) {
+        const op = randomOp(ctx.rng);
+        const failure = expectedFailure(op, expected.length, capacity);
+        const offsetBefore = writer.offset;
+
+        if (failure !== null) {
+          assert.throws(
+            () => applyWriter(writer, op),
+            (err: unknown) => assertBinaryError(err, failure),
+          );
+          assert.equal(writer.offset, offsetBefore, "failed writes must not advance the cursor");
+          if (
+            chance(ctx.rng, 45) &&
+            expectedFailure({ kind: "pad4" }, expected.length, capacity) === null
+          ) {
+            applyWriter(writer, { kind: "pad4" });
+            applyExpected({ kind: "pad4" }, expected, reads);
+          }
+          continue;
+        }
+
+        applyWriter(writer, op);
+        applyExpected(op, expected, reads);
+        assert.equal(writer.offset, expected.length);
+      }
+
+      const bytes = writer.finish();
+      assert.deepEqual(Array.from(bytes), expected);
+      assertReaderRoundTrip(bytes, reads);
+      assertTruncatedReadsFail(bytes, reads);
+    },
+  );
+});

--- a/packages/core/src/drawlist/__tests__/builder.fuzz.test.ts
+++ b/packages/core/src/drawlist/__tests__/builder.fuzz.test.ts
@@ -1,0 +1,240 @@
+import { assert, test } from "@rezi-ui/testkit";
+import { chance, pick, randomAsciiString, randomInt, runFuzz } from "@rezi-ui/testkit";
+import {
+  OP_CLEAR,
+  OP_DEF_STRING,
+  OP_DRAW_TEXT,
+  OP_FILL_RECT,
+  OP_POP_CLIP,
+  OP_PUSH_CLIP,
+  OP_SET_CURSOR,
+  parseCommandHeaders,
+  u32,
+} from "../../__tests__/drawlistDecode.js";
+import { ZRDL_MAGIC, ZR_DRAWLIST_VERSION_V1 } from "../../abi.js";
+import { createDrawlistBuilder } from "../builder.js";
+import type { DrawlistBuildErrorCode, DrawlistBuildResult } from "../types.js";
+
+const HEADER_SIZE = 64;
+const INT32_MIN = -2147483648;
+const INT32_MAX = 2147483647;
+
+type Header = Readonly<{
+  magic: number;
+  version: number;
+  headerSize: number;
+  totalSize: number;
+  cmdOffset: number;
+  cmdBytes: number;
+  cmdCount: number;
+  stringsCount: number;
+  stringsBytesLen: number;
+  blobsCount: number;
+  blobsBytesLen: number;
+}>;
+
+function readHeader(bytes: Uint8Array): Header {
+  return {
+    magic: u32(bytes, 0),
+    version: u32(bytes, 4),
+    headerSize: u32(bytes, 8),
+    totalSize: u32(bytes, 12),
+    cmdOffset: u32(bytes, 16),
+    cmdBytes: u32(bytes, 20),
+    cmdCount: u32(bytes, 24),
+    stringsCount: u32(bytes, 32),
+    stringsBytesLen: u32(bytes, 40),
+    blobsCount: u32(bytes, 48),
+    blobsBytesLen: u32(bytes, 56),
+  };
+}
+
+function expectOk(result: DrawlistBuildResult): Uint8Array {
+  if (!result.ok) throw new Error(`expected drawlist build to succeed: ${result.error.detail}`);
+  assert.equal(result.ok, true);
+  return result.bytes;
+}
+
+function expectError(result: DrawlistBuildResult, codes: readonly DrawlistBuildErrorCode[]): void {
+  assert.equal(result.ok, false);
+  if (result.ok) throw new Error("expected drawlist build to fail");
+  assert.ok(codes.includes(result.error.code), result.error.detail);
+  assert.equal(typeof result.error.detail, "string");
+  assert.ok(result.error.detail.length > 0);
+}
+
+test("DrawlistBuilder fuzz: valid command programs produce well-formed bounded ZRDL", async () => {
+  await runFuzz({ label: "drawlist-valid-programs", seed: 0x5a19_d117, iterations: 220 }, (ctx) => {
+    const b = createDrawlistBuilder({
+      maxCmdCount: 96,
+      maxDrawlistBytes: 32_768,
+      maxStringBytes: 4096,
+      maxStrings: 128,
+      maxBlobBytes: 4096,
+      maxBlobs: 32,
+    });
+    const uniqueTexts = new Set<string>();
+    const expectedVisibleOpcodes: number[] = [];
+    let openClips = 0;
+
+    const commandCount = randomInt(ctx.rng, 1, 48);
+    for (let i = 0; i < commandCount; i++) {
+      const op = pick(ctx.rng, [
+        "clear",
+        "fillRect",
+        "drawText",
+        "pushClip",
+        "popClip",
+        "setCursor",
+        "hideCursor",
+      ] as const);
+
+      switch (op) {
+        case "clear":
+          b.clear();
+          expectedVisibleOpcodes.push(OP_CLEAR);
+          break;
+        case "fillRect":
+          b.fillRect(
+            randomInt(ctx.rng, -30, 160),
+            randomInt(ctx.rng, -10, 80),
+            randomInt(ctx.rng, 0, 40),
+            randomInt(ctx.rng, 0, 20),
+            chance(ctx.rng, 50)
+              ? { bold: chance(ctx.rng, 50), fg: randomInt(ctx.rng, 0, 0xffffff) }
+              : undefined,
+          );
+          expectedVisibleOpcodes.push(OP_FILL_RECT);
+          break;
+        case "drawText": {
+          const text = randomAsciiString(ctx.rng, {
+            minLength: chance(ctx.rng, 20) ? 0 : 1,
+            maxLength: 24,
+            alphabet: "abcXYZ012 -_/.:",
+          });
+          b.drawText(randomInt(ctx.rng, -30, 160), randomInt(ctx.rng, -10, 80), text, {
+            underline: chance(ctx.rng, 35),
+            italic: chance(ctx.rng, 35),
+          });
+          uniqueTexts.add(text);
+          expectedVisibleOpcodes.push(OP_DRAW_TEXT);
+          break;
+        }
+        case "pushClip":
+          b.pushClip(
+            randomInt(ctx.rng, -20, 120),
+            randomInt(ctx.rng, -10, 60),
+            randomInt(ctx.rng, 0, 80),
+            randomInt(ctx.rng, 0, 30),
+          );
+          openClips += 1;
+          expectedVisibleOpcodes.push(OP_PUSH_CLIP);
+          break;
+        case "popClip":
+          if (openClips > 0 || chance(ctx.rng, 20)) {
+            b.popClip();
+            openClips = Math.max(0, openClips - 1);
+            expectedVisibleOpcodes.push(OP_POP_CLIP);
+          }
+          break;
+        case "setCursor":
+          b.setCursor({
+            x: randomInt(ctx.rng, -1, 160),
+            y: randomInt(ctx.rng, -1, 80),
+            shape: pick(ctx.rng, [0, 1, 2] as const),
+            visible: chance(ctx.rng, 80),
+            blink: chance(ctx.rng, 50),
+          });
+          expectedVisibleOpcodes.push(OP_SET_CURSOR);
+          break;
+        case "hideCursor":
+          b.hideCursor();
+          expectedVisibleOpcodes.push(OP_SET_CURSOR);
+          break;
+      }
+    }
+
+    const bytes = expectOk(b.build());
+    const header = readHeader(bytes);
+    const commands = parseCommandHeaders(bytes);
+    const visibleOpcodes = commands
+      .map((cmd) => cmd.opcode)
+      .filter((opcode) => opcode !== 10 && opcode !== 11 && opcode !== 12 && opcode !== 13);
+
+    assert.equal(header.magic, ZRDL_MAGIC);
+    assert.equal(header.version, ZR_DRAWLIST_VERSION_V1);
+    assert.equal(header.headerSize, HEADER_SIZE);
+    assert.equal(header.totalSize, bytes.byteLength);
+    assert.equal((header.totalSize & 3) === 0, true);
+    assert.equal(header.cmdOffset === 0 || header.cmdOffset === HEADER_SIZE, true);
+    assert.equal(header.cmdBytes % 4, 0);
+    assert.equal(header.stringsBytesLen % 4, 0);
+    assert.equal(header.blobsBytesLen % 4, 0);
+    assert.equal(commands.length, header.cmdCount);
+    assert.deepEqual(visibleOpcodes, expectedVisibleOpcodes);
+    assert.equal(commands.filter((cmd) => cmd.opcode === OP_DEF_STRING).length, uniqueTexts.size);
+    assert.equal(header.stringsCount, 0);
+    assert.equal(header.stringsBytesLen, 0);
+    assert.equal(header.blobsCount, 0);
+  });
+});
+
+test("DrawlistBuilder fuzz: invalid public inputs produce structured errors without throwing", async () => {
+  await runFuzz({ label: "drawlist-invalid-inputs", seed: 0xbad_d117, iterations: 160 }, (ctx) => {
+    const b = createDrawlistBuilder();
+    const invalidNumber = pick(ctx.rng, [
+      Number.NaN,
+      Number.POSITIVE_INFINITY,
+      Number.NEGATIVE_INFINITY,
+      INT32_MAX + 1,
+      INT32_MIN - 1,
+      1.25,
+    ]);
+    const op = pick(ctx.rng, [
+      "fillRectNegativeSize",
+      "drawTextBadX",
+      "drawTextBadText",
+      "clipBadWidth",
+      "cursorBadShape",
+      "blobBadInput",
+      "textRunBadBlob",
+      "canvasBadBlob",
+    ] as const);
+
+    assert.doesNotThrow(() => {
+      switch (op) {
+        case "fillRectNegativeSize":
+          b.fillRect(0, 0, -1, randomInt(ctx.rng, 0, 10));
+          break;
+        case "drawTextBadX":
+          b.drawText(invalidNumber, 0, "x");
+          break;
+        case "drawTextBadText":
+          b.drawText(0, 0, 42 as unknown as string);
+          break;
+        case "clipBadWidth":
+          b.pushClip(0, 0, invalidNumber, 1);
+          break;
+        case "cursorBadShape":
+          b.setCursor({ x: 0, y: 0, shape: 99 as 0, visible: true, blink: false });
+          break;
+        case "blobBadInput":
+          b.addBlob("not bytes" as unknown as Uint8Array);
+          break;
+        case "textRunBadBlob":
+          b.drawTextRun(0, 0, 0);
+          break;
+        case "canvasBadBlob":
+          b.drawCanvas(0, 0, 1, 1, 0, "braille");
+          break;
+      }
+    });
+
+    expectError(b.build(), ["ZRDL_BAD_PARAMS"]);
+    b.reset();
+    const bytes = expectOk(b.build());
+    const header = readHeader(bytes);
+    assert.equal(header.magic, ZRDL_MAGIC);
+    assert.equal(header.cmdCount, 0);
+  });
+});

--- a/packages/core/src/keybindings/__tests__/parser.fuzz.test.ts
+++ b/packages/core/src/keybindings/__tests__/parser.fuzz.test.ts
@@ -1,0 +1,129 @@
+import { assert, test } from "@rezi-ui/testkit";
+import { type Rng, chance, pick, randomAsciiString, randomInt, runFuzz } from "@rezi-ui/testkit";
+import { keyToString, keysEqual, parseKeySequence, sequenceToString } from "../parser.js";
+import type { ParsedKey } from "../types.js";
+
+const KEY_NAMES = [
+  "a",
+  "z",
+  "A",
+  "Z",
+  "0",
+  "9",
+  "escape",
+  "enter",
+  "tab",
+  "space",
+  "backspace",
+  "delete",
+  "home",
+  "end",
+  "pageup",
+  "pagedown",
+  "up",
+  "down",
+  "left",
+  "right",
+  "f1",
+  "f12",
+] as const;
+
+const MODIFIER_SETS = [
+  [] as const,
+  ["ctrl"] as const,
+  ["alt"] as const,
+  ["shift"] as const,
+  ["meta"] as const,
+  ["ctrl", "shift"] as const,
+  ["ctrl", "alt"] as const,
+  ["alt", "shift"] as const,
+  ["ctrl", "alt", "shift"] as const,
+  ["ctrl", "alt", "shift", "meta"] as const,
+] as const;
+
+function buildKeyPart(rng: Rng): string {
+  const mods = pick(rng, MODIFIER_SETS);
+  const key = pick(rng, KEY_NAMES);
+  const parts: string[] = chance(rng, 25) ? [...mods].reverse() : [...mods];
+  parts.push(key);
+  return parts.join("+");
+}
+
+function assertSameSequence(a: readonly ParsedKey[], b: readonly ParsedKey[]): void {
+  assert.equal(a.length, b.length);
+  for (let i = 0; i < a.length; i++) {
+    const left = a[i];
+    const right = b[i];
+    assert.ok(left);
+    assert.ok(right);
+    if (!left || !right) continue;
+    assert.equal(keysEqual(left, right), true);
+  }
+}
+
+test("keybinding parser fuzz: valid public syntax round-trips through canonical strings", async () => {
+  await runFuzz(
+    { label: "keybinding-valid-roundtrip", seed: 0x6b3d_0001, iterations: 260 },
+    (ctx) => {
+      const chordLength = randomInt(ctx.rng, 1, 8);
+      const input = Array.from({ length: chordLength }, () => buildKeyPart(ctx.rng)).join(
+        chance(ctx.rng, 35) ? "   " : " ",
+      );
+
+      const parsed = parseKeySequence(chance(ctx.rng, 25) ? `  ${input}  ` : input);
+      assert.equal(parsed.ok, true, input);
+      if (!parsed.ok) return;
+
+      const canonical = sequenceToString(parsed.value);
+      const reparsed = parseKeySequence(canonical);
+      assert.equal(reparsed.ok, true, canonical);
+      if (!reparsed.ok) return;
+
+      assertSameSequence(parsed.value.keys, reparsed.value.keys);
+
+      for (const key of parsed.value.keys) {
+        const keyString = keyToString(key);
+        const single = parseKeySequence(keyString);
+        assert.equal(single.ok, true, keyString);
+        if (!single.ok) continue;
+        assert.equal(single.value.keys.length, 1);
+        const singleKey = single.value.keys[0];
+        assert.ok(singleKey);
+        if (singleKey) assert.equal(keysEqual(key, singleKey), true);
+      }
+    },
+  );
+});
+
+test("keybinding parser fuzz: malformed syntax is rejected with structured errors", async () => {
+  await runFuzz(
+    { label: "keybinding-invalid-structured", seed: 0x6b3d_0002, iterations: 200 },
+    (ctx) => {
+      const invalid = pick(ctx.rng, [
+        "",
+        "   ",
+        "ctrl",
+        "alt+",
+        "+a",
+        "ctrl+ctrl+a",
+        "a+ctrl",
+        "unknownKey",
+        "ctrl+unknownKey",
+        "g g g g g g g g g",
+        randomAsciiString(ctx.rng, { minLength: 2, maxLength: 12, alphabet: "+ " }),
+        `${randomAsciiString(ctx.rng, { minLength: 1, maxLength: 6, alphabet: "!@#$%^&*" })}+a`,
+      ]);
+
+      assert.doesNotThrow(() => parseKeySequence(invalid));
+      const parsed = parseKeySequence(invalid);
+      assert.equal(parsed.ok, false, invalid);
+      if (parsed.ok) return;
+      assert.ok(
+        ["EMPTY_SEQUENCE", "INVALID_KEY", "INVALID_MODIFIER"].includes(parsed.error.code),
+        parsed.error.detail,
+      );
+      assert.equal(typeof parsed.error.detail, "string");
+      assert.ok(parsed.error.detail.length > 0);
+    },
+  );
+});

--- a/packages/core/src/layout/__tests__/textMeasure.fuzz.test.ts
+++ b/packages/core/src/layout/__tests__/textMeasure.fuzz.test.ts
@@ -1,0 +1,106 @@
+import { assert, type Rng, chance, pick, randomInt, runFuzz, test } from "@rezi-ui/testkit";
+import {
+  clearTextMeasureCache,
+  getTextMeasureCacheSize,
+  measureTextCells,
+  setTextMeasureEmojiPolicy,
+  truncateMiddle,
+  truncateStart,
+  truncateWithEllipsis,
+} from "../textMeasure.js";
+
+const ASCII = "abcdefghijklmnopqrstuvwxyz0123456789 /_-";
+const COMBINING = [0x0301, 0x0308, 0x20e3] as const;
+const WIDE = [0x4e2d, 0x754c, 0xac00, 0x3000] as const;
+const EMOJI = [0x1f600, 0x1f680, 0x1f469, 0x1f4bb] as const;
+
+function appendCodePoint(out: string[], value: number): void {
+  out.push(String.fromCodePoint(value));
+}
+
+function randomText(rng: Rng): string {
+  const clusters = randomInt(rng, 0, 48);
+  const out: string[] = [];
+
+  for (let i = 0; i < clusters; i++) {
+    const kind = randomInt(rng, 0, 9);
+    if (kind <= 3) {
+      out.push(ASCII[rng.u32() % ASCII.length] ?? "x");
+      continue;
+    }
+    if (kind === 4) {
+      appendCodePoint(out, pick(rng, COMBINING));
+      continue;
+    }
+    if (kind === 5) {
+      appendCodePoint(out, pick(rng, WIDE));
+      continue;
+    }
+    if (kind === 6) {
+      appendCodePoint(out, pick(rng, EMOJI));
+      if (chance(rng, 45)) appendCodePoint(out, 0xfe0f);
+      continue;
+    }
+    if (kind === 7) {
+      appendCodePoint(out, 0x200d);
+      appendCodePoint(out, pick(rng, EMOJI));
+      continue;
+    }
+    if (kind === 8) {
+      out.push(String.fromCharCode(randomInt(rng, 0xd800, 0xdbff)));
+      continue;
+    }
+    out.push(String.fromCharCode(randomInt(rng, 0xdc00, 0xdfff)));
+  }
+
+  return out.join("");
+}
+
+function assertWidth(width: number, text: string): void {
+  assert.equal(Number.isInteger(width), true);
+  assert.equal(width >= 0, true);
+  assert.equal(width <= Math.max(2, text.length * 2), true);
+}
+
+function assertTruncationFits(text: string, maxWidth: number, actual: string): void {
+  assertWidth(measureTextCells(actual), actual);
+  if (maxWidth <= 0) {
+    assert.equal(actual, "");
+    return;
+  }
+  assert.equal(measureTextCells(actual) <= maxWidth, true);
+}
+
+test("text measurement fuzz: malformed unicode and truncation stay deterministic", async () => {
+  await runFuzz(
+    {
+      seed: 0x7e57_0001,
+      iterations: 4096,
+      label: "text measurement",
+    },
+    (ctx) => {
+      const text = randomText(ctx.rng);
+      const maxWidth = randomInt(ctx.rng, 0, 32);
+      ctx.note(`len=${String(text.length)} maxWidth=${String(maxWidth)}`);
+
+      setTextMeasureEmojiPolicy("wide");
+      const wideA = measureTextCells(text);
+      const wideB = measureTextCells(text);
+      assert.equal(wideA, wideB);
+      assertWidth(wideA, text);
+
+      setTextMeasureEmojiPolicy("narrow");
+      const narrow = measureTextCells(text);
+      assertWidth(narrow, text);
+      assert.equal(narrow <= wideA, true);
+
+      assertTruncationFits(text, maxWidth, truncateWithEllipsis(text, maxWidth));
+      assertTruncationFits(text, maxWidth, truncateStart(text, maxWidth));
+      assertTruncationFits(text, maxWidth, truncateMiddle(text, maxWidth));
+
+      assert.equal(getTextMeasureCacheSize() <= 10000, true);
+      clearTextMeasureCache();
+      setTextMeasureEmojiPolicy("wide");
+    },
+  );
+});

--- a/packages/core/src/protocol/__tests__/zrev_v1_fuzz_lite.test.ts
+++ b/packages/core/src/protocol/__tests__/zrev_v1_fuzz_lite.test.ts
@@ -1,10 +1,10 @@
-import { assert, createRng, test } from "@rezi-ui/testkit";
+import { assert, randomInt, runFuzz, test } from "@rezi-ui/testkit";
 import { parseEventBatchV1 } from "../zrev_v1.js";
 
-test("parseEventBatchV1 fuzz-lite (seeded, bounded): never throws", () => {
-  const rng = createRng(0x5a52_4556); // 'ZREV'
+test("parseEventBatchV1 fuzz-lite (seeded, bounded): never throws", async () => {
   const maxLen = 4096;
-  const iters = 10_000;
+  const exhaustiveShortLengths = 65;
+  const randomIters = 10_000;
 
   function check(bytes: Uint8Array): void {
     let res: ReturnType<typeof parseEventBatchV1>;
@@ -26,12 +26,17 @@ test("parseEventBatchV1 fuzz-lite (seeded, bounded): never throws", () => {
     }
   }
 
-  for (let len = 0; len <= 64; len++) {
-    check(rng.bytes(len));
-  }
-
-  for (let i = 0; i < iters; i++) {
-    const len = rng.u32() % (maxLen + 1);
-    check(rng.bytes(len));
-  }
+  await runFuzz(
+    {
+      seed: 0x5a52_4556, // 'ZREV'
+      iterations: exhaustiveShortLengths + randomIters,
+      label: "parseEventBatchV1",
+    },
+    (ctx) => {
+      const len =
+        ctx.iteration < exhaustiveShortLengths ? ctx.iteration : randomInt(ctx.rng, 0, maxLen);
+      ctx.note(`len=${String(len)}`);
+      check(ctx.rng.bytes(len));
+    },
+  );
 });

--- a/packages/core/src/runtime/router/__tests__/eventRouting.fuzz.test.ts
+++ b/packages/core/src/runtime/router/__tests__/eventRouting.fuzz.test.ts
@@ -1,0 +1,514 @@
+import { assert, type Rng, pick, randomInt, runFuzz, test } from "@rezi-ui/testkit";
+import type { ZrevEvent, ZrevKeyAction, ZrevMouseKind } from "../../../events.js";
+import { hitTestFocusable } from "../../../layout/hitTest.js";
+import type { LayoutTree } from "../../../layout/layout.js";
+import type { Rect } from "../../../layout/types.js";
+import type { VNode } from "../../../widgets/types.js";
+import { routeKey } from "../key.js";
+import { routeMouse } from "../mouse.js";
+import type { EnabledById, RoutingResult } from "../types.js";
+import { type WheelRoutingCtx, type WheelRoutingResult, routeWheel } from "../wheel.js";
+
+const KEY_ENTER = 2;
+const KEY_TAB = 3;
+const KEY_SPACE = 32;
+const MOD_SHIFT = 1 << 0;
+
+const MOUSE_MOVE = 1;
+const MOUSE_DRAG = 2;
+const MOUSE_DOWN = 3;
+const MOUSE_UP = 4;
+const MOUSE_WHEEL = 5;
+
+const SCROLL_LINES = 3;
+
+function idAt(ids: readonly string[], index: number): string {
+  const id = ids[index];
+  if (id === undefined) throw new Error(`missing id at index ${String(index)}`);
+  return id;
+}
+
+function randomIds(rng: Rng, max: number): readonly string[] {
+  const count = randomInt(rng, 0, max);
+  return Object.freeze(Array.from({ length: count }, (_, index) => `id.${String(index)}`));
+}
+
+function randomKnownId(rng: Rng, ids: readonly string[]): string | null {
+  if (ids.length === 0) return null;
+  return idAt(ids, randomInt(rng, 0, ids.length - 1));
+}
+
+function randomKnownUnknownOrNull(rng: Rng, ids: readonly string[]): string | null {
+  const choice = randomInt(rng, 0, 9);
+  if (choice <= 1) return null;
+  if (choice <= 6) return randomKnownId(rng, ids);
+  return `missing.${String(randomInt(rng, 0, 7))}`;
+}
+
+function randomEnabledById(rng: Rng, ids: readonly string[]): ReadonlyMap<string, boolean> {
+  const entries: Array<readonly [string, boolean]> = [];
+  for (const id of ids) entries.push([id, (rng.u32() & 1) === 0]);
+  return new Map(entries);
+}
+
+function randomPressableIds(rng: Rng, ids: readonly string[]): ReadonlySet<string> | undefined {
+  if ((rng.u32() & 1) === 0) return undefined;
+  const pressable = new Set<string>();
+  for (const id of ids) {
+    if ((rng.u32() & 1) === 0) pressable.add(id);
+  }
+  return pressable;
+}
+
+function isEnabled(enabledById: EnabledById, id: string): boolean {
+  return enabledById.get(id) === true;
+}
+
+function isPressable(pressableIds: ReadonlySet<string> | undefined, id: string): boolean {
+  return pressableIds === undefined || pressableIds.has(id);
+}
+
+function keyEvent(key: number, action: ZrevKeyAction, mods = 0): ZrevEvent {
+  return { kind: "key", timeMs: 0, key, mods, action };
+}
+
+function mouseEvent(
+  mouseKind: ZrevMouseKind,
+  opts: Readonly<{ x?: number; y?: number; wheelX?: number; wheelY?: number }> = {},
+): ZrevEvent {
+  return {
+    kind: "mouse",
+    timeMs: 0,
+    x: opts.x ?? 0,
+    y: opts.y ?? 0,
+    mouseKind,
+    mods: 0,
+    buttons: 0,
+    wheelX: opts.wheelX ?? 0,
+    wheelY: opts.wheelY ?? 0,
+  };
+}
+
+function randomNonRoutingEvent(rng: Rng): ZrevEvent {
+  const kind = pick(rng, ["text", "paste", "resize", "tick", "user"] as const);
+  if (kind === "text") {
+    return { kind, timeMs: 0, codepoint: randomInt(rng, 0, 0x10ffff) };
+  }
+  if (kind === "paste") {
+    return { kind, timeMs: 0, bytes: rng.bytes(randomInt(rng, 0, 8)) };
+  }
+  if (kind === "resize") {
+    return { kind, timeMs: 0, cols: randomInt(rng, 0, 120), rows: randomInt(rng, 0, 40) };
+  }
+  if (kind === "tick") {
+    return { kind, timeMs: 0, dtMs: randomInt(rng, 0, 1000) };
+  }
+  return { kind, timeMs: 0, tag: rng.u32(), payload: rng.bytes(randomInt(rng, 0, 8)) };
+}
+
+function randomKeyRoutingEvent(rng: Rng): ZrevEvent {
+  const choice = randomInt(rng, 0, 9);
+  if (choice <= 1) return keyEvent(KEY_TAB, "down", choice === 0 ? 0 : MOD_SHIFT);
+  if (choice <= 3) return keyEvent(pick(rng, [KEY_ENTER, KEY_SPACE] as const), "down");
+  if (choice <= 5) {
+    return keyEvent(
+      pick(rng, [KEY_TAB, KEY_ENTER, KEY_SPACE] as const),
+      pick(rng, ["up", "repeat"] as const),
+    );
+  }
+  if (choice <= 7) return keyEvent(randomInt(rng, -64, 256), "down", rng.u32());
+  return randomNonRoutingEvent(rng);
+}
+
+function expectedTabFocus(
+  focusList: readonly string[],
+  focusedId: string | null,
+  backwards: boolean,
+): string | null {
+  if (focusList.length === 0) return null;
+  if (focusedId === null) {
+    return backwards ? idAt(focusList, focusList.length - 1) : idAt(focusList, 0);
+  }
+
+  const index = focusList.indexOf(focusedId);
+  if (index < 0) {
+    return backwards ? idAt(focusList, focusList.length - 1) : idAt(focusList, 0);
+  }
+
+  const nextIndex = backwards
+    ? (index - 1 + focusList.length) % focusList.length
+    : (index + 1) % focusList.length;
+  return idAt(focusList, nextIndex);
+}
+
+function expectedKeyRoute(
+  event: ZrevEvent,
+  focusedId: string | null,
+  focusList: readonly string[],
+  enabledById: EnabledById,
+  pressableIds: ReadonlySet<string> | undefined,
+): RoutingResult {
+  if (event.kind !== "key" || event.action !== "down") return {};
+
+  if (event.key === KEY_TAB) {
+    return {
+      nextFocusedId: expectedTabFocus(focusList, focusedId, (event.mods & MOD_SHIFT) !== 0),
+    };
+  }
+
+  if (
+    (event.key === KEY_ENTER || event.key === KEY_SPACE) &&
+    focusedId !== null &&
+    isEnabled(enabledById, focusedId) &&
+    isPressable(pressableIds, focusedId)
+  ) {
+    return { action: { id: focusedId, action: "press" } };
+  }
+
+  return {};
+}
+
+function randomMouseRoutingEvent(rng: Rng): ZrevEvent {
+  const choice = randomInt(rng, 0, 9);
+  if (choice <= 6) {
+    const mouseKind = pick(rng, [
+      MOUSE_MOVE,
+      MOUSE_DRAG,
+      MOUSE_DOWN,
+      MOUSE_UP,
+      MOUSE_WHEEL,
+    ] as const);
+    return mouseEvent(mouseKind, {
+      x: randomInt(rng, -4, 24),
+      y: randomInt(rng, -2, 8),
+      wheelX: randomInt(rng, -4, 4),
+      wheelY: randomInt(rng, -4, 4),
+    });
+  }
+  if (choice === 7)
+    return keyEvent(randomInt(rng, -64, 256), pick(rng, ["down", "up", "repeat"] as const));
+  return randomNonRoutingEvent(rng);
+}
+
+function expectedMouseRoute(
+  event: ZrevEvent,
+  pressedId: string | null,
+  hitTestTargetId: string | null,
+  enabledById: EnabledById,
+  pressableIds: ReadonlySet<string> | undefined,
+): RoutingResult {
+  if (event.kind !== "mouse") return {};
+
+  if (event.mouseKind === MOUSE_DOWN) {
+    if (hitTestTargetId !== null && isEnabled(enabledById, hitTestTargetId)) {
+      return {
+        nextFocusedId: hitTestTargetId,
+        nextPressedId: isPressable(pressableIds, hitTestTargetId) ? hitTestTargetId : null,
+      };
+    }
+    return { nextPressedId: null };
+  }
+
+  if (event.mouseKind === MOUSE_UP) {
+    if (
+      pressedId !== null &&
+      hitTestTargetId === pressedId &&
+      isEnabled(enabledById, pressedId) &&
+      isPressable(pressableIds, pressedId)
+    ) {
+      return { nextPressedId: null, action: { id: pressedId, action: "press" } };
+    }
+    return { nextPressedId: null };
+  }
+
+  return {};
+}
+
+function clamp(value: number, min: number, max: number): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function randomWheelCtx(rng: Rng): WheelRoutingCtx {
+  const viewportWidth = randomInt(rng, 0, 40);
+  const viewportHeight = randomInt(rng, 0, 20);
+  const contentWidth = viewportWidth + randomInt(rng, 0, 80);
+  const contentHeight = viewportHeight + randomInt(rng, 0, 60);
+  const maxScrollX = Math.max(0, contentWidth - viewportWidth);
+  const maxScrollY = Math.max(0, contentHeight - viewportHeight);
+  return {
+    scrollX: randomInt(rng, 0, maxScrollX),
+    scrollY: randomInt(rng, 0, maxScrollY),
+    contentWidth,
+    contentHeight,
+    viewportWidth,
+    viewportHeight,
+  };
+}
+
+function expectedWheelRoute(event: ZrevEvent, ctx: WheelRoutingCtx): WheelRoutingResult {
+  if (event.kind !== "mouse" || event.mouseKind !== MOUSE_WHEEL) return {};
+
+  const maxScrollX = Math.max(0, ctx.contentWidth - ctx.viewportWidth);
+  const maxScrollY = Math.max(0, ctx.contentHeight - ctx.viewportHeight);
+  const nextScrollX = clamp(ctx.scrollX + event.wheelX * SCROLL_LINES, 0, maxScrollX);
+  const nextScrollY = clamp(ctx.scrollY + event.wheelY * SCROLL_LINES, 0, maxScrollY);
+
+  if (nextScrollX === ctx.scrollX && nextScrollY === ctx.scrollY) return {};
+  return { nextScrollX, nextScrollY };
+}
+
+type HitLeaf = Readonly<{
+  id: string;
+  vnode: VNode;
+  rect: Rect;
+  enabled: boolean;
+  pressable: boolean;
+  focusable: boolean;
+}>;
+
+function buttonNode(id: string, disabled: boolean, hidden: boolean): VNode {
+  return {
+    kind: "button",
+    props: { id, label: id, disabled, ...(hidden ? { display: false } : {}) },
+  } as unknown as VNode;
+}
+
+function inputNode(id: string): VNode {
+  return { kind: "input", props: { id, value: "" } } as unknown as VNode;
+}
+
+function textNode(id: string): VNode {
+  return { kind: "text", text: id, props: { id } } as unknown as VNode;
+}
+
+function rootNode(children: readonly VNode[]): VNode {
+  return { kind: "row", props: {}, children: Object.freeze([...children]) } as unknown as VNode;
+}
+
+function layoutNode(vnode: VNode, rect: Rect, children: readonly LayoutTree[] = []): LayoutTree {
+  return { vnode, rect, children: Object.freeze([...children]) };
+}
+
+function randomHitTree(
+  rng: Rng,
+): Readonly<{ root: VNode; layout: LayoutTree; leaves: readonly HitLeaf[] }> {
+  const leafCount = randomInt(rng, 1, 7);
+  const leaves: HitLeaf[] = [];
+  const layoutChildren: LayoutTree[] = [];
+  let x = 0;
+
+  for (let i = 0; i < leafCount; i++) {
+    const id = `hit.${String(i)}`;
+    const kind = pick(rng, ["button", "disabledButton", "hiddenButton", "input", "text"] as const);
+    const width = kind === "hiddenButton" ? 0 : randomInt(rng, 1, 5);
+    const rect: Rect = { x, y: 0, w: width, h: width === 0 ? 0 : 1 };
+
+    const leaf =
+      kind === "input"
+        ? { id, vnode: inputNode(id), rect, enabled: true, pressable: false, focusable: true }
+        : kind === "text"
+          ? { id, vnode: textNode(id), rect, enabled: false, pressable: false, focusable: false }
+          : kind === "disabledButton"
+            ? {
+                id,
+                vnode: buttonNode(id, true, false),
+                rect,
+                enabled: false,
+                pressable: false,
+                focusable: false,
+              }
+            : kind === "hiddenButton"
+              ? {
+                  id,
+                  vnode: buttonNode(id, false, true),
+                  rect,
+                  enabled: false,
+                  pressable: false,
+                  focusable: false,
+                }
+              : {
+                  id,
+                  vnode: buttonNode(id, false, false),
+                  rect,
+                  enabled: true,
+                  pressable: true,
+                  focusable: true,
+                };
+
+    leaves.push(leaf);
+    layoutChildren.push(layoutNode(leaf.vnode, rect));
+    x += Math.max(1, width);
+  }
+
+  const root = rootNode(leaves.map((leaf) => leaf.vnode));
+  return {
+    root,
+    layout: layoutNode(root, { x: 0, y: 0, w: Math.max(1, x), h: 1 }, layoutChildren),
+    leaves: Object.freeze(leaves),
+  };
+}
+
+function contains(rect: Rect, x: number, y: number): boolean {
+  return x >= rect.x && x < rect.x + rect.w && y >= rect.y && y < rect.y + rect.h;
+}
+
+function expectedHitTarget(leaves: readonly HitLeaf[], x: number, y: number): string | null {
+  for (const leaf of leaves) {
+    if (leaf.focusable && leaf.enabled && contains(leaf.rect, x, y)) return leaf.id;
+  }
+  return null;
+}
+
+test("routeKey fuzz: bounded streams only tab-focus or press the enabled focused id", async () => {
+  await runFuzz({ seed: 0x4655_5a4b, iterations: 512, label: "router-key" }, (ctx) => {
+    const focusList = randomIds(ctx.rng, 6);
+    const enabledById = randomEnabledById(ctx.rng, focusList);
+    const pressableIds = randomPressableIds(ctx.rng, focusList);
+    let focusedId = randomKnownUnknownOrNull(ctx.rng, focusList);
+    const steps = randomInt(ctx.rng, 1, 32);
+    ctx.note(`focusable=${String(focusList.length)} steps=${String(steps)}`);
+
+    for (let step = 0; step < steps; step++) {
+      const event = randomKeyRoutingEvent(ctx.rng);
+      const expected = expectedKeyRoute(event, focusedId, focusList, enabledById, pressableIds);
+      const actual = routeKey(event, {
+        focusedId,
+        focusList,
+        enabledById,
+        ...(pressableIds ? { pressableIds } : {}),
+      });
+
+      assert.deepEqual(actual, expected);
+
+      if (actual.action) {
+        assert.equal(actual.action.id, focusedId);
+        assert.equal(isEnabled(enabledById, actual.action.id), true);
+        assert.equal(isPressable(pressableIds, actual.action.id), true);
+      }
+
+      if (actual.nextFocusedId !== undefined) focusedId = actual.nextFocusedId;
+    }
+  });
+});
+
+test("routeMouse fuzz: bounded streams cannot activate disabled, unknown, or non-pressable targets", async () => {
+  await runFuzz({ seed: 0x4655_5a4d, iterations: 512, label: "router-mouse" }, (ctx) => {
+    const ids = randomIds(ctx.rng, 7);
+    const enabledById = randomEnabledById(ctx.rng, ids);
+    const pressableIds = randomPressableIds(ctx.rng, ids);
+    let pressedId = randomKnownUnknownOrNull(ctx.rng, ids);
+    const steps = randomInt(ctx.rng, 1, 40);
+    ctx.note(`targets=${String(ids.length)} steps=${String(steps)}`);
+
+    for (let step = 0; step < steps; step++) {
+      const event = randomMouseRoutingEvent(ctx.rng);
+      const hitTestTargetId = randomKnownUnknownOrNull(ctx.rng, ids);
+      const expected = expectedMouseRoute(
+        event,
+        pressedId,
+        hitTestTargetId,
+        enabledById,
+        pressableIds,
+      );
+      const actual = routeMouse(event, {
+        pressedId,
+        hitTestTargetId,
+        enabledById,
+        ...(pressableIds ? { pressableIds } : {}),
+      });
+
+      assert.deepEqual(actual, expected);
+
+      if (actual.action) {
+        assert.equal(event.kind, "mouse");
+        assert.equal(event.kind === "mouse" ? event.mouseKind : null, MOUSE_UP);
+        assert.equal(actual.action.id, pressedId);
+        assert.equal(actual.action.id, hitTestTargetId);
+        assert.equal(isEnabled(enabledById, actual.action.id), true);
+        assert.equal(isPressable(pressableIds, actual.action.id), true);
+      }
+
+      if (actual.nextPressedId !== undefined) pressedId = actual.nextPressedId;
+    }
+  });
+});
+
+test("hit-tested mouse fuzz: hidden, disabled, and non-focusable cells do not route actions", async () => {
+  await runFuzz({ seed: 0x4655_4854, iterations: 384, label: "router-hit-test" }, (ctx) => {
+    const tree = randomHitTree(ctx.rng);
+    const enabledById = new Map<string, boolean>();
+    const pressableIds = new Set<string>();
+    for (const leaf of tree.leaves) {
+      if (leaf.enabled) enabledById.set(leaf.id, true);
+      if (leaf.pressable) pressableIds.add(leaf.id);
+    }
+
+    const x = randomInt(ctx.rng, -2, tree.layout.rect.w + 2);
+    const y = randomInt(ctx.rng, -1, 2);
+    const expectedTarget = expectedHitTarget(tree.leaves, x, y);
+    ctx.note(`leaves=${String(tree.leaves.length)} x=${String(x)} y=${String(y)}`);
+
+    const hitTestTargetId = hitTestFocusable(tree.root, tree.layout, x, y);
+    assert.equal(hitTestTargetId, expectedTarget);
+
+    const down = routeMouse(mouseEvent(MOUSE_DOWN, { x, y }), {
+      pressedId: null,
+      hitTestTargetId,
+      enabledById,
+      pressableIds,
+    });
+    const up = routeMouse(mouseEvent(MOUSE_UP, { x, y }), {
+      pressedId: down.nextPressedId ?? null,
+      hitTestTargetId,
+      enabledById,
+      pressableIds,
+    });
+
+    if (expectedTarget === null || !pressableIds.has(expectedTarget)) {
+      assert.equal(up.action, undefined);
+      return;
+    }
+
+    assert.deepEqual(up.action, { id: expectedTarget, action: "press" });
+  });
+});
+
+test("routeWheel fuzz: wheel deltas stay clamped and unsupported events are no-ops", async () => {
+  await runFuzz({ seed: 0x4655_5a57, iterations: 768, label: "router-wheel" }, (ctx) => {
+    const routingCtx = randomWheelCtx(ctx.rng);
+    const event =
+      randomInt(ctx.rng, 0, 3) === 0
+        ? randomNonRoutingEvent(ctx.rng)
+        : mouseEvent(
+            pick(ctx.rng, [MOUSE_MOVE, MOUSE_DRAG, MOUSE_DOWN, MOUSE_UP, MOUSE_WHEEL] as const),
+            {
+              x: randomInt(ctx.rng, -4, 40),
+              y: randomInt(ctx.rng, -4, 20),
+              wheelX: randomInt(ctx.rng, -6, 6),
+              wheelY: randomInt(ctx.rng, -6, 6),
+            },
+          );
+    ctx.note(
+      `viewport=${String(routingCtx.viewportWidth)}x${String(routingCtx.viewportHeight)} content=${String(
+        routingCtx.contentWidth,
+      )}x${String(routingCtx.contentHeight)}`,
+    );
+
+    const actual = routeWheel(event, routingCtx);
+    const expected = expectedWheelRoute(event, routingCtx);
+    assert.deepEqual(actual, expected);
+
+    if (actual.nextScrollX !== undefined) {
+      assert.ok(actual.nextScrollX >= 0);
+      assert.ok(
+        actual.nextScrollX <= Math.max(0, routingCtx.contentWidth - routingCtx.viewportWidth),
+      );
+    }
+    if (actual.nextScrollY !== undefined) {
+      assert.ok(actual.nextScrollY >= 0);
+      assert.ok(
+        actual.nextScrollY <= Math.max(0, routingCtx.contentHeight - routingCtx.viewportHeight),
+      );
+    }
+  });
+});

--- a/packages/core/src/testing/__tests__/layoutRendering.fuzz.test.ts
+++ b/packages/core/src/testing/__tests__/layoutRendering.fuzz.test.ts
@@ -1,0 +1,527 @@
+import {
+  assert,
+  type Rng,
+  chance,
+  fuzzTest,
+  pick,
+  randomAsciiString,
+  randomInt,
+} from "@rezi-ui/testkit";
+import {
+  type BoxProps,
+  type DividerProps,
+  type SpacerProps,
+  type SpacingValue,
+  type TestRenderResult,
+  type TestViewport,
+  type TextProps,
+  type VNode,
+  createTestRenderer,
+  ui,
+} from "../../index.js";
+import type { SizeConstraint } from "../../layout/types.js";
+import type { ColumnProps, GridProps, RowProps } from "../../widgets/types.js";
+
+type IdState = { next: number };
+type MutableProps = Record<string, unknown>;
+type RenderSignature = Readonly<{
+  text: string;
+  nodes: readonly Readonly<{
+    kind: VNode["kind"];
+    id: string | null;
+    text: string | null;
+    rect: Readonly<{ x: number; y: number; w: number; h: number }>;
+  }>[];
+}>;
+
+const SPACING_VALUES = [
+  0,
+  1,
+  2,
+  3,
+  4,
+  6,
+  "none",
+  "xs",
+  "sm",
+  "md",
+  "lg",
+  "xl",
+  "2xl",
+] as const satisfies readonly SpacingValue[];
+
+const OVERFLOW_VALUES = ["visible", "hidden", "scroll"] as const;
+const BORDER_VALUES = ["none", "single", "rounded", "double"] as const;
+const TEXT_OVERFLOW_VALUES = ["clip", "ellipsis", "middle", "start"] as const;
+
+function setProp(props: MutableProps, key: string, value: unknown): void {
+  props[key] = value;
+}
+
+function getProp(props: Record<string, unknown>, key: string): unknown {
+  return props[key];
+}
+
+function nextId(ids: IdState, prefix: string): string {
+  const id = `${prefix}-${String(ids.next)}`;
+  ids.next += 1;
+  return id;
+}
+
+function randomViewport(rng: Rng): TestViewport {
+  return Object.freeze({
+    cols: randomInt(rng, 4, 80),
+    rows: randomInt(rng, 2, 24),
+  });
+}
+
+function randomSmallViewport(rng: Rng): TestViewport {
+  return Object.freeze({
+    cols: randomInt(rng, 1, 24),
+    rows: randomInt(rng, 1, 10),
+  });
+}
+
+function randomSpacing(rng: Rng): SpacingValue {
+  return pick(rng, SPACING_VALUES);
+}
+
+function randomSizeConstraint(rng: Rng, viewportSize: number): SizeConstraint {
+  const max = Math.max(0, viewportSize);
+  switch (randomInt(rng, 0, 5)) {
+    case 0:
+      return 0;
+    case 1:
+      return "auto";
+    case 2:
+      return "full";
+    case 3:
+      return randomInt(rng, 1, Math.max(1, max));
+    case 4:
+      return randomInt(rng, max + 1, max + 16);
+    default:
+      return randomInt(rng, 0, 6);
+  }
+}
+
+function randomEdgeSizeConstraint(rng: Rng, viewportSize: number): SizeConstraint {
+  const max = Math.max(0, viewportSize);
+  switch (randomInt(rng, 0, 6)) {
+    case 0:
+      return 0;
+    case 1:
+      return 1;
+    case 2:
+      return "auto";
+    case 3:
+      return "full";
+    case 4:
+      return max;
+    case 5:
+      return max + randomInt(rng, 1, 32);
+    default:
+      return randomInt(rng, 0, 3);
+  }
+}
+
+function maybeAddMinMax(
+  props: MutableProps,
+  rng: Rng,
+  minName: "minWidth" | "minHeight",
+  maxName: "maxWidth" | "maxHeight",
+  viewportSize: number,
+): void {
+  if (!chance(rng, 20)) return;
+  const min = randomInt(rng, 0, Math.max(0, Math.min(viewportSize + 4, 20)));
+  const max = randomInt(rng, min, min + randomInt(rng, 0, 12));
+  props[minName] = min;
+  props[maxName] = max;
+}
+
+function addLayoutProps(
+  props: MutableProps,
+  rng: Rng,
+  viewport: TestViewport,
+  opts: Readonly<{ edge?: boolean }> = {},
+): void {
+  const size = opts.edge === true ? randomEdgeSizeConstraint : randomSizeConstraint;
+
+  if (chance(rng, 45)) setProp(props, "width", size(rng, viewport.cols));
+  if (chance(rng, 35)) setProp(props, "height", size(rng, viewport.rows));
+  maybeAddMinMax(props, rng, "minWidth", "maxWidth", viewport.cols);
+  maybeAddMinMax(props, rng, "minHeight", "maxHeight", viewport.rows);
+
+  if (chance(rng, 25)) setProp(props, "flex", randomInt(rng, 0, 3));
+  if (chance(rng, 20)) setProp(props, "flexShrink", randomInt(rng, 0, 3));
+  if (chance(rng, 18)) setProp(props, "flexBasis", size(rng, viewport.cols));
+  if (chance(rng, 10)) {
+    setProp(props, "aspectRatio", pick(rng, [0.5, 1, 1.5, 2, 3] as const));
+  }
+  if (chance(rng, 18)) {
+    setProp(props, "alignSelf", pick(rng, ["auto", "start", "stretch"] as const));
+  }
+  if (chance(rng, 8)) setProp(props, "display", chance(rng, 85));
+
+  if (chance(rng, 12)) setProp(props, "gridColumn", randomInt(rng, 1, 3));
+  if (chance(rng, 12)) setProp(props, "gridRow", randomInt(rng, 1, 3));
+  if (chance(rng, 10)) setProp(props, "colSpan", randomInt(rng, 1, 2));
+  if (chance(rng, 10)) setProp(props, "rowSpan", randomInt(rng, 1, 2));
+}
+
+function addSurfaceProps(props: MutableProps, rng: Rng, edge = false): void {
+  if (chance(rng, edge ? 75 : 45)) setProp(props, "p", randomSpacing(rng));
+  if (chance(rng, edge ? 45 : 20)) setProp(props, "px", randomSpacing(rng));
+  if (chance(rng, edge ? 45 : 20)) setProp(props, "py", randomSpacing(rng));
+  if (chance(rng, edge ? 30 : 12)) setProp(props, "m", randomInt(rng, 0, edge ? 6 : 3));
+  if (chance(rng, 50)) setProp(props, "gap", randomSpacing(rng));
+  if (chance(rng, 35)) setProp(props, "overflow", pick(rng, OVERFLOW_VALUES));
+  if (chance(rng, edge ? 45 : 15)) {
+    setProp(props, "scrollX", randomInt(rng, 0, edge ? 128 : 12));
+  }
+  if (chance(rng, edge ? 45 : 15)) {
+    setProp(props, "scrollY", randomInt(rng, 0, edge ? 128 : 12));
+  }
+}
+
+function randomText(rng: Rng, maxLength = 80): string {
+  return randomAsciiString(rng, {
+    minLength: 0,
+    maxLength,
+    alphabet: "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 -_:/[]{}",
+  });
+}
+
+function randomTextNode(rng: Rng, ids: IdState, viewport: TestViewport, edge = false): VNode {
+  const props: MutableProps = {};
+  if (chance(rng, 30)) setProp(props, "id", nextId(ids, "text"));
+  if (chance(rng, 70)) setProp(props, "textOverflow", pick(rng, TEXT_OVERFLOW_VALUES));
+  if (chance(rng, 55)) {
+    setProp(props, "maxWidth", randomInt(rng, 0, viewport.cols + (edge ? 80 : 20)));
+  }
+  if (chance(rng, 35)) setProp(props, "wrap", chance(rng, 50));
+  const content = randomText(rng, edge ? 180 : 90);
+  return Object.keys(props).length === 0 ? ui.text(content) : ui.text(content, props as TextProps);
+}
+
+function randomLeaf(rng: Rng, ids: IdState, viewport: TestViewport, edge = false): VNode {
+  switch (randomInt(rng, 0, 4)) {
+    case 0:
+      return randomTextNode(rng, ids, viewport, edge);
+    case 1:
+      return ui.button({
+        id: nextId(ids, "button"),
+        label: randomText(rng, edge ? 48 : 24),
+        disabled: chance(rng, 20),
+        px: randomInt(rng, 0, edge ? 8 : 3),
+        intent: pick(rng, [
+          "primary",
+          "secondary",
+          "danger",
+          "success",
+          "warning",
+          "link",
+        ] as const),
+      });
+    case 2: {
+      const props: MutableProps = { size: randomInt(rng, 0, viewport.cols + (edge ? 64 : 12)) };
+      if (chance(rng, 35)) setProp(props, "flex", randomInt(rng, 0, 3));
+      return ui.spacer(props as SpacerProps);
+    }
+    case 3: {
+      const props: MutableProps = {
+        direction: pick(rng, ["horizontal", "vertical"] as const),
+        char: pick(rng, ["-", "=", ".", "|"] as const),
+      };
+      if (chance(rng, 30)) setProp(props, "label", randomText(rng, 16));
+      return ui.divider(props as DividerProps);
+    }
+    default:
+      return ui.box({ id: nextId(ids, "empty-box"), border: "none", width: 0, height: 0 }, []);
+  }
+}
+
+function randomChildren(
+  rng: Rng,
+  ids: IdState,
+  viewport: TestViewport,
+  depth: number,
+  edge = false,
+): readonly VNode[] {
+  const count = randomInt(rng, edge ? 1 : 0, edge ? 5 : 4);
+  const children: VNode[] = [];
+  for (let i = 0; i < count; i++) {
+    children.push(randomNode(rng, ids, viewport, depth, edge));
+  }
+  return Object.freeze(children);
+}
+
+function randomBox(rng: Rng, ids: IdState, viewport: TestViewport, depth: number, edge: boolean) {
+  const props: MutableProps = {
+    id: nextId(ids, "box"),
+    border: pick(rng, BORDER_VALUES),
+  };
+  if (chance(rng, 25)) setProp(props, "title", randomText(rng, 20));
+  addSurfaceProps(props, rng, edge);
+  addLayoutProps(props, rng, viewport, { edge });
+  return ui.box(props as BoxProps, randomChildren(rng, ids, viewport, depth - 1, edge));
+}
+
+function randomStack(
+  kind: "row" | "column",
+  rng: Rng,
+  ids: IdState,
+  viewport: TestViewport,
+  depth: number,
+  edge: boolean,
+): VNode {
+  const props: MutableProps = { id: nextId(ids, kind) };
+  addSurfaceProps(props, rng, edge);
+  addLayoutProps(props, rng, viewport, { edge });
+  if (chance(rng, 20)) setProp(props, "reverse", chance(rng, 50));
+  if (chance(rng, 35)) setProp(props, "wrap", chance(rng, 60));
+  if (chance(rng, 40)) setProp(props, "align", pick(rng, ["start", "stretch"] as const));
+  if (chance(rng, 25)) setProp(props, "justify", "start");
+  if (chance(rng, 30)) setProp(props, "items", pick(rng, ["start", "stretch"] as const));
+
+  const children = randomChildren(rng, ids, viewport, depth - 1, edge);
+  return kind === "row"
+    ? ui.row(props as RowProps, children)
+    : ui.column(props as ColumnProps, children);
+}
+
+function randomGrid(
+  rng: Rng,
+  ids: IdState,
+  viewport: TestViewport,
+  depth: number,
+  edge: boolean,
+): VNode {
+  const props: MutableProps = {
+    id: nextId(ids, "grid"),
+    columns: randomInt(rng, 1, edge ? 5 : 4),
+  };
+  if (chance(rng, 55)) setProp(props, "rows", randomInt(rng, 1, edge ? 4 : 3));
+  if (chance(rng, 55)) setProp(props, "gap", randomInt(rng, 0, edge ? 5 : 3));
+  if (chance(rng, 25)) setProp(props, "columnGap", randomInt(rng, 0, edge ? 5 : 3));
+  if (chance(rng, 25)) setProp(props, "rowGap", randomInt(rng, 0, edge ? 5 : 3));
+  addLayoutProps(props, rng, viewport, { edge });
+  return ui.grid(props as GridProps, ...randomChildren(rng, ids, viewport, depth - 1, edge));
+}
+
+function randomNode(
+  rng: Rng,
+  ids: IdState,
+  viewport: TestViewport,
+  depth: number,
+  edge = false,
+): VNode {
+  if (depth <= 0) return randomLeaf(rng, ids, viewport, edge);
+
+  switch (randomInt(rng, 0, edge ? 5 : 4)) {
+    case 0:
+      return randomLeaf(rng, ids, viewport, edge);
+    case 1:
+      return randomBox(rng, ids, viewport, depth, edge);
+    case 2:
+      return randomStack("row", rng, ids, viewport, depth, edge);
+    case 3:
+      return randomStack("column", rng, ids, viewport, depth, edge);
+    default:
+      return randomGrid(rng, ids, viewport, depth, edge);
+  }
+}
+
+function randomPublicUiTree(rng: Rng, viewport: TestViewport): VNode {
+  const ids: IdState = { next: 0 };
+  return ui.column(
+    {
+      id: nextId(ids, "root"),
+      width: "full",
+      height: "full",
+      overflow: "hidden",
+      p: randomInt(rng, 0, 2),
+      gap: randomSpacing(rng),
+    },
+    randomChildren(rng, ids, viewport, 3),
+  );
+}
+
+function randomEdgeUiTree(rng: Rng, viewport: TestViewport): VNode {
+  const ids: IdState = { next: 0 };
+  return ui.box(
+    {
+      id: nextId(ids, "edge-root"),
+      width: "full",
+      height: "full",
+      border: pick(rng, BORDER_VALUES),
+      overflow: pick(rng, ["hidden", "scroll"] as const),
+      p: pick(rng, [0, 1, 4, 6, "2xl"] as const satisfies readonly SpacingValue[]),
+      gap: randomSpacing(rng),
+      scrollX: randomInt(rng, 0, 256),
+      scrollY: randomInt(rng, 0, 256),
+    },
+    randomChildren(rng, ids, viewport, 4, true),
+  );
+}
+
+function assertTextWithinViewport(result: TestRenderResult): void {
+  const text = result.toText();
+  if (text.length === 0) return;
+  const lines = text.split("\n");
+  assert.equal(
+    lines.length <= result.viewport.rows,
+    true,
+    `rendered ${String(lines.length)} lines into ${String(result.viewport.rows)} rows`,
+  );
+  for (const line of lines) {
+    assert.equal(
+      line.length <= result.viewport.cols,
+      true,
+      `rendered line width ${String(line.length)} into ${String(result.viewport.cols)} cols`,
+    );
+  }
+}
+
+function assertRectContract(result: TestRenderResult): void {
+  for (const node of result.nodes) {
+    const rect = node.rect;
+    const detail = `${node.kind}${node.id === null ? "" : `#${node.id}`} rect=${JSON.stringify(
+      rect,
+    )}`;
+    for (const [name, value] of Object.entries(rect)) {
+      assert.equal(Number.isFinite(value), true, `${detail} ${name} must be finite`);
+      assert.equal(Number.isInteger(value), true, `${detail} ${name} must be an integer`);
+    }
+    assert.equal(rect.w >= 0, true, `${detail} exposed rect.w must be non-negative`);
+    assert.equal(rect.h >= 0, true, `${detail} exposed rect.h must be non-negative`);
+  }
+}
+
+function renderSignature(result: TestRenderResult): RenderSignature {
+  return Object.freeze({
+    text: result.toText(),
+    nodes: Object.freeze(
+      result.nodes.map((node) =>
+        Object.freeze({
+          kind: node.kind,
+          id: node.id,
+          text: node.text ?? null,
+          rect: node.rect,
+        }),
+      ),
+    ),
+  });
+}
+
+function summarizeTree(vnode: VNode, maxLength = 1200): string {
+  const seen: string[] = [];
+  const walk = (node: VNode, depth: number): unknown => {
+    const props = (node as Readonly<{ props?: Record<string, unknown> }>).props ?? {};
+    const rawId = getProp(props, "id");
+    const id = typeof rawId === "string" ? rawId : undefined;
+    const summary: Record<string, unknown> = {
+      kind: node.kind,
+      ...(id === undefined ? {} : { id }),
+    };
+    for (const key of [
+      "width",
+      "height",
+      "minWidth",
+      "maxWidth",
+      "minHeight",
+      "maxHeight",
+      "flex",
+      "flexShrink",
+      "flexBasis",
+      "aspectRatio",
+      "align",
+      "alignSelf",
+      "justify",
+      "items",
+      "wrap",
+      "p",
+      "px",
+      "py",
+      "m",
+      "gap",
+      "overflow",
+      "gridColumn",
+      "gridRow",
+      "colSpan",
+      "rowSpan",
+      "columns",
+      "rows",
+    ] as const) {
+      if (props[key] !== undefined) summary[key] = props[key];
+    }
+    if (node.kind === "text") {
+      setProp(summary, "textLen", (node as Readonly<{ text?: string }>).text?.length ?? 0);
+    }
+    const children = (node as Readonly<{ children?: readonly VNode[] }>).children ?? [];
+    if (children.length > 0 && depth < 4) {
+      setProp(
+        summary,
+        "children",
+        children.map((child) => walk(child, depth + 1)),
+      );
+    } else if (children.length > 0) {
+      setProp(summary, "children", `${String(children.length)} more`);
+    }
+    return summary;
+  };
+  seen.push(JSON.stringify(walk(vnode, 0)));
+  const text = seen.join("");
+  return text.length <= maxLength ? text : `${text.slice(0, maxLength)}...`;
+}
+
+function assertRenderContract(result: TestRenderResult): void {
+  assertTextWithinViewport(result);
+  assertRectContract(result);
+}
+
+fuzzTest(
+  "layout/rendering fuzz: public ui trees render bounded deterministic frames",
+  {
+    seed: 0x1a70_f001,
+    iterations: 512,
+  },
+  (ctx) => {
+    const viewport = randomViewport(ctx.rng);
+    const tree = randomPublicUiTree(ctx.rng, viewport);
+    ctx.note(`viewport=${String(viewport.cols)}x${String(viewport.rows)}`);
+    ctx.note(`tree=${summarizeTree(tree)}`);
+
+    const renderer = createTestRenderer({ viewport });
+    const first = renderer.render(tree);
+    const second = renderer.render(tree);
+    const fresh = createTestRenderer({ viewport }).render(tree);
+
+    assertRenderContract(first);
+    assertRenderContract(second);
+    assertRenderContract(fresh);
+    assert.deepEqual(renderSignature(second), renderSignature(first));
+    assert.deepEqual(renderSignature(fresh), renderSignature(first));
+  },
+);
+
+fuzzTest(
+  "layout/rendering fuzz: edge spacing and size props stay bounded",
+  {
+    seed: 0x1a70_f002,
+    iterations: 256,
+  },
+  (ctx) => {
+    const viewport = randomSmallViewport(ctx.rng);
+    const tree = randomEdgeUiTree(ctx.rng, viewport);
+    ctx.note(`viewport=${String(viewport.cols)}x${String(viewport.rows)}`);
+    ctx.note(`tree=${summarizeTree(tree)}`);
+
+    const renderer = createTestRenderer({ viewport });
+    const first = renderer.render(tree);
+    const second = renderer.render(tree);
+
+    assertRenderContract(first);
+    assertRenderContract(second);
+    assert.deepEqual(renderSignature(second), renderSignature(first));
+  },
+);

--- a/packages/core/src/testing/__tests__/layoutRendering.fuzz.test.ts
+++ b/packages/core/src/testing/__tests__/layoutRendering.fuzz.test.ts
@@ -406,7 +406,12 @@ function renderSignature(result: TestRenderResult): RenderSignature {
           kind: node.kind,
           id: node.id,
           text: node.text ?? null,
-          rect: node.rect,
+          rect: Object.freeze({
+            x: node.rect.x,
+            y: node.rect.y,
+            w: node.rect.w,
+            h: node.rect.h,
+          }),
         }),
       ),
     ),
@@ -493,14 +498,17 @@ fuzzTest(
 
     const renderer = createTestRenderer({ viewport });
     const first = renderer.render(tree);
+    const firstSig = renderSignature(first);
     const second = renderer.render(tree);
+    const secondSig = renderSignature(second);
     const fresh = createTestRenderer({ viewport }).render(tree);
+    const freshSig = renderSignature(fresh);
 
     assertRenderContract(first);
     assertRenderContract(second);
     assertRenderContract(fresh);
-    assert.deepEqual(renderSignature(second), renderSignature(first));
-    assert.deepEqual(renderSignature(fresh), renderSignature(first));
+    assert.deepEqual(secondSig, firstSig);
+    assert.deepEqual(freshSig, firstSig);
   },
 );
 
@@ -518,10 +526,12 @@ fuzzTest(
 
     const renderer = createTestRenderer({ viewport });
     const first = renderer.render(tree);
+    const firstSig = renderSignature(first);
     const second = renderer.render(tree);
+    const secondSig = renderSignature(second);
 
     assertRenderContract(first);
     assertRenderContract(second);
-    assert.deepEqual(renderSignature(second), renderSignature(first));
+    assert.deepEqual(secondSig, firstSig);
   },
 );

--- a/packages/core/src/theme/__tests__/theme.validation.fuzz.test.ts
+++ b/packages/core/src/theme/__tests__/theme.validation.fuzz.test.ts
@@ -1,0 +1,215 @@
+import { assert, test } from "@rezi-ui/testkit";
+import {
+  type FuzzIterationContext,
+  chance,
+  pick,
+  randomAsciiString,
+  randomInt,
+  runFuzz,
+} from "@rezi-ui/testkit";
+import { darkTheme } from "../presets.js";
+import {
+  isValidColorPath,
+  resolveColorOrRgb,
+  resolveColorToken,
+  tryResolveColorToken,
+} from "../resolve.js";
+import { validateTheme } from "../validate.js";
+
+const COLOR_PATHS = [
+  "bg.base",
+  "bg.elevated",
+  "bg.overlay",
+  "bg.subtle",
+  "fg.primary",
+  "fg.secondary",
+  "fg.muted",
+  "fg.inverse",
+  "accent.primary",
+  "accent.secondary",
+  "accent.tertiary",
+  "success",
+  "warning",
+  "error",
+  "info",
+  "focus.ring",
+  "focus.bg",
+  "selected.bg",
+  "selected.fg",
+  "disabled.fg",
+  "disabled.bg",
+  "diagnostic.error",
+  "diagnostic.warning",
+  "diagnostic.info",
+  "diagnostic.hint",
+  "border.subtle",
+  "border.default",
+  "border.strong",
+  "widget.syntax.keyword",
+  "widget.diff.addBg",
+  "widget.logs.error",
+  "widget.toast.warning",
+  "widget.chart.danger",
+] as const;
+
+const MUTABLE_REQUIRED_PATHS = [
+  "name",
+  "colors.bg.base",
+  "colors.fg.primary",
+  "colors.accent.primary",
+  "colors.success",
+  "colors.focus.ring",
+  "colors.selected.bg",
+  "colors.disabled.fg",
+  "colors.diagnostic.error",
+  "colors.border.default",
+  "widget.syntax.keyword",
+  "widget.diff.addBg",
+  "widget.logs.error",
+  "widget.toast.warning",
+  "widget.chart.danger",
+  "spacing.xs",
+  "spacing.md",
+  "spacing.2xl",
+  "focusIndicator.bold",
+  "focusIndicator.underline",
+] as const;
+
+function cloneTheme(): Record<string, unknown> {
+  return JSON.parse(JSON.stringify(darkTheme)) as Record<string, unknown>;
+}
+
+function setPath(root: Record<string, unknown>, path: string, value: unknown): void {
+  const parts = path.split(".");
+  let cursor = root;
+  for (const part of parts.slice(0, -1)) {
+    const next = cursor[part];
+    if (typeof next !== "object" || next === null || Array.isArray(next)) {
+      throw new Error(`test fixture path is not an object: ${path}`);
+    }
+    cursor = next as Record<string, unknown>;
+  }
+  const key = parts[parts.length - 1];
+  if (!key) throw new Error(`invalid path: ${path}`);
+  cursor[key] = value;
+}
+
+function deletePath(root: Record<string, unknown>, path: string): void {
+  const parts = path.split(".");
+  let cursor = root;
+  for (const part of parts.slice(0, -1)) {
+    const next = cursor[part];
+    if (typeof next !== "object" || next === null || Array.isArray(next)) {
+      throw new Error(`test fixture path is not an object: ${path}`);
+    }
+    cursor = next as Record<string, unknown>;
+  }
+  const key = parts[parts.length - 1];
+  if (key) delete cursor[key];
+}
+
+function randomInvalidToken(ctx: FuzzIterationContext): unknown {
+  return pick(ctx.rng, [
+    -1,
+    0x01_000000,
+    1.5,
+    Number.NaN,
+    Number.POSITIVE_INFINITY,
+    "",
+    "255",
+    true,
+    null,
+    {},
+    [],
+  ]);
+}
+
+test("theme validation fuzz: valid token mutations preserve strict theme contract", async () => {
+  await runFuzz(
+    { label: "theme-valid-token-mutations", seed: 0x7e4a_0001, iterations: 180 },
+    (ctx) => {
+      const theme = cloneTheme();
+      const edits = randomInt(ctx.rng, 1, 12);
+      for (let i = 0; i < edits; i++) {
+        const path = pick(ctx.rng, MUTABLE_REQUIRED_PATHS);
+        if (path === "name") {
+          setPath(
+            theme,
+            path,
+            `fuzz-${randomAsciiString(ctx.rng, { minLength: 1, maxLength: 12 })}`,
+          );
+        } else if (path.startsWith("spacing.")) {
+          setPath(theme, path, randomInt(ctx.rng, 0, 12));
+        } else if (path.startsWith("focusIndicator.")) {
+          setPath(theme, path, chance(ctx.rng, 50));
+        } else {
+          setPath(theme, path, randomInt(ctx.rng, 0, 0xffffff));
+        }
+      }
+
+      const validated = validateTheme(theme);
+      assert.equal(validated, theme);
+
+      for (const path of COLOR_PATHS) {
+        assert.equal(isValidColorPath(path), true);
+        const resolved = resolveColorToken(validated, path);
+        assert.equal(typeof resolved, "number");
+        assert.ok(resolved >= 0 && resolved <= 0xffffff);
+        assert.deepEqual(tryResolveColorToken(validated, path), { ok: true, value: resolved });
+        assert.equal(resolveColorOrRgb(validated, path, 0), resolved);
+      }
+    },
+  );
+});
+
+test("theme validation fuzz: invalid or missing required tokens fail before use", async () => {
+  await runFuzz(
+    { label: "theme-invalid-token-rejection", seed: 0x7e4a_0002, iterations: 180 },
+    (ctx) => {
+      const theme = cloneTheme();
+      const path = pick(ctx.rng, MUTABLE_REQUIRED_PATHS);
+      if (chance(ctx.rng, 35)) {
+        deletePath(theme, path);
+      } else if (path === "name") {
+        setPath(theme, path, "");
+      } else if (path.startsWith("spacing.")) {
+        setPath(theme, path, pick(ctx.rng, [-1, 1.5, Number.NaN, "1", null]));
+      } else if (path.startsWith("focusIndicator.")) {
+        setPath(theme, path, pick(ctx.rng, [0, 1, "true", null, {}]));
+      } else {
+        setPath(theme, path, randomInvalidToken(ctx));
+      }
+
+      assert.throws(
+        () => validateTheme(theme),
+        (err: unknown) => {
+          assert.ok(err instanceof Error);
+          assert.match(err.message, /^Theme validation failed/u);
+          return true;
+        },
+      );
+    },
+  );
+});
+
+test("theme color resolver fuzz: unknown paths return fallback instead of accidental tokens", async () => {
+  await runFuzz(
+    { label: "theme-invalid-color-paths", seed: 0x7e4a_0003, iterations: 160 },
+    (ctx) => {
+      const path = `${randomAsciiString(ctx.rng, {
+        minLength: 1,
+        maxLength: 10,
+        alphabet: "abcdefghijklmnopqrstuvwxyz.",
+      })}.${randomInt(ctx.rng, 0, 99)}`;
+
+      if (isValidColorPath(path)) return;
+
+      assert.equal(resolveColorToken(darkTheme, path), null);
+      assert.deepEqual(tryResolveColorToken(darkTheme, path), {
+        ok: false,
+        error: `Invalid color path: ${path}`,
+      });
+      assert.equal(resolveColorOrRgb(darkTheme, path, 0xabcdef), 0xabcdef);
+    },
+  );
+});

--- a/packages/core/src/theme/__tests__/theme.validation.fuzz.test.ts
+++ b/packages/core/src/theme/__tests__/theme.validation.fuzz.test.ts
@@ -148,7 +148,6 @@ test("theme validation fuzz: valid token mutations preserve strict theme contrac
       }
 
       const validated = validateTheme(theme);
-      assert.equal(validated, theme);
 
       for (const path of COLOR_PATHS) {
         assert.equal(isValidColorPath(path), true);

--- a/packages/core/src/widgets/__tests__/publicContract.fuzz.test.ts
+++ b/packages/core/src/widgets/__tests__/publicContract.fuzz.test.ts
@@ -1,0 +1,283 @@
+import {
+  assert,
+  type Rng,
+  chance,
+  fuzzTest,
+  pick,
+  randomAsciiString,
+  randomInt,
+} from "@rezi-ui/testkit";
+import {
+  routeCheckboxKeyDown,
+  routeRadioGroupKeyDown,
+  routeSelectKeyDown,
+} from "../../app/widgetRenderer/keyboardRouting.js";
+import type { ZrevEvent } from "../../events.js";
+import { type SelectOption, type VNode, createTestRenderer, ui } from "../../index.js";
+import {
+  ZR_KEY_DOWN,
+  ZR_KEY_ENTER,
+  ZR_KEY_LEFT,
+  ZR_KEY_RIGHT,
+  ZR_KEY_SPACE,
+  ZR_KEY_UP,
+} from "../../keybindings/keyCodes.js";
+import { routeKey } from "../../runtime/router.js";
+import type { CheckboxProps, RadioGroupProps, SelectProps } from "../types.js";
+
+const VIEWPORT = Object.freeze({ cols: 72, rows: 24 });
+const TEXT_ALPHABET = " abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789_-:/[]().";
+
+function keyDown(key: number): ZrevEvent {
+  return { kind: "key", timeMs: 0, key, mods: 0, action: "down" };
+}
+
+function fuzzText(rng: Rng, maxLength: number): string {
+  return randomAsciiString(rng, {
+    maxLength,
+    alphabet: TEXT_ALPHABET,
+  });
+}
+
+function makeWidgetId(prefix: string, iteration: number, index: number): string {
+  return `${prefix}-${String(iteration)}-${String(index)}`;
+}
+
+function renderWidget(
+  vnode: VNode,
+  focusedId?: string,
+): ReturnType<ReturnType<typeof createTestRenderer>["render"]> {
+  return createTestRenderer({ viewport: VIEWPORT, focusedId: focusedId ?? null }).render(vnode);
+}
+
+function enabledValues(options: readonly SelectOption[]): readonly string[] {
+  return options.filter((option) => option.disabled !== true).map((option) => option.value);
+}
+
+function expectedNextValue(
+  options: readonly SelectOption[],
+  value: string,
+  direction: -1 | 1,
+): string | null {
+  const values = enabledValues(options);
+  if (values.length === 0) return null;
+  const current = values.indexOf(value);
+  const nextIndex = current < 0 ? 0 : (current + direction + values.length) % values.length;
+  return values[nextIndex] ?? null;
+}
+
+function randomOptions(rng: Rng, count: number): readonly SelectOption[] {
+  const out: SelectOption[] = [];
+  for (let i = 0; i < count; i++) {
+    out.push({
+      value: i === 0 && chance(rng, 20) ? "" : `value-${String(i)}-${fuzzText(rng, 6)}`,
+      label: fuzzText(rng, randomInt(rng, 0, 18)),
+      ...(chance(rng, 35) ? { disabled: true } : {}),
+    });
+  }
+  return Object.freeze(out);
+}
+
+function chooseCurrentValue(rng: Rng, options: readonly SelectOption[]): string {
+  if (options.length === 0 || chance(rng, 25)) return `missing-${fuzzText(rng, 6)}`;
+  return pick(rng, options).value;
+}
+
+fuzzTest(
+  "interactive button contracts route only enabled focused ids",
+  { seed: 0xc011_7a01, iterations: 96 },
+  (ctx) => {
+    const count = randomInt(ctx.rng, 1, 8);
+    const buttons = Array.from({ length: count }, (_, i) => {
+      const id = makeWidgetId("button", ctx.iteration, i);
+      const disabled = chance(ctx.rng, 35);
+      return {
+        id,
+        disabled,
+        vnode: ui.button({
+          id,
+          label: fuzzText(ctx.rng, randomInt(ctx.rng, 0, 28)),
+          ...(disabled ? { disabled } : {}),
+        }),
+      };
+    });
+    const focused = pick(ctx.rng, buttons);
+    const root = ui.column(
+      { gap: 0 },
+      buttons.map((button) => button.vnode),
+    );
+    const rendered = createTestRenderer({ viewport: VIEWPORT, focusedId: focused.id }).render(root);
+
+    for (const button of buttons) {
+      assert.equal(rendered.findById(button.id)?.kind, "button");
+    }
+
+    const result = routeKey(keyDown(pick(ctx.rng, [ZR_KEY_ENTER, ZR_KEY_SPACE] as const)), {
+      focusedId: focused.id,
+      focusList: buttons.filter((button) => !button.disabled).map((button) => button.id),
+      enabledById: new Map(buttons.map((button) => [button.id, !button.disabled])),
+      pressableIds: new Set(buttons.map((button) => button.id)),
+    });
+
+    if (focused.disabled) {
+      assert.deepEqual(result, {});
+      return;
+    }
+    assert.deepEqual(result.action, { id: focused.id, action: "press" });
+  },
+);
+
+fuzzTest(
+  "form choice widgets render type-valid unusual values and route bounded changes",
+  { seed: 0xc011_7a02, iterations: 96 },
+  (ctx) => {
+    const selectId = makeWidgetId("select", ctx.iteration, 0);
+    const selectOptions = randomOptions(ctx.rng, randomInt(ctx.rng, 0, 6));
+    const selectValue = chooseCurrentValue(ctx.rng, selectOptions);
+    const selectDisabled = chance(ctx.rng, 25);
+    const selectChanges: string[] = [];
+    const selectProps: SelectProps = {
+      id: selectId,
+      value: selectValue,
+      options: selectOptions,
+      placeholder: fuzzText(ctx.rng, randomInt(ctx.rng, 0, 12)),
+      onChange: (next) => selectChanges.push(next),
+      ...(selectDisabled ? { disabled: true } : {}),
+    };
+
+    const selectRendered = renderWidget(ui.select(selectProps), selectId);
+    assert.equal(selectRendered.findById(selectId)?.kind, "select");
+
+    const selectKey = pick(ctx.rng, [ZR_KEY_UP, ZR_KEY_DOWN, ZR_KEY_ENTER, ZR_KEY_SPACE] as const);
+    const selectDirection = selectKey === ZR_KEY_UP ? -1 : 1;
+    const selectExpected = expectedNextValue(selectOptions, selectValue, selectDirection);
+    const selectResult = routeSelectKeyDown(keyDown(selectKey), {
+      focusedId: selectId,
+      selectById: new Map([[selectId, selectProps]]),
+    });
+
+    if (selectDisabled || selectExpected === null || selectExpected === selectValue) {
+      assert.equal(selectResult, null);
+      assert.deepEqual(selectChanges, []);
+    } else {
+      assert.deepEqual(selectResult, { needsRender: true });
+      assert.deepEqual(selectChanges, [selectExpected]);
+      assert.ok(enabledValues(selectOptions).includes(selectExpected));
+    }
+
+    const radioId = makeWidgetId("radio", ctx.iteration, 0);
+    const radioOptions = randomOptions(ctx.rng, randomInt(ctx.rng, 1, 6));
+    const radioValue = chooseCurrentValue(ctx.rng, radioOptions);
+    const radioDisabled = chance(ctx.rng, 25);
+    const direction = pick(ctx.rng, ["horizontal", "vertical"] as const);
+    const radioChanges: string[] = [];
+    const radioProps: RadioGroupProps = {
+      id: radioId,
+      value: radioValue,
+      options: radioOptions,
+      direction,
+      onChange: (next) => radioChanges.push(next),
+      ...(radioDisabled ? { disabled: true } : {}),
+    };
+
+    const radioRendered = renderWidget(ui.radioGroup(radioProps), radioId);
+    assert.equal(radioRendered.findById(radioId)?.kind, "radioGroup");
+
+    const forwardKey = direction === "horizontal" ? ZR_KEY_RIGHT : ZR_KEY_DOWN;
+    const backKey = direction === "horizontal" ? ZR_KEY_LEFT : ZR_KEY_UP;
+    const radioKey = chance(ctx.rng, 50) ? forwardKey : backKey;
+    const radioDirection = radioKey === forwardKey ? 1 : -1;
+    const radioExpected = expectedNextValue(radioOptions, radioValue, radioDirection);
+    const radioResult = routeRadioGroupKeyDown(keyDown(radioKey), {
+      focusedId: radioId,
+      radioGroupById: new Map([[radioId, radioProps]]),
+    });
+
+    if (radioDisabled || radioExpected === null || radioExpected === radioValue) {
+      assert.equal(radioResult, null);
+      assert.deepEqual(radioChanges, []);
+    } else {
+      assert.deepEqual(radioResult?.action, {
+        id: radioId,
+        action: "change",
+        value: radioExpected,
+      });
+      assert.deepEqual(radioChanges, [radioExpected]);
+      assert.ok(enabledValues(radioOptions).includes(radioExpected));
+    }
+  },
+);
+
+fuzzTest(
+  "checkbox contracts route toggle payloads and suppress disabled widgets",
+  { seed: 0xc011_7a03, iterations: 64 },
+  (ctx) => {
+    const id = makeWidgetId("checkbox", ctx.iteration, 0);
+    const checked = chance(ctx.rng, 50);
+    const disabled = chance(ctx.rng, 35);
+    const changes: boolean[] = [];
+    const props: CheckboxProps = {
+      id,
+      checked,
+      label: fuzzText(ctx.rng, randomInt(ctx.rng, 0, 32)),
+      onChange: (next) => changes.push(next),
+      ...(disabled ? { disabled: true } : {}),
+    };
+
+    const rendered = renderWidget(ui.checkbox(props), id);
+    assert.equal(rendered.findById(id)?.kind, "checkbox");
+
+    const result = routeCheckboxKeyDown(
+      keyDown(pick(ctx.rng, [ZR_KEY_ENTER, ZR_KEY_SPACE] as const)),
+      {
+        focusedId: id,
+        checkboxById: new Map([[id, props]]),
+      },
+    );
+
+    if (disabled) {
+      assert.equal(result, null);
+      assert.deepEqual(changes, []);
+      return;
+    }
+
+    assert.deepEqual(result?.action, { id, action: "toggle", checked: !checked });
+    assert.deepEqual(changes, [!checked]);
+  },
+);
+
+fuzzTest(
+  "duplicate interactive ids fail during widget render commit",
+  { seed: 0xc011_7a04, iterations: 48 },
+  (ctx) => {
+    const duplicateId = `dup-${String(ctx.iteration)}-${fuzzText(ctx.rng, 8) || "x"}`;
+    const factories = [
+      () => ui.button({ id: duplicateId, label: fuzzText(ctx.rng, 12) }),
+      () => ui.input({ id: duplicateId, value: fuzzText(ctx.rng, 12) }),
+      () => ui.select({ id: duplicateId, value: "", options: [] }),
+      () => ui.checkbox({ id: duplicateId, checked: chance(ctx.rng, 50) }),
+      () =>
+        ui.radioGroup({
+          id: duplicateId,
+          value: "a",
+          options: [{ value: "a", label: fuzzText(ctx.rng, 12) }],
+        }),
+      () => ui.slider({ id: duplicateId, value: randomInt(ctx.rng, 0, 100) }),
+      () =>
+        ui.virtualList({
+          id: duplicateId,
+          items: [1, 2],
+          renderItem: (item) => ui.text(String(item)),
+        }),
+    ] as const;
+
+    const first = pick(ctx.rng, factories)();
+    const second = pick(ctx.rng, factories)();
+    ctx.note(`id=${duplicateId}`);
+
+    assert.throws(
+      () => renderWidget(ui.column({ gap: 0 }, [first, second])),
+      /ZRUI_DUPLICATE_ID|Duplicate interactive widget id/u,
+    );
+  },
+);

--- a/packages/testkit/README.md
+++ b/packages/testkit/README.md
@@ -2,6 +2,8 @@
 
 Test utilities, deterministic fuzz helpers, and golden fixtures for Rezi.
 
+Fuzz seeds are unsigned 32-bit integers.
+
 Most applications do not need this package directly.
 
 Docs: `https://rezitui.dev/packages/testkit/`

--- a/packages/testkit/README.md
+++ b/packages/testkit/README.md
@@ -1,6 +1,6 @@
 # @rezi-ui/testkit
 
-Test utilities and golden fixtures for Rezi.
+Test utilities, deterministic fuzz helpers, and golden fixtures for Rezi.
 
 Most applications do not need this package directly.
 

--- a/packages/testkit/etc/testkit.api.md
+++ b/packages/testkit/etc/testkit.api.md
@@ -14,9 +14,77 @@ export { assert }
 export function assertBytesEqual(actual: Uint8Array, expected: Uint8Array, label?: string): void;
 
 // @public (undocumented)
+export function chance(rng: Rng, percent: number): boolean;
+
+// @public (undocumented)
+export function createFuzzFaultPlan<T extends string>(ctx: FuzzIterationContext, points: readonly T[], opts?: FuzzFaultPlanOptions): FuzzFaultPlan<T>;
+
+// @public (undocumented)
 export function createRng(seed: number): Rng;
 
+// @public (undocumented)
+export function deriveFuzzCaseSeed(seed: number, iteration: number): number;
+
 export { describe }
+
+// @public (undocumented)
+export type FuzzBody = (ctx: FuzzIterationContext) => void | Promise<void>;
+
+// @public (undocumented)
+export class FuzzFailureError extends Error {
+    constructor(ctx: Pick<FuzzIterationContext, "label" | "seed" | "iteration" | "caseSeed">, cause: unknown, notes: readonly string[]);
+    // (undocumented)
+    readonly caseSeed: number;
+    // (undocumented)
+    readonly iteration: number;
+    // (undocumented)
+    readonly label: string;
+    // (undocumented)
+    readonly notes: readonly string[];
+    // (undocumented)
+    readonly seed: number;
+}
+
+// @public (undocumented)
+export type FuzzFaultPlan<T extends string> = Readonly<{
+    selected: readonly T[];
+    has: (point: T) => boolean;
+    describe: () => string;
+}>;
+
+// @public (undocumented)
+export type FuzzFaultPlanOptions = Readonly<{
+    minFailures?: number;
+    maxFailures?: number;
+}>;
+
+// @public (undocumented)
+export type FuzzIterationContext = Readonly<{
+    label: string;
+    seed: number;
+    iteration: number;
+    caseSeed: number;
+    rng: Rng;
+    note: (message: string) => void;
+    fail: (message: string, cause?: unknown) => never;
+}>;
+
+// @public (undocumented)
+export type FuzzRunOptions = Readonly<{
+    seed: number;
+    iterations: number;
+    label?: string;
+}>;
+
+// @public (undocumented)
+export type FuzzRunSummary = Readonly<{
+    label: string;
+    seed: number;
+    iterations: number;
+}>;
+
+// @public (undocumented)
+export function fuzzTest(name: string, options: FuzzRunOptions, body: FuzzBody): void;
 
 // @public (undocumented)
 export function hexdump(bytes: Uint8Array, opts?: HexdumpOptions): string;
@@ -28,7 +96,23 @@ export type HexdumpOptions = Readonly<{
 }>;
 
 // @public (undocumented)
+export function hexSeed(seed: number): string;
+
+// @public (undocumented)
 export function matchesSnapshot(actualValue: string, snapshotName: string, opts?: SnapshotMatchOptions): void;
+
+// @public (undocumented)
+export function pick<T>(rng: Rng, values: readonly T[]): T;
+
+// @public (undocumented)
+export function randomAsciiString(rng: Rng, opts: Readonly<{
+    minLength?: number;
+    maxLength: number;
+    alphabet?: string;
+}>): string;
+
+// @public (undocumented)
+export function randomInt(rng: Rng, min: number, max: number): number;
 
 // @public (undocumented)
 export function readFixture(relPath: string): Promise<Uint8Array>;
@@ -38,6 +122,9 @@ export type Rng = Readonly<{
     u32(): number;
     bytes(len: number): Uint8Array;
 }>;
+
+// @public (undocumented)
+export function runFuzz(options: FuzzRunOptions, body: FuzzBody): Promise<FuzzRunSummary>;
 
 // @public (undocumented)
 export type SnapshotMatchOptions = Readonly<{

--- a/packages/testkit/src/__tests__/fuzz.test.ts
+++ b/packages/testkit/src/__tests__/fuzz.test.ts
@@ -1,0 +1,92 @@
+import {
+  FuzzFailureError,
+  chance,
+  createFuzzFaultPlan,
+  deriveFuzzCaseSeed,
+  fuzzTest,
+  hexSeed,
+  pick,
+  randomAsciiString,
+  randomInt,
+  runFuzz,
+} from "../fuzz.js";
+import { assert, test } from "../nodeTest.js";
+
+test("deriveFuzzCaseSeed: stable non-zero per iteration", () => {
+  assert.equal(hexSeed(0x7a11_c001), "0x7a11c001");
+  assert.equal(deriveFuzzCaseSeed(0x7a11_c001, 0), deriveFuzzCaseSeed(0x7a11_c001, 0));
+  assert.notEqual(deriveFuzzCaseSeed(0x7a11_c001, 0), deriveFuzzCaseSeed(0x7a11_c001, 1));
+  assert.notEqual(deriveFuzzCaseSeed(0, 0), 0);
+});
+
+test("runFuzz: deterministic case rng is independent per iteration", async () => {
+  const first: number[] = [];
+  const second: number[] = [];
+
+  await runFuzz({ seed: 0x1234, iterations: 8, label: "first" }, (ctx) => {
+    first.push(ctx.rng.u32());
+  });
+  await runFuzz({ seed: 0x1234, iterations: 8, label: "second" }, (ctx) => {
+    second.push(ctx.rng.u32());
+  });
+
+  assert.deepEqual(first, second);
+});
+
+test("runFuzz: failure includes reproducible seed and notes", async () => {
+  await assert.rejects(
+    runFuzz({ seed: 0xfeed, iterations: 4, label: "failure-shape" }, (ctx) => {
+      ctx.note("generated=bad-input");
+      if (ctx.iteration === 2) throw new Error("boom");
+    }),
+    (err: unknown) => {
+      assert.ok(err instanceof FuzzFailureError);
+      assert.equal(err.seed, 0xfeed);
+      assert.equal(err.iteration, 2);
+      assert.equal(err.notes.includes("generated=bad-input"), true);
+      assert.match(err.message, /failure-shape seed=0x0000feed iteration=2/u);
+      assert.match(err.message, /generated=bad-input/u);
+      return true;
+    },
+  );
+});
+
+test("fuzz helpers validate ranges and use deterministic choices", async () => {
+  await runFuzz({ seed: 0x2026, iterations: 4, label: "helper-shape" }, (ctx) => {
+    assert.equal(randomInt(ctx.rng, 3, 3), 3);
+    assert.equal(chance(ctx.rng, 100), true);
+    assert.equal(chance(ctx.rng, 0), false);
+    assert.ok(["a", "b", "c"].includes(pick(ctx.rng, ["a", "b", "c"] as const)));
+    const text = randomAsciiString(ctx.rng, { minLength: 2, maxLength: 8, alphabet: "ab" });
+    assert.equal(text.length >= 2 && text.length <= 8, true);
+    assert.match(text, /^[ab]+$/u);
+  });
+});
+
+test("createFuzzFaultPlan: deterministic bounded fault selection", async () => {
+  const plans: string[] = [];
+  await runFuzz({ seed: 0x9bad, iterations: 6, label: "faults" }, (ctx) => {
+    const plan = createFuzzFaultPlan(ctx, ["poll", "frame", "stop"] as const, {
+      minFailures: 1,
+      maxFailures: 2,
+    });
+    assert.equal(plan.selected.length >= 1 && plan.selected.length <= 2, true);
+    for (const point of plan.selected) assert.equal(plan.has(point), true);
+    plans.push(plan.describe());
+  });
+
+  const replayed: string[] = [];
+  await runFuzz({ seed: 0x9bad, iterations: 6, label: "faults-replay" }, (ctx) => {
+    replayed.push(
+      createFuzzFaultPlan(ctx, ["poll", "frame", "stop"] as const, {
+        minFailures: 1,
+        maxFailures: 2,
+      }).describe(),
+    );
+  });
+  assert.deepEqual(plans, replayed);
+});
+
+fuzzTest("fuzzTest delegates to runFuzz", { seed: 0x55aa, iterations: 3 }, (ctx) => {
+  assert.equal(typeof ctx.caseSeed, "number");
+});

--- a/packages/testkit/src/__tests__/fuzz.test.ts
+++ b/packages/testkit/src/__tests__/fuzz.test.ts
@@ -19,6 +19,15 @@ test("deriveFuzzCaseSeed: stable non-zero per iteration", () => {
   assert.notEqual(deriveFuzzCaseSeed(0, 0), 0);
 });
 
+test("fuzz seeds reject values outside uint32 range", async () => {
+  assert.throws(() => hexSeed(0x1_0000_0000), /seed must be <= 0xffffffff/u);
+  assert.throws(() => deriveFuzzCaseSeed(0x1_0000_0000, 0), /seed must be <= 0xffffffff/u);
+  await assert.rejects(
+    runFuzz({ seed: 0x1_0000_0000, iterations: 1, label: "bad-seed" }, () => {}),
+    /seed must be <= 0xffffffff/u,
+  );
+});
+
 test("runFuzz: deterministic case rng is independent per iteration", async () => {
   const first: number[] = [];
   const second: number[] = [];
@@ -85,6 +94,15 @@ test("createFuzzFaultPlan: deterministic bounded fault selection", async () => {
     );
   });
   assert.deepEqual(plans, replayed);
+});
+
+test("createFuzzFaultPlan: duplicate points fail before sampling", async () => {
+  await runFuzz({ seed: 0x9bad, iterations: 1, label: "fault-duplicates" }, (ctx) => {
+    assert.throws(
+      () => createFuzzFaultPlan(ctx, ["poll", "poll"] as const, { minFailures: 2 }),
+      /points must be unique/u,
+    );
+  });
 });
 
 fuzzTest("fuzzTest delegates to runFuzz", { seed: 0x55aa, iterations: 3 }, (ctx) => {

--- a/packages/testkit/src/__tests__/rng.test.ts
+++ b/packages/testkit/src/__tests__/rng.test.ts
@@ -10,6 +10,12 @@ test("createRng: same seed => same u32 sequence", () => {
   assert.deepEqual(aa, bb);
 });
 
+test("createRng: seed must be a uint32 integer", () => {
+  assert.throws(() => createRng(-1), /seed must be a uint32 integer/u);
+  assert.throws(() => createRng(1.5), /seed must be a uint32 integer/u);
+  assert.throws(() => createRng(0x1_0000_0000), /seed must be a uint32 integer/u);
+});
+
 test("createRng: bytes() is deterministic and little-endian from u32()", () => {
   const r1 = createRng(1);
   const r2 = createRng(1);

--- a/packages/testkit/src/fuzz.ts
+++ b/packages/testkit/src/fuzz.ts
@@ -1,0 +1,247 @@
+import { test } from "./nodeTest.js";
+import { type Rng, createRng } from "./rng.js";
+
+export type FuzzIterationContext = Readonly<{
+  label: string;
+  seed: number;
+  iteration: number;
+  caseSeed: number;
+  rng: Rng;
+  note: (message: string) => void;
+  fail: (message: string, cause?: unknown) => never;
+}>;
+
+export type FuzzRunOptions = Readonly<{
+  seed: number;
+  iterations: number;
+  label?: string;
+}>;
+
+export type FuzzRunSummary = Readonly<{
+  label: string;
+  seed: number;
+  iterations: number;
+}>;
+
+export type FuzzBody = (ctx: FuzzIterationContext) => void | Promise<void>;
+
+export type FuzzFaultPlan<T extends string> = Readonly<{
+  selected: readonly T[];
+  has: (point: T) => boolean;
+  describe: () => string;
+}>;
+
+export type FuzzFaultPlanOptions = Readonly<{
+  minFailures?: number;
+  maxFailures?: number;
+}>;
+
+export class FuzzFailureError extends Error {
+  readonly label: string;
+  readonly seed: number;
+  readonly iteration: number;
+  readonly caseSeed: number;
+  readonly notes: readonly string[];
+
+  constructor(
+    ctx: Pick<FuzzIterationContext, "label" | "seed" | "iteration" | "caseSeed">,
+    cause: unknown,
+    notes: readonly string[],
+  ) {
+    const detail = describeThrown(cause);
+    const noteText = notes.length === 0 ? "" : ` notes=[${notes.join("; ")}]`;
+    super(
+      `fuzz failed: ${ctx.label} seed=${hexSeed(ctx.seed)} iteration=${String(
+        ctx.iteration,
+      )} caseSeed=${hexSeed(ctx.caseSeed)}: ${detail}${noteText}`,
+      { cause },
+    );
+    this.name = "FuzzFailureError";
+    this.label = ctx.label;
+    this.seed = ctx.seed;
+    this.iteration = ctx.iteration;
+    this.caseSeed = ctx.caseSeed;
+    this.notes = Object.freeze([...notes]);
+  }
+}
+
+export function hexSeed(seed: number): string {
+  return `0x${(seed >>> 0).toString(16).padStart(8, "0")}`;
+}
+
+export function deriveFuzzCaseSeed(seed: number, iteration: number): number {
+  assertNonNegativeInteger("seed", seed);
+  assertNonNegativeInteger("iteration", iteration);
+
+  let x = (seed ^ Math.imul(iteration + 0x9e37_79b9, 0x85eb_ca6b)) >>> 0;
+  x = Math.imul(x ^ (x >>> 16), 0x7feb_352d) >>> 0;
+  x = Math.imul(x ^ (x >>> 15), 0x846c_a68b) >>> 0;
+  x = (x ^ (x >>> 16)) >>> 0;
+  return x === 0 ? 0x9e37_79b9 : x;
+}
+
+export function randomInt(rng: Rng, min: number, max: number): number {
+  assertInteger("min", min);
+  assertInteger("max", max);
+  if (max < min) {
+    throw new Error(`randomInt: max must be >= min (got min=${String(min)} max=${String(max)})`);
+  }
+  return min + (rng.u32() % (max - min + 1));
+}
+
+export function chance(rng: Rng, percent: number): boolean {
+  assertInteger("percent", percent);
+  if (percent < 0 || percent > 100) {
+    throw new Error(`chance: percent must be between 0 and 100 (got ${String(percent)})`);
+  }
+  return rng.u32() % 100 < percent;
+}
+
+export function pick<T>(rng: Rng, values: readonly T[]): T {
+  if (values.length === 0) throw new Error("pick: values must not be empty");
+  const value = values[rng.u32() % values.length];
+  if (value === undefined) throw new Error("pick: selected value is unexpectedly undefined");
+  return value;
+}
+
+export function randomAsciiString(
+  rng: Rng,
+  opts: Readonly<{ minLength?: number; maxLength: number; alphabet?: string }>,
+): string {
+  const minLength = opts.minLength ?? 0;
+  const maxLength = opts.maxLength;
+  assertNonNegativeInteger("minLength", minLength);
+  assertNonNegativeInteger("maxLength", maxLength);
+  if (maxLength < minLength) {
+    throw new Error(
+      `randomAsciiString: maxLength must be >= minLength (got minLength=${String(
+        minLength,
+      )} maxLength=${String(maxLength)})`,
+    );
+  }
+
+  const alphabet =
+    opts.alphabet ?? "abcdefghijklmnopqrstuvwxyzABCDEFGHIJKLMNOPQRSTUVWXYZ0123456789 -_:/";
+  if (alphabet.length === 0) throw new Error("randomAsciiString: alphabet must not be empty");
+
+  const len = randomInt(rng, minLength, maxLength);
+  let out = "";
+  for (let i = 0; i < len; i++) {
+    out += alphabet[rng.u32() % alphabet.length] ?? "x";
+  }
+  return out;
+}
+
+export async function runFuzz(options: FuzzRunOptions, body: FuzzBody): Promise<FuzzRunSummary> {
+  const label = options.label ?? "fuzz";
+  assertNonNegativeInteger("seed", options.seed);
+  assertPositiveInteger("iterations", options.iterations);
+
+  for (let iteration = 0; iteration < options.iterations; iteration++) {
+    const caseSeed = deriveFuzzCaseSeed(options.seed, iteration);
+    const notes: string[] = [];
+    const ctx: FuzzIterationContext = Object.freeze({
+      label,
+      seed: options.seed >>> 0,
+      iteration,
+      caseSeed,
+      rng: createRng(caseSeed),
+      note(message: string): void {
+        notes.push(message);
+      },
+      fail(message: string, cause?: unknown): never {
+        throw new FuzzFailureError(
+          { label, seed: options.seed >>> 0, iteration, caseSeed },
+          cause === undefined ? new Error(message) : new Error(message, { cause }),
+          notes,
+        );
+      },
+    });
+
+    try {
+      await body(ctx);
+    } catch (cause: unknown) {
+      if (cause instanceof FuzzFailureError) throw cause;
+      throw new FuzzFailureError(ctx, cause, notes);
+    }
+  }
+
+  return Object.freeze({
+    label,
+    seed: options.seed >>> 0,
+    iterations: options.iterations,
+  });
+}
+
+export function fuzzTest(name: string, options: FuzzRunOptions, body: FuzzBody): void {
+  const label = options.label ?? name;
+  test(`${name} (${String(options.iterations)} iters, seed ${hexSeed(options.seed)})`, async () => {
+    await runFuzz({ ...options, label }, body);
+  });
+}
+
+export function createFuzzFaultPlan<T extends string>(
+  ctx: FuzzIterationContext,
+  points: readonly T[],
+  opts: FuzzFaultPlanOptions = {},
+): FuzzFaultPlan<T> {
+  if (points.length === 0) throw new Error("createFuzzFaultPlan: points must not be empty");
+  const minFailures = opts.minFailures ?? 0;
+  const maxFailures = opts.maxFailures ?? points.length;
+  assertNonNegativeInteger("minFailures", minFailures);
+  assertNonNegativeInteger("maxFailures", maxFailures);
+  if (minFailures > maxFailures) {
+    throw new Error("createFuzzFaultPlan: minFailures must be <= maxFailures");
+  }
+  if (maxFailures > points.length) {
+    throw new Error("createFuzzFaultPlan: maxFailures must not exceed points.length");
+  }
+
+  const target = randomInt(ctx.rng, minFailures, maxFailures);
+  const selected: T[] = [];
+  while (selected.length < target) {
+    const point = pick(ctx.rng, points);
+    if (!selected.includes(point)) selected.push(point);
+  }
+  selected.sort();
+  const selectedSet = new Set<T>(selected);
+
+  return Object.freeze({
+    selected: Object.freeze([...selected]),
+    has(point: T): boolean {
+      return selectedSet.has(point);
+    },
+    describe(): string {
+      return selected.length === 0 ? "none" : selected.join(",");
+    },
+  });
+}
+
+function assertInteger(name: string, value: number): void {
+  if (!Number.isInteger(value)) {
+    throw new Error(`${name} must be an integer (got ${String(value)})`);
+  }
+}
+
+function assertNonNegativeInteger(name: string, value: number): void {
+  assertInteger(name, value);
+  if (value < 0) {
+    throw new Error(`${name} must be a non-negative integer (got ${String(value)})`);
+  }
+}
+
+function assertPositiveInteger(name: string, value: number): void {
+  assertInteger(name, value);
+  if (value <= 0) {
+    throw new Error(`${name} must be a positive integer (got ${String(value)})`);
+  }
+}
+
+function describeThrown(value: unknown): string {
+  if (value instanceof Error) return `${value.name}: ${value.message}`;
+  try {
+    return String(value);
+  } catch {
+    return "[unstringifiable thrown value]";
+  }
+}

--- a/packages/testkit/src/fuzz.ts
+++ b/packages/testkit/src/fuzz.ts
@@ -66,11 +66,12 @@ export class FuzzFailureError extends Error {
 }
 
 export function hexSeed(seed: number): string {
+  assertUInt32("seed", seed);
   return `0x${(seed >>> 0).toString(16).padStart(8, "0")}`;
 }
 
 export function deriveFuzzCaseSeed(seed: number, iteration: number): number {
-  assertNonNegativeInteger("seed", seed);
+  assertUInt32("seed", seed);
   assertNonNegativeInteger("iteration", iteration);
 
   let x = (seed ^ Math.imul(iteration + 0x9e37_79b9, 0x85eb_ca6b)) >>> 0;
@@ -134,7 +135,7 @@ export function randomAsciiString(
 
 export async function runFuzz(options: FuzzRunOptions, body: FuzzBody): Promise<FuzzRunSummary> {
   const label = options.label ?? "fuzz";
-  assertNonNegativeInteger("seed", options.seed);
+  assertUInt32("seed", options.seed);
   assertPositiveInteger("iterations", options.iterations);
 
   for (let iteration = 0; iteration < options.iterations; iteration++) {
@@ -186,21 +187,25 @@ export function createFuzzFaultPlan<T extends string>(
   opts: FuzzFaultPlanOptions = {},
 ): FuzzFaultPlan<T> {
   if (points.length === 0) throw new Error("createFuzzFaultPlan: points must not be empty");
+  const uniquePoints = [...new Set(points)];
+  if (uniquePoints.length !== points.length) {
+    throw new Error("createFuzzFaultPlan: points must be unique");
+  }
   const minFailures = opts.minFailures ?? 0;
-  const maxFailures = opts.maxFailures ?? points.length;
+  const maxFailures = opts.maxFailures ?? uniquePoints.length;
   assertNonNegativeInteger("minFailures", minFailures);
   assertNonNegativeInteger("maxFailures", maxFailures);
   if (minFailures > maxFailures) {
     throw new Error("createFuzzFaultPlan: minFailures must be <= maxFailures");
   }
-  if (maxFailures > points.length) {
+  if (maxFailures > uniquePoints.length) {
     throw new Error("createFuzzFaultPlan: maxFailures must not exceed points.length");
   }
 
   const target = randomInt(ctx.rng, minFailures, maxFailures);
   const selected: T[] = [];
   while (selected.length < target) {
-    const point = pick(ctx.rng, points);
+    const point = pick(ctx.rng, uniquePoints);
     if (!selected.includes(point)) selected.push(point);
   }
   selected.sort();
@@ -234,6 +239,13 @@ function assertPositiveInteger(name: string, value: number): void {
   assertInteger(name, value);
   if (value <= 0) {
     throw new Error(`${name} must be a positive integer (got ${String(value)})`);
+  }
+}
+
+function assertUInt32(name: string, value: number): void {
+  assertNonNegativeInteger(name, value);
+  if (value > 0xffff_ffff) {
+    throw new Error(`${name} must be <= 0xffffffff (got ${String(value)})`);
   }
 }
 

--- a/packages/testkit/src/index.ts
+++ b/packages/testkit/src/index.ts
@@ -1,4 +1,22 @@
 export { createRng, type Rng } from "./rng.js";
+export {
+  FuzzFailureError,
+  chance,
+  createFuzzFaultPlan,
+  deriveFuzzCaseSeed,
+  fuzzTest,
+  hexSeed,
+  pick,
+  randomAsciiString,
+  randomInt,
+  runFuzz,
+  type FuzzBody,
+  type FuzzFaultPlan,
+  type FuzzFaultPlanOptions,
+  type FuzzIterationContext,
+  type FuzzRunOptions,
+  type FuzzRunSummary,
+} from "./fuzz.js";
 export { readFixture } from "./fixtures.js";
 export { assertBytesEqual, hexdump, type HexdumpOptions } from "./golden.js";
 export { matchesSnapshot, type SnapshotMatchOptions } from "./snapshot.js";

--- a/packages/testkit/src/rng.ts
+++ b/packages/testkit/src/rng.ts
@@ -4,6 +4,7 @@ export type Rng = Readonly<{
 }>;
 
 export function createRng(seed: number): Rng {
+  assertUInt32("seed", seed);
   let state = seed >>> 0;
 
   function nextU32(): number {
@@ -44,4 +45,10 @@ export function createRng(seed: number): Rng {
       return out;
     },
   } as const;
+}
+
+function assertUInt32(name: string, value: number): void {
+  if (!Number.isInteger(value) || value < 0 || value > 0xffff_ffff) {
+    throw new Error(`${name} must be a uint32 integer (got ${String(value)})`);
+  }
 }


### PR DESCRIPTION
## Summary

- Adds deterministic fuzzing helpers to `@rezi-ui/testkit`, including per-iteration case seeds, failure notes, `fuzzTest`, and bounded fault-plan helpers.
- Adds fuzz coverage for app backend failure injection, binary reader/writer failure atomicity, malformed Unicode text measurement/truncation, and the ZREV parser fuzz-lite path.
- Adds broader contract fuzzing for drawlist command programs, keybinding parser round-trips, router key/mouse/hit-test/wheel dispatch, public widget interaction payloads, layout/render determinism, and theme token validation/resolution.
- Adds `npm run test:fuzz` plus developer docs and testkit API docs for seeded fuzz tests.

## Investigation Notes

- No product bug was found by the encoded fuzz suites.
- A stricter layout oracle found an under-specified contract question: exposed child rect `x/y` can go negative under clipped oversized overflow while terminal text remains bounded. The committed layout fuzz tests assert the observable contract that rendered output stays within the viewport, exposed rects are finite, dimensions are non-negative, and repeated renders are deterministic.
- Select keyboard changes appear callback-only in the current contract evidence, unlike checkbox/radio action payloads, so the widget fuzz suite does not invent a select `change` action expectation.

## Validation

- `npm run build`
- `npm run test:fuzz` (50 fuzz tests, 0 failures)
- `npm run lint`
- `npm run typecheck`
- `npm run quality:api`
- `npm test` (4,977 passing, 1 skipped, 0 failures)
- `npm run docs:build` (passes with existing TypeDoc `supportsCursorProtocol` warning and MkDocs Material notice)