### PR TITLE
fix: bound binary and drawlist capacities

### DIFF
--- a/docs/backend/engine-config.md
+++ b/docs/backend/engine-config.md
@@ -82,7 +82,7 @@ backend or extremely large paste events.
 
 | Detail   | Value |
 |----------|-------|
-| Type     | `number` (positive integer) |
+| Type     | `number` (positive integer, `<= 8 << 20`) |
 | Default  | `2 << 20` (2 MiB) |
 
 Maximum byte size of a single rendered drawlist frame. If the builder exceeds
@@ -99,7 +99,7 @@ config: {
 
 | Detail   | Value |
 |----------|-------|
-| Type     | `number` (positive integer) |
+| Type     | `number` (positive integer, `<= 4 << 20`) |
 | Default  | `512 << 10` (512 KiB) |
 
 Maximum total byte size of the drawlist blob pool for a frame. If binary payloads

--- a/docs/protocol/safety.md
+++ b/docs/protocol/safety.md
@@ -45,7 +45,7 @@ class BinaryWriter {
 }
 ```
 
-The writer additionally enforces that `writeU32` and `writeI32` are called only at 4-byte aligned offsets. Calling at a misaligned offset throws `ZR_MISALIGNED`.
+The writer additionally enforces that constructor capacity is bounded and that `writeU32` and `writeI32` are called only at 4-byte aligned offsets. Calling at a misaligned offset throws `ZR_MISALIGNED`.
 
 ## ZrBinaryError
 

--- a/packages/core/src/app/__tests__/config.bounds.test.ts
+++ b/packages/core/src/app/__tests__/config.bounds.test.ts
@@ -34,3 +34,35 @@ test("config bounds: maxEventBytes must be <= 4 MiB", () => {
       err.message.includes("maxEventBytes must be <= 4194304"),
   );
 });
+
+test("config bounds: maxDrawlistBytes must be <= 8 MiB", () => {
+  const backend = new StubBackend();
+  assert.throws(
+    () =>
+      createApp({
+        backend,
+        initialState: { value: 0 },
+        config: { maxDrawlistBytes: (8 << 20) + 1 },
+      }),
+    (err: unknown) =>
+      err instanceof ZrUiError &&
+      err.code === "ZRUI_INVALID_PROPS" &&
+      err.message.includes("maxDrawlistBytes must be <= 8388608"),
+  );
+});
+
+test("config bounds: maxBlobBytes must be <= 4 MiB", () => {
+  const backend = new StubBackend();
+  assert.throws(
+    () =>
+      createApp({
+        backend,
+        initialState: { value: 0 },
+        config: { maxBlobBytes: (4 << 20) + 1 },
+      }),
+    (err: unknown) =>
+      err instanceof ZrUiError &&
+      err.code === "ZRUI_INVALID_PROPS" &&
+      err.message.includes("maxBlobBytes must be <= 4194304"),
+  );
+});

--- a/packages/core/src/app/createApp/config.ts
+++ b/packages/core/src/app/createApp/config.ts
@@ -50,6 +50,8 @@ const DEFAULT_CONFIG: ResolvedAppConfig = Object.freeze({
 
 const MAX_SAFE_FPS_CAP = 1000;
 const MAX_SAFE_EVENT_BYTES = 4 << 20; /* 4 MiB */
+const MAX_SAFE_DRAWLIST_BYTES = 8 << 20; /* 8 MiB */
+const MAX_SAFE_BLOB_BYTES = 4 << 20; /* 4 MiB */
 
 function invalidProps(detail: string): never {
   throw new ZrUiError("ZRUI_INVALID_PROPS", detail);
@@ -84,11 +86,15 @@ export function resolveAppConfig(config: AppConfig | undefined): ResolvedAppConf
   const maxDrawlistBytes =
     config.maxDrawlistBytes === undefined
       ? DEFAULT_CONFIG.maxDrawlistBytes
-      : requirePositiveInt("maxDrawlistBytes", config.maxDrawlistBytes);
+      : requirePositiveIntAtMost(
+          "maxDrawlistBytes",
+          config.maxDrawlistBytes,
+          MAX_SAFE_DRAWLIST_BYTES,
+        );
   const maxBlobBytes =
     config.maxBlobBytes === undefined
       ? DEFAULT_CONFIG.maxBlobBytes
-      : requirePositiveInt("maxBlobBytes", config.maxBlobBytes);
+      : requirePositiveIntAtMost("maxBlobBytes", config.maxBlobBytes, MAX_SAFE_BLOB_BYTES);
   const rootPadding =
     config.rootPadding === undefined
       ? DEFAULT_CONFIG.rootPadding

--- a/packages/core/src/binary/__tests__/writer.test.ts
+++ b/packages/core/src/binary/__tests__/writer.test.ts
@@ -3,6 +3,52 @@ import { ZrBinaryError } from "../parseError.js";
 import { BinaryWriter } from "../writer.js";
 
 describe("BinaryWriter", () => {
+  test("constructor rejects invalid capacity with ZrBinaryError", () => {
+    assert.throws(
+      () => new BinaryWriter(-1),
+      (err: unknown) => {
+        assert.ok(err instanceof ZrBinaryError);
+        assert.equal(err.code, "ZR_LIMIT");
+        assert.equal(err.offset, 0);
+        assert.equal(
+          err.message,
+          "ZR_LIMIT at 0: capacity must be a non-negative integer (got -1)",
+        );
+        return true;
+      },
+    );
+
+    assert.throws(
+      () => new BinaryWriter(1.5),
+      (err: unknown) => {
+        assert.ok(err instanceof ZrBinaryError);
+        assert.equal(err.code, "ZR_LIMIT");
+        assert.equal(err.offset, 0);
+        assert.equal(
+          err.message,
+          "ZR_LIMIT at 0: capacity must be a non-negative integer (got 1.5)",
+        );
+        return true;
+      },
+    );
+  });
+
+  test("constructor rejects excessive capacity before allocation", () => {
+    assert.throws(
+      () => new BinaryWriter(Number.MAX_SAFE_INTEGER),
+      (err: unknown) => {
+        assert.ok(err instanceof ZrBinaryError);
+        assert.equal(err.code, "ZR_LIMIT");
+        assert.equal(err.offset, 0);
+        assert.equal(
+          err.message,
+          "ZR_LIMIT at 0: capacity 9007199254740991 exceeds maximum 16777216",
+        );
+        return true;
+      },
+    );
+  });
+
   test("padTo4 writes 0x00 bytes only", () => {
     const w = new BinaryWriter(16);
     w.writeU8(0xff);

--- a/packages/core/src/binary/writer.ts
+++ b/packages/core/src/binary/writer.ts
@@ -17,6 +17,8 @@
 
 import { ZrBinaryError } from "./parseError.js";
 
+const MAX_WRITER_CAPACITY_BYTES = 16 << 20; /* 16 MiB */
+
 /**
  * Bounds-checked binary writer with cursor tracking.
  *
@@ -30,9 +32,18 @@ export class BinaryWriter {
 
   constructor(capacity: number) {
     if (!Number.isInteger(capacity) || capacity < 0) {
-      throw new Error(
-        `BinaryWriter: capacity must be a non-negative integer (got ${String(capacity)})`,
-      );
+      throw new ZrBinaryError({
+        code: "ZR_LIMIT",
+        offset: 0,
+        detail: `capacity must be a non-negative integer (got ${String(capacity)})`,
+      });
+    }
+    if (capacity > MAX_WRITER_CAPACITY_BYTES) {
+      throw new ZrBinaryError({
+        code: "ZR_LIMIT",
+        offset: 0,
+        detail: `capacity ${String(capacity)} exceeds maximum ${String(MAX_WRITER_CAPACITY_BYTES)}`,
+      });
     }
     this.buf = new Uint8Array(capacity);
     this.dv = new DataView(this.buf.buffer, this.buf.byteOffset, this.buf.byteLength);


### PR DESCRIPTION
Fixed #408.
Fixed #409.

Validation:
- npm run build
- npm run lint
- npm run typecheck
- npm run quality:api
- npm run test:scripts
- npm run test:packages